### PR TITLE
cli: add pmcp upgrade subcommand and install-drift check in doctor

### DIFF
--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from pmcp.cli_commands.doctor import collect_remote_header_diagnostics
+from pmcp.cli_commands.install import (
+    detect_install_drift,
+    detect_install_method,
+)
 from pmcp.cli_commands.secrets import (
     run_secrets_check,
     run_secrets_set,
@@ -93,6 +97,7 @@ def parse_args() -> argparse.Namespace:
   pmcp setup --client claude --mode http --write
   pmcp setup --client opencode --mode http --write
   pmcp doctor
+  pmcp upgrade
   pmcp secrets set API_TOKEN my-token --scope user
   pmcp secrets sync --from-scope user --to-scope project --overwrite
   pmcp status --json
@@ -450,6 +455,40 @@ Environment overrides:
         help="SSE probe timeout in seconds (default: 3.0)",
     )
     doctor_parser.add_argument(
+        "-l",
+        "--log-level",
+        choices=["debug", "info", "warn", "error"],
+        default="warn",
+        help="Log level (default: warn)",
+    )
+
+    # Upgrade command
+    upgrade_parser = subparsers.add_parser(
+        "upgrade",
+        help="Upgrade the pmcp package to the latest release",
+        description=(
+            "Detect how pmcp was installed (uv tool vs pip --user) and "
+            "run the matching upgrade command. Optionally restart the "
+            "local gateway service afterwards."
+        ),
+    )
+    upgrade_parser.add_argument(
+        "--method",
+        choices=["auto", "uv", "pip"],
+        default="auto",
+        help="Override install-method detection (default: auto)",
+    )
+    upgrade_parser.add_argument(
+        "--restart-service",
+        action="store_true",
+        help="Restart the local systemd/launchd pmcp service after upgrade",
+    )
+    upgrade_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would run without invoking the upgrade command",
+    )
+    upgrade_parser.add_argument(
         "-l",
         "--log-level",
         choices=["debug", "info", "warn", "error"],
@@ -1416,6 +1455,27 @@ async def run_doctor(args: argparse.Namespace) -> None:
     else:
         checks.append(("remote", "ok", "No remote downstream header issues detected."))
 
+    drift = detect_install_drift()
+    if drift.has_drift:
+        checks.append(
+            (
+                "install",
+                "warn",
+                (
+                    f"pmcp is installed by BOTH uv tool ({drift.uv_path}) and "
+                    f"pip --user ({drift.pip_user_site}). Whichever shim wins PATH "
+                    "masks the other; upgrading one leaves the other stale. Remove "
+                    "the inactive copy: 'pip uninstall --user --break-system-packages "
+                    "pmcp' or 'uv tool uninstall pmcp'."
+                ),
+            )
+        )
+    else:
+        method = detect_install_method()
+        checks.append(
+            ("install", "ok", f"pmcp install method: {method} (no drift detected).")
+        )
+
     status_icon = {"ok": "OK", "warn": "WARN", "fail": "FAIL"}
     print("PMCP Doctor")
     print("===========")
@@ -1425,6 +1485,92 @@ async def run_doctor(args: argparse.Namespace) -> None:
 
     if any(status == "fail" for _, status, _ in checks):
         sys.exit(1)
+
+
+def _restart_local_pmcp_service() -> None:
+    """Best-effort restart of the local pmcp service (systemd user or launchd)."""
+    if shutil.which("systemctl") and Path("/run/systemd/system").exists():
+        probe = subprocess.run(
+            ["systemctl", "--user", "is-active", "pmcp.service"],
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0:
+            print("No active pmcp systemd user service found — skipping restart.")
+            return
+        print("Restarting pmcp systemd user service...")
+        subprocess.run(
+            ["systemctl", "--user", "restart", "pmcp.service"], check=False
+        )
+        return
+    if sys.platform == "darwin" and shutil.which("launchctl"):
+        label = f"gui/{os.getuid()}/com.user.pmcp"
+        print(f"Kickstarting launchd {label}...")
+        subprocess.run(["launchctl", "kickstart", "-k", label], check=False)
+        return
+    print("No supported service manager detected — skipping restart.")
+
+
+async def run_upgrade(args: argparse.Namespace) -> None:
+    """Upgrade the pmcp package using the detected install method."""
+    setup_logging(args.log_level)
+
+    method = args.method
+    if method == "auto":
+        method = detect_install_method()
+        if method == "unknown":
+            print(
+                "error: could not auto-detect install method (neither uv tool nor "
+                "pip --user). Pass --method=uv or --method=pip explicitly, or "
+                "reinstall pmcp from PyPI.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    if method == "uv":
+        cmd = ["uv", "tool", "upgrade", "pmcp"]
+    elif method == "pip":
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-U",
+            "--user",
+            "--break-system-packages",
+            "pmcp",
+        ]
+    else:
+        print(f"error: unsupported --method={method}", file=sys.stderr)
+        sys.exit(2)
+
+    if args.dry_run:
+        print(f"[dry-run] would run: {' '.join(cmd)}")
+        return
+
+    print(f"Upgrading pmcp via {method}: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(cmd, check=False)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if result.returncode != 0:
+        print(
+            f"error: upgrade command failed with exit {result.returncode}",
+            file=sys.stderr,
+        )
+        sys.exit(result.returncode)
+
+    drift = detect_install_drift()
+    if drift.has_drift:
+        print(
+            "\nwarning: pmcp is installed by BOTH uv tool and pip --user. The copy "
+            f"that was upgraded is {method}; the other is now stale and will mask "
+            "the upgrade if PATH order changes. Run 'pmcp doctor' for details."
+        )
+
+    if args.restart_service:
+        _restart_local_pmcp_service()
 
 
 async def run_server(args: argparse.Namespace) -> None:
@@ -1711,6 +1857,8 @@ async def async_main(args: argparse.Namespace) -> None:
         run_guidance(args)  # Synchronous command
     elif args.command == "doctor":
         await run_doctor(args)
+    elif args.command == "upgrade":
+        await run_upgrade(args)
     elif args.command == "secrets":
         if args.secrets_command == "set":
             output = await run_secrets_set(args)

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -1465,8 +1465,8 @@ async def run_doctor(args: argparse.Namespace) -> None:
                     f"pmcp is installed by BOTH uv tool ({drift.uv_path}) and "
                     f"pip --user ({drift.pip_user_site}). Whichever shim wins PATH "
                     "masks the other; upgrading one leaves the other stale. Remove "
-                    "the inactive copy: 'pip uninstall --user --break-system-packages "
-                    "pmcp' or 'uv tool uninstall pmcp'."
+                    "the inactive copy: 'python -m pip uninstall pmcp' or "
+                    "'uv tool uninstall pmcp'."
                 ),
             )
         )
@@ -1499,9 +1499,7 @@ def _restart_local_pmcp_service() -> None:
             print("No active pmcp systemd user service found — skipping restart.")
             return
         print("Restarting pmcp systemd user service...")
-        subprocess.run(
-            ["systemctl", "--user", "restart", "pmcp.service"], check=False
-        )
+        subprocess.run(["systemctl", "--user", "restart", "pmcp.service"], check=False)
         return
     if sys.platform == "darwin" and shutil.which("launchctl"):
         label = f"gui/{os.getuid()}/com.user.pmcp"

--- a/src/pmcp/cli_commands/install.py
+++ b/src/pmcp/cli_commands/install.py
@@ -1,0 +1,103 @@
+"""Detect how `pmcp` was installed on the current host.
+
+Supports two install paths used in practice:
+- `uv tool install pmcp` — lives under `~/.local/share/uv/tools/pmcp`
+- `pip install --user pmcp` — lives under the Python user-site tree
+
+Both typically shim `~/.local/bin/pmcp`, so having a binary on PATH does
+not tell you which installer owns it. We inspect the running interpreter
+and the filesystem layout instead.
+"""
+
+from __future__ import annotations
+
+import os
+import site
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+InstallMethod = Literal["uv", "pip", "unknown"]
+
+
+def _uv_tool_dir() -> Path:
+    """Return the directory uv puts tool installs under."""
+    env = os.environ.get("UV_TOOL_DIR")
+    if env:
+        return Path(env).expanduser().resolve()
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".local" / "share"
+    return (base / "uv" / "tools").resolve()
+
+
+def _has_uv_tool_pmcp() -> bool:
+    return (_uv_tool_dir() / "pmcp").is_dir()
+
+
+def _has_pip_user_pmcp() -> bool:
+    """True when pmcp is present in the Python user-site tree."""
+    try:
+        user_site = site.getusersitepackages()
+    except Exception:
+        return False
+    if not user_site:
+        return False
+    root = Path(user_site)
+    if not root.exists():
+        return False
+    # pip creates either pmcp/ (pre-PEP 420) or pmcp-*.dist-info
+    if (root / "pmcp").is_dir():
+        return True
+    return any(root.glob("pmcp-*.dist-info"))
+
+
+def detect_install_method() -> InstallMethod:
+    """Best-effort detection of which installer owns the running pmcp.
+
+    Logic:
+    - If ``sys.executable`` lives under the uv tool directory, it's uv.
+    - Else if pmcp is present in the user-site tree, it's pip --user.
+    - Else if the uv tool directory has a pmcp copy, fall back to uv.
+    - Otherwise unknown (system pip, pipx, editable dev install, etc.).
+    """
+    exe = Path(sys.executable).resolve()
+    uv_root = _uv_tool_dir()
+    try:
+        exe.relative_to(uv_root)
+        return "uv"
+    except ValueError:
+        pass
+
+    if _has_pip_user_pmcp():
+        return "pip"
+    if _has_uv_tool_pmcp():
+        return "uv"
+    return "unknown"
+
+
+@dataclass(frozen=True)
+class InstallDrift:
+    has_drift: bool
+    uv_path: Path | None
+    pip_user_site: Path | None
+
+
+def detect_install_drift() -> InstallDrift:
+    """Detect the ``uv tool`` + ``pip --user`` dual-install case.
+
+    When both installers have placed a copy of pmcp, whichever shim wins
+    ``PATH`` masks the other. Upgrading one leaves the other stale and
+    can cause ``pmcp`` to silently run an older version later if PATH
+    order changes (e.g., on a fresh login or after a distro upgrade).
+    """
+    uv_path = _uv_tool_dir() / "pmcp" if _has_uv_tool_pmcp() else None
+    pip_site = None
+    if _has_pip_user_pmcp():
+        try:
+            pip_site = Path(site.getusersitepackages())
+        except Exception:
+            pip_site = None
+    has_drift = uv_path is not None and pip_site is not None
+    return InstallDrift(has_drift=has_drift, uv_path=uv_path, pip_user_site=pip_site)

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -1,0 +1,267 @@
+"""Tests for install-method detection and the `pmcp upgrade` subcommand."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pmcp.cli import run_upgrade
+from pmcp.cli_commands import install as install_mod
+from pmcp.cli_commands.install import (
+    InstallDrift,
+    detect_install_drift,
+    detect_install_method,
+)
+
+
+class TestDetectInstallMethod:
+    """Install-method detection heuristic."""
+
+    def test_detects_uv_from_sys_executable(self, tmp_path: Path) -> None:
+        """sys.executable under the uv tool dir => uv."""
+        uv_root = tmp_path / "uv" / "tools"
+        exe = uv_root / "pmcp" / "bin" / "python"
+        exe.parent.mkdir(parents=True)
+        exe.write_text("")
+
+        with patch.object(install_mod, "sys") as sys_mock:
+            sys_mock.executable = str(exe)
+            with patch.object(install_mod, "_uv_tool_dir", return_value=uv_root):
+                with patch.object(install_mod, "_has_pip_user_pmcp", return_value=False):
+                    assert detect_install_method() == "uv"
+
+    def test_detects_pip_when_user_site_has_pmcp(self, tmp_path: Path) -> None:
+        """Non-uv sys.executable + pmcp in user-site => pip."""
+        with patch.object(install_mod, "_uv_tool_dir", return_value=tmp_path / "uv"):
+            with patch.object(install_mod, "_has_pip_user_pmcp", return_value=True):
+                with patch.object(install_mod, "_has_uv_tool_pmcp", return_value=False):
+                    assert detect_install_method() == "pip"
+
+    def test_falls_back_to_uv_tool_dir(self, tmp_path: Path) -> None:
+        """sys.executable outside uv + no pip-user but uv tool dir exists => uv."""
+        with patch.object(install_mod, "_uv_tool_dir", return_value=tmp_path / "uv"):
+            with patch.object(install_mod, "_has_pip_user_pmcp", return_value=False):
+                with patch.object(install_mod, "_has_uv_tool_pmcp", return_value=True):
+                    assert detect_install_method() == "uv"
+
+    def test_returns_unknown_when_nothing_matches(self, tmp_path: Path) -> None:
+        with patch.object(install_mod, "_uv_tool_dir", return_value=tmp_path / "uv"):
+            with patch.object(install_mod, "_has_pip_user_pmcp", return_value=False):
+                with patch.object(install_mod, "_has_uv_tool_pmcp", return_value=False):
+                    assert detect_install_method() == "unknown"
+
+
+class TestDetectInstallDrift:
+    """Drift detection: both uv and pip --user have pmcp."""
+
+    def test_drift_when_both_present(self, tmp_path: Path) -> None:
+        uv_root = tmp_path / "uv" / "tools"
+        (uv_root / "pmcp").mkdir(parents=True)
+        user_site = tmp_path / "user_site"
+        user_site.mkdir()
+
+        with patch.object(install_mod, "_uv_tool_dir", return_value=uv_root):
+            with patch.object(install_mod, "_has_pip_user_pmcp", return_value=True):
+                with patch.object(install_mod, "site") as site_mock:
+                    site_mock.getusersitepackages.return_value = str(user_site)
+                    drift = detect_install_drift()
+
+        assert drift.has_drift is True
+        assert drift.uv_path == uv_root / "pmcp"
+        assert drift.pip_user_site == user_site
+
+    def test_no_drift_when_only_one(self, tmp_path: Path) -> None:
+        uv_root = tmp_path / "uv" / "tools"
+        with patch.object(install_mod, "_uv_tool_dir", return_value=uv_root):
+            with patch.object(install_mod, "_has_pip_user_pmcp", return_value=False):
+                drift = detect_install_drift()
+        assert drift.has_drift is False
+
+
+class TestUpgradeCommand:
+    """`pmcp upgrade` subcommand."""
+
+    def test_parser_defaults(self) -> None:
+        from pmcp.cli import parse_args
+
+        with patch("sys.argv", ["pmcp", "upgrade"]):
+            args = parse_args()
+        assert args.command == "upgrade"
+        assert args.method == "auto"
+        assert args.restart_service is False
+        assert args.dry_run is False
+
+    def test_parser_flags(self) -> None:
+        from pmcp.cli import parse_args
+
+        with patch(
+            "sys.argv",
+            ["pmcp", "upgrade", "--method", "pip", "--restart-service", "--dry-run"],
+        ):
+            args = parse_args()
+        assert args.method == "pip"
+        assert args.restart_service is True
+        assert args.dry_run is True
+
+    @pytest.mark.asyncio
+    async def test_dry_run_auto_uv(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        args = argparse.Namespace(
+            command="upgrade",
+            method="auto",
+            restart_service=False,
+            dry_run=True,
+            log_level="warn",
+        )
+        with patch("pmcp.cli.detect_install_method", return_value="uv"):
+            await run_upgrade(args)
+
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        assert "uv tool upgrade pmcp" in out
+
+    @pytest.mark.asyncio
+    async def test_dry_run_explicit_pip(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        args = argparse.Namespace(
+            command="upgrade",
+            method="pip",
+            restart_service=False,
+            dry_run=True,
+            log_level="warn",
+        )
+        await run_upgrade(args)
+
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        assert "pip install -U --user --break-system-packages pmcp" in out
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_unknown_exits(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        args = argparse.Namespace(
+            command="upgrade",
+            method="auto",
+            restart_service=False,
+            dry_run=True,
+            log_level="warn",
+        )
+        with patch("pmcp.cli.detect_install_method", return_value="unknown"):
+            with pytest.raises(SystemExit) as exc_info:
+                await run_upgrade(args)
+
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "could not auto-detect" in err
+
+    @pytest.mark.asyncio
+    async def test_runs_subprocess_for_uv(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        args = argparse.Namespace(
+            command="upgrade",
+            method="uv",
+            restart_service=False,
+            dry_run=False,
+            log_level="warn",
+        )
+        fake_result = type("R", (), {"returncode": 0})()
+        no_drift = InstallDrift(has_drift=False, uv_path=None, pip_user_site=None)
+
+        with patch("pmcp.cli.subprocess.run", return_value=fake_result) as run_mock:
+            with patch("pmcp.cli.detect_install_drift", return_value=no_drift):
+                await run_upgrade(args)
+
+        cmd = run_mock.call_args.args[0]
+        assert cmd == ["uv", "tool", "upgrade", "pmcp"]
+
+    @pytest.mark.asyncio
+    async def test_drift_warning_after_upgrade(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        args = argparse.Namespace(
+            command="upgrade",
+            method="pip",
+            restart_service=False,
+            dry_run=False,
+            log_level="warn",
+        )
+        fake_result = type("R", (), {"returncode": 0})()
+        drift = InstallDrift(
+            has_drift=True,
+            uv_path=tmp_path / "uv" / "pmcp",
+            pip_user_site=tmp_path / "user_site",
+        )
+
+        with patch("pmcp.cli.subprocess.run", return_value=fake_result):
+            with patch("pmcp.cli.detect_install_drift", return_value=drift):
+                await run_upgrade(args)
+
+        out = capsys.readouterr().out
+        assert "BOTH uv tool and pip --user" in out
+        assert "pmcp doctor" in out
+
+
+class TestDoctorDriftCheck:
+    """run_doctor surfaces an install-drift warning."""
+
+    @pytest.mark.asyncio
+    async def test_doctor_warns_on_drift(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        from pmcp.cli import run_doctor
+
+        args = argparse.Namespace(
+            command="doctor", project=None, timeout=2.0, log_level="warn"
+        )
+        drift = InstallDrift(
+            has_drift=True,
+            uv_path=tmp_path / "uv" / "pmcp",
+            pip_user_site=tmp_path / "user_site",
+        )
+
+        with patch("pmcp.cli.Path.home", return_value=tmp_path):
+            with patch("pmcp.cli._is_pmcp_system_service_active", return_value=False):
+                with patch(
+                    "pmcp.cli._load_local_mcp_json",
+                    return_value=(tmp_path / ".mcp.json", {"mcpServers": {}}),
+                ):
+                    with patch("pmcp.cli.detect_install_drift", return_value=drift):
+                        await run_doctor(args)
+
+        out = capsys.readouterr().out
+        assert "[WARN] install" in out
+        assert "uv tool uninstall pmcp" in out
+
+    @pytest.mark.asyncio
+    async def test_doctor_ok_without_drift(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        from pmcp.cli import run_doctor
+
+        args = argparse.Namespace(
+            command="doctor", project=None, timeout=2.0, log_level="warn"
+        )
+        no_drift = InstallDrift(has_drift=False, uv_path=None, pip_user_site=None)
+
+        with patch("pmcp.cli.Path.home", return_value=tmp_path):
+            with patch("pmcp.cli._is_pmcp_system_service_active", return_value=False):
+                with patch(
+                    "pmcp.cli._load_local_mcp_json",
+                    return_value=(tmp_path / ".mcp.json", {"mcpServers": {}}),
+                ):
+                    with patch("pmcp.cli.detect_install_drift", return_value=no_drift):
+                        with patch(
+                            "pmcp.cli.detect_install_method", return_value="pip"
+                        ):
+                            await run_doctor(args)
+
+        out = capsys.readouterr().out
+        assert "[OK] install" in out
+        assert "pmcp install method: pip" in out

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -30,7 +30,9 @@ class TestDetectInstallMethod:
         with patch.object(install_mod, "sys") as sys_mock:
             sys_mock.executable = str(exe)
             with patch.object(install_mod, "_uv_tool_dir", return_value=uv_root):
-                with patch.object(install_mod, "_has_pip_user_pmcp", return_value=False):
+                with patch.object(
+                    install_mod, "_has_pip_user_pmcp", return_value=False
+                ):
                     assert detect_install_method() == "uv"
 
     def test_detects_pip_when_user_site_has_pmcp(self, tmp_path: Path) -> None:
@@ -107,9 +109,7 @@ class TestUpgradeCommand:
         assert args.dry_run is True
 
     @pytest.mark.asyncio
-    async def test_dry_run_auto_uv(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    async def test_dry_run_auto_uv(self, capsys: pytest.CaptureFixture[str]) -> None:
         args = argparse.Namespace(
             command="upgrade",
             method="auto",


### PR DESCRIPTION
## Summary

- Adds `pmcp upgrade` subcommand. Detects install method (`uv tool` vs `pip --user`) by inspecting `sys.executable` and filesystem layout, then runs the matching upgrade command. Optional `--restart-service` kicks the local systemd user / launchd `pmcp` service afterwards.
- Adds a drift check to `pmcp doctor`. When pmcp is installed by *both* `uv tool` and `pip --user`, whichever shim wins PATH masks the other; upgrading one leaves the other stale and can silently take over later. Doctor now surfaces this as a WARN with remediation.
- Detection lives in a new helper module `pmcp/cli_commands/install.py` shared by `upgrade` and `doctor`.

## Why

Fleet drift. Bootstrap installs are idempotent (no upgrade path), and operators have to remember which installer owns each host's binary. We've watched `pmcp` drift to 1.5.1 / 1.8.0 / 1.8.1 / 1.9.2 across four hosts before manual cleanup, in part because of pip-vs-uv confusion on hosts where both are present.

Related: #58 (`pmcp update` CLI hangs against 1.9.2) — `pmcp upgrade` is the gateway-independent alternative that doesn't need to talk to the running service.

## Test plan

15 new tests in `tests/test_install_command.py`, all passing:

- `TestDetectInstallMethod` — uv via sys.executable, pip via user-site, uv fallback via tool dir, unknown otherwise.
- `TestDetectInstallDrift` — drift true when both installers present, false when only one.
- `TestUpgradeCommand` — parser defaults/flags, dry-run auto/pip, unknown auto exits 2, subprocess dispatch for uv, drift warning after upgrade.
- `TestDoctorDriftCheck` — doctor WARN when drift, OK when not.

Existing `tests/test_cli.py` passes 63/63.

Smoke-tested `pmcp upgrade --help` and `pmcp upgrade --dry-run --method={uv,pip}` on the dev install.
