### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Anthropic has [highlighted context bloat](https://www.anthropic.com/news) as a k
 - **Progressive disclosure**: Compact capability cards first, detailed schemas only on request
 - **Policy enforcement**: Output size caps and optional secret redaction
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/viperjuice-mcp-gateway).
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/viperjuice-mcp-gateway)

Made with [Cursor](https://cursor.com)