### PR TITLE
Fix gateway streamable HTTP routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ env/
 htmlcov/
 .tox/
 .nox/
+.benchmarks/
 
 # OS
 .DS_Store
@@ -45,6 +46,8 @@ Thumbs.db
 
 # Logs
 *.log
+.pmcp/
+.playwright-mcp/
 
 # Env files
 .env
@@ -57,3 +60,7 @@ Thumbs.db
 # BAML generated client
 src/mcp_gateway/baml_client/
 data.db
+code_index.db
+
+# Local screenshot artifacts
+/*.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.9.2"
+version = "1.9.3"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pyyaml>=6.0",
     "python-dotenv>=1.0.0",
     "aiohttp>=3.9.0",
-    "baml-py==0.219.0",
+    "baml-py==0.221.0",
 ]
 
 [project.urls]

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.9.2"
+__version__ = "1.9.3"

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -685,11 +685,11 @@ async def run_update(args: argparse.Namespace) -> None:
         max_tools_per_server=policy_manager.get_max_tools_per_server()
     )
 
-    gateway_url = os.environ.get("PMCP_STATUS_SSE_URL", "http://127.0.0.1:3344/mcp")
+    gateway_url = _get_gateway_url()
     gateway_config = ResolvedServerConfig(
         name="pmcp-gateway",
         source="custom",
-        config=RemoteMcpServerConfig(type="http", url=gateway_url),
+        config=RemoteMcpServerConfig(type="streamable-http", url=gateway_url),
     )
 
     async def _call(tool_name: str, arguments: dict[str, object]) -> dict[str, object]:
@@ -698,8 +698,11 @@ async def run_update(args: argparse.Namespace) -> None:
         )
         return _extract_tool_payload(raw) or {}
 
-    await client_manager.connect_all([gateway_config])
     try:
+        errors = await client_manager.connect_all([gateway_config])
+        if errors:
+            _exit_gateway_unreachable(errors)
+
         targets: list[str] = []
         if args.all:
             health = await _call("gateway.health", {})
@@ -738,6 +741,21 @@ async def run_update(args: argparse.Namespace) -> None:
         await client_manager.disconnect_all()
 
 
+def _get_gateway_url() -> str:
+    """Return the PMCP gateway MCP endpoint URL."""
+    return os.environ.get(
+        "PMCP_GATEWAY_URL",
+        os.environ.get("PMCP_STATUS_SSE_URL", "http://127.0.0.1:3344/mcp"),
+    )
+
+
+def _exit_gateway_unreachable(errors: list[str]) -> None:
+    """Exit with a clear direct-gateway connection failure."""
+    detail = "; ".join(errors)
+    print(f"Error: cannot reach PMCP gateway: {detail}", file=sys.stderr)
+    sys.exit(1)
+
+
 def _extract_tool_payload(result: dict[str, object]) -> dict[str, object] | None:
     """Extract JSON payload from MCP tool response content."""
     content = result.get("content")
@@ -762,24 +780,29 @@ def _extract_tool_payload(result: dict[str, object]) -> dict[str, object] | None
 async def _query_running_gateway_status(
     args: argparse.Namespace, policy_manager: object
 ) -> dict[str, object] | None:
-    """Query live gateway status over SSE, return None on failure."""
+    """Query live gateway status over streamable HTTP, return None on failure."""
     import time
 
     from pmcp.client.manager import ClientManager
     from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
 
+    logger = logging.getLogger(__name__)
     probe_manager = ClientManager(
         max_tools_per_server=policy_manager.get_max_tools_per_server()  # type: ignore[attr-defined]
     )
-    probe_url = os.environ.get("PMCP_STATUS_SSE_URL", "http://127.0.0.1:3344/mcp")
+    probe_url = _get_gateway_url()
     probe_config = ResolvedServerConfig(
         name="pmcp-gateway",
         source="custom",
-        config=RemoteMcpServerConfig(type="http", url=probe_url),
+        config=RemoteMcpServerConfig(type="streamable-http", url=probe_url),
     )
 
     try:
-        await probe_manager.connect_all([probe_config])
+        errors = await probe_manager.connect_all([probe_config])
+        if errors:
+            logger.debug("Live gateway status query failed: %s", "; ".join(errors))
+            return None
+
         health_raw = await probe_manager.call_tool(
             "pmcp-gateway::gateway.health", {}, timeout_ms=3000
         )
@@ -821,6 +844,7 @@ async def _query_running_gateway_status(
 
         return snapshot
     except Exception:
+        logger.debug("Live gateway status query failed", exc_info=True)
         return None
     finally:
         await probe_manager.disconnect_all()
@@ -1772,11 +1796,11 @@ async def run_auth_connect(args: argparse.Namespace) -> None:
         max_tools_per_server=policy_manager.get_max_tools_per_server()
     )
 
-    gateway_url = os.environ.get("PMCP_STATUS_SSE_URL", "http://127.0.0.1:3344/mcp")
+    gateway_url = _get_gateway_url()
     gateway_config = ResolvedServerConfig(
         name="pmcp-gateway",
         source="custom",
-        config=RemoteMcpServerConfig(type="http", url=gateway_url),
+        config=RemoteMcpServerConfig(type="streamable-http", url=gateway_url),
     )
 
     async def _call(tool_name: str, arguments: dict[str, object]) -> dict[str, object]:
@@ -1786,8 +1810,11 @@ async def run_auth_connect(args: argparse.Namespace) -> None:
         payload = _extract_tool_payload(raw)
         return payload or {}
 
-    await client_manager.connect_all([gateway_config])
     try:
+        errors = await client_manager.connect_all([gateway_config])
+        if errors:
+            _exit_gateway_unreachable(errors)
+
         server_name = args.server_name
         first = await _call("gateway.provision", {"server_name": server_name})
 

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import mcp.types as mcp_types
 from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.message import SessionMessage
 
 from pmcp.config.loader import make_tool_id
@@ -191,6 +192,15 @@ def _interpolate_header_value(value: str) -> str:
     if not match:
         return value
     return os.environ.get(match.group(1), "")
+
+
+def _remote_headers(config: RemoteMcpServerConfig) -> dict[str, str] | None:
+    """Return remote transport headers with env-var placeholders expanded."""
+    if not config.headers:
+        return None
+    return {
+        key: _interpolate_header_value(value) for key, value in config.headers.items()
+    }
 
 
 @dataclass
@@ -383,7 +393,10 @@ class ClientManager:
     async def _connect_server(self, config: ResolvedServerConfig) -> None:
         """Connect to a single MCP server."""
         if isinstance(config.config, RemoteMcpServerConfig):
-            await self._connect_sse(config)
+            if config.config.type in ("http", "streamable-http"):
+                await self._connect_streamable_http(config)
+            else:
+                await self._connect_sse(config)
             return
 
         await self._connect_stdio(config)
@@ -573,6 +586,38 @@ class ClientManager:
 
     async def _connect_sse(self, config: ResolvedServerConfig) -> None:
         """Connect to a remote SSE MCP server."""
+        if not isinstance(config.config, RemoteMcpServerConfig):
+            raise ValueError(f"Server {config.name} has unsupported remote config type")
+
+        remote_config = config.config
+        headers = _remote_headers(remote_config)
+        await self._connect_remote_stream(
+            config,
+            sse_client(remote_config.url, headers=headers),
+            transport_name="SSE",
+        )
+
+    async def _connect_streamable_http(self, config: ResolvedServerConfig) -> None:
+        """Connect to a remote streamable-HTTP MCP server."""
+        if not isinstance(config.config, RemoteMcpServerConfig):
+            raise ValueError(f"Server {config.name} has unsupported remote config type")
+
+        remote_config = config.config
+        headers = _remote_headers(remote_config)
+        await self._connect_remote_stream(
+            config,
+            streamablehttp_client(remote_config.url, headers=headers),
+            transport_name="streamable HTTP",
+        )
+
+    async def _connect_remote_stream(
+        self,
+        config: ResolvedServerConfig,
+        transport_context: Any,
+        *,
+        transport_name: str,
+    ) -> None:
+        """Connect to a remote MCP server using a read/write stream transport."""
         name = config.name
 
         status = ServerStatus(
@@ -582,29 +627,17 @@ class ClientManager:
         )
         self._servers[name] = status
 
-        if not isinstance(config.config, RemoteMcpServerConfig):
-            raise ValueError(f"Server {name} has unsupported remote config type")
+        logger.info(f"Connecting to remote MCP server via {transport_name}: {name}")
 
-        remote_config = config.config
-        headers = None
-        if remote_config.headers:
-            headers = {
-                key: _interpolate_header_value(value)
-                for key, value in remote_config.headers.items()
-            }
-
-        logger.info(f"Connecting to remote MCP server: {name}")
-
-        sse_stack = AsyncExitStack()
-        read_stream, write_stream = await sse_stack.enter_async_context(
-            sse_client(remote_config.url, headers=headers)
-        )
+        remote_stack = AsyncExitStack()
+        transport = await remote_stack.enter_async_context(transport_context)
+        read_stream, write_stream = transport[:2]
 
         managed = ManagedClient(
             config=config,
             process=None,
             is_remote=True,
-            sse_exit_stack=sse_stack,
+            sse_exit_stack=remote_stack,
             write_stream=write_stream,
             status=status,
         )
@@ -717,7 +750,7 @@ class ClientManager:
         except Exception as e:
             status.status = ServerStatusEnum.ERROR
             status.last_error = str(e)
-            await sse_stack.aclose()
+            await remote_stack.aclose()
             raise
 
     async def _read_stderr(self, name: str, stderr: asyncio.StreamReader) -> None:

--- a/src/pmcp/transport/http.py
+++ b/src/pmcp/transport/http.py
@@ -19,7 +19,7 @@ import hmac
 import json
 import logging
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, MutableMapping
 from typing import TYPE_CHECKING, Any, Callable
 
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
@@ -282,7 +282,7 @@ def create_http_app(
         response_started = False
         original_send = request._send
 
-        async def tracking_send(message: dict[str, Any]) -> None:
+        async def tracking_send(message: MutableMapping[str, Any]) -> None:
             nonlocal response_started
             if message.get("type") == "http.response.start":
                 response_started = True

--- a/src/pmcp/transport/http.py
+++ b/src/pmcp/transport/http.py
@@ -279,10 +279,19 @@ def create_http_app(
 
             request._receive = replay_receive  # type: ignore[method-assign]
 
+        response_started = False
+        original_send = request._send
+
+        async def tracking_send(message: dict[str, Any]) -> None:
+            nonlocal response_started
+            if message.get("type") == "http.response.start":
+                response_started = True
+            await original_send(message)
+
         try:
             await asyncio.wait_for(
                 session_manager.handle_request(
-                    request.scope, request.receive, request._send
+                    request.scope, request.receive, tracking_send
                 ),
                 timeout=request_timeout,
             )
@@ -292,6 +301,8 @@ def create_http_app(
                 request_id,
                 request_timeout,
             )
+            if response_started:
+                return _NullResponse()
             return Response("Gateway Timeout", status_code=504)
         _inc("requests_ok")
         return _NullResponse()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1056,6 +1056,127 @@ class TestDoctorAndSecretsIntegration:
         mock_update.assert_awaited_once_with(args)
 
 
+class TestGatewayCliRemoteConfig:
+    """Tests for CLI commands that talk to the running PMCP gateway."""
+
+    def test_get_gateway_url_prefers_new_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PMCP_GATEWAY_URL should override the legacy SSE alias."""
+        from pmcp.cli import _get_gateway_url
+
+        monkeypatch.setenv("PMCP_STATUS_SSE_URL", "http://legacy.example/mcp")
+        monkeypatch.setenv("PMCP_GATEWAY_URL", "http://gateway.example/mcp")
+
+        assert _get_gateway_url() == "http://gateway.example/mcp"
+
+    @pytest.mark.asyncio
+    async def test_run_update_exits_when_gateway_connect_fails(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """run_update should stop before tool calls when the gateway is unreachable."""
+        from pmcp.cli import run_update
+
+        args = argparse.Namespace(
+            command="update",
+            server="context7",
+            all=False,
+            json=False,
+            policy=None,
+            log_level="warn",
+        )
+
+        with patch(
+            "pmcp.client.manager.ClientManager.connect_all",
+            new=AsyncMock(return_value=["Failed to connect to pmcp-gateway: boom"]),
+        ) as mock_connect_all:
+            with patch(
+                "pmcp.client.manager.ClientManager.call_tool", new=AsyncMock()
+            ) as mock_call_tool:
+                with patch(
+                    "pmcp.client.manager.ClientManager.disconnect_all",
+                    new=AsyncMock(),
+                ):
+                    with pytest.raises(SystemExit) as exc_info:
+                        await run_update(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "cannot reach PMCP gateway" in captured.err
+        gateway_config = mock_connect_all.await_args.args[0][0]
+        assert gateway_config.config.type == "streamable-http"
+        mock_call_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_query_running_gateway_status_returns_none_on_connect_failure(
+        self,
+    ) -> None:
+        """Live status query failures should preserve static-config fallback."""
+        from pmcp.cli import _query_running_gateway_status
+
+        class Policy:
+            def get_max_tools_per_server(self) -> int:
+                return 100
+
+        args = argparse.Namespace(server=None, pending=False)
+
+        with patch(
+            "pmcp.client.manager.ClientManager.connect_all",
+            new=AsyncMock(return_value=["Failed to connect to pmcp-gateway: boom"]),
+        ) as mock_connect_all:
+            with patch(
+                "pmcp.client.manager.ClientManager.call_tool", new=AsyncMock()
+            ) as mock_call_tool:
+                with patch(
+                    "pmcp.client.manager.ClientManager.disconnect_all",
+                    new=AsyncMock(),
+                ):
+                    result = await _query_running_gateway_status(args, Policy())
+
+        assert result is None
+        gateway_config = mock_connect_all.await_args.args[0][0]
+        assert gateway_config.config.type == "streamable-http"
+        mock_call_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_auth_connect_exits_when_gateway_connect_fails(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """auth connect should use streamable HTTP and stop on connect errors."""
+        from pmcp.cli import run_auth_connect
+
+        args = argparse.Namespace(
+            command="auth",
+            auth_command="connect",
+            server_name="browser-use",
+            credential=None,
+            policy=None,
+            log_level="warn",
+            json=False,
+        )
+
+        with patch(
+            "pmcp.client.manager.ClientManager.connect_all",
+            new=AsyncMock(return_value=["Failed to connect to pmcp-gateway: boom"]),
+        ) as mock_connect_all:
+            with patch(
+                "pmcp.client.manager.ClientManager.call_tool", new=AsyncMock()
+            ) as mock_call_tool:
+                with patch(
+                    "pmcp.client.manager.ClientManager.disconnect_all",
+                    new=AsyncMock(),
+                ):
+                    with pytest.raises(SystemExit) as exc_info:
+                        await run_auth_connect(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "cannot reach PMCP gateway" in captured.err
+        gateway_config = mock_connect_all.await_args.args[0][0]
+        assert gateway_config.config.type == "streamable-http"
+        mock_call_tool.assert_not_awaited()
+
+
 class TestRunStatusWithData:
     """Tests for run_status with actual server data."""
 

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -359,6 +359,121 @@ class TestRemoteConnectSseHeaders:
 
         await manager.disconnect_all()
 
+    @pytest.mark.asyncio
+    async def test_connect_streamable_http_interpolates_headers_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Streamable-HTTP remote configs should use the same header interpolation."""
+        manager = ClientManager()
+        monkeypatch.setenv("PMCP_TEST_TOKEN", "test-token")
+
+        config = ResolvedServerConfig(
+            name="remote-http",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http",
+                url="https://example.com/mcp",
+                headers={
+                    "Authorization": "${PMCP_TEST_TOKEN}",
+                    "X-Static": "literal-value",
+                    "X-Missing": "${PMCP_MISSING}",
+                },
+            ),
+        )
+
+        captured_headers: dict[str, str] = {}
+
+        class EmptyReadStream:
+            def __aiter__(self) -> "EmptyReadStream":
+                return self
+
+            async def __anext__(self) -> None:
+                raise StopAsyncIteration
+
+        @asynccontextmanager
+        async def mock_streamablehttp_client(
+            url: str, headers: dict[str, str] | None = None
+        ):
+            assert url == "https://example.com/mcp"
+            captured_headers.update(headers or {})
+            yield EmptyReadStream(), MagicMock(), MagicMock(return_value=None)
+
+        manager._send_initialize = AsyncMock()
+
+        async def mock_send_request(*args: object, **kwargs: object) -> dict:
+            method = args[1]
+            if method == "tools/list":
+                return {"tools": []}
+            if method == "resources/list":
+                return {"resources": []}
+            if method == "prompts/list":
+                return {"prompts": []}
+            return {}
+
+        manager._send_request = AsyncMock(side_effect=mock_send_request)
+        manager._read_sse = AsyncMock()
+
+        with patch(
+            "pmcp.client.manager.streamablehttp_client", mock_streamablehttp_client
+        ):
+            await manager._connect_streamable_http(config)
+
+        assert captured_headers == {
+            "Authorization": "test-token",
+            "X-Static": "literal-value",
+            "X-Missing": "",
+        }
+
+        await manager.disconnect_all()
+
+
+class TestRemoteConnectTransportDispatch:
+    """Tests for remote transport dispatch."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("config_type", ["http", "streamable-http"])
+    async def test_http_remote_types_use_streamable_http(
+        self, config_type: str
+    ) -> None:
+        """HTTP-style remote configs should use the streamable-HTTP client."""
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name=f"remote-{config_type}",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type=cast(Any, config_type),
+                url="https://example.com/mcp",
+            ),
+        )
+        manager._connect_streamable_http = AsyncMock()  # type: ignore[method-assign]
+        manager._connect_sse = AsyncMock()  # type: ignore[method-assign]
+
+        await manager._connect_server(config)
+
+        manager._connect_streamable_http.assert_awaited_once_with(config)  # type: ignore[attr-defined]
+        manager._connect_sse.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("config_type", ["sse", "remote"])
+    async def test_legacy_remote_types_use_sse(self, config_type: str) -> None:
+        """SSE and legacy remote configs should keep using the SSE client."""
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name=f"remote-{config_type}",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type=cast(Any, config_type),
+                url="https://example.com/sse",
+            ),
+        )
+        manager._connect_streamable_http = AsyncMock()  # type: ignore[method-assign]
+        manager._connect_sse = AsyncMock()  # type: ignore[method-assign]
+
+        await manager._connect_server(config)
+
+        manager._connect_sse.assert_awaited_once_with(config)  # type: ignore[attr-defined]
+        manager._connect_streamable_http.assert_not_awaited()  # type: ignore[attr-defined]
+
 
 class TestCallTool:
     """Tests for call_tool method."""

--- a/tests/test_transport_http.py
+++ b/tests/test_transport_http.py
@@ -271,6 +271,42 @@ class TestRequestTimeout:
         )
         assert r.status_code == 504
 
+    def test_timeout_after_response_start_does_not_double_send(self) -> None:
+        """A timeout after response start should not trigger a second Starlette response."""
+        mcp_server = MagicMock()
+        mcp_server.list_tools = AsyncMock(return_value=[])
+
+        with patch(
+            "pmcp.transport.http.StreamableHTTPSessionManager",
+            autospec=True,
+        ) as MockManager:
+            instance = MockManager.return_value
+            instance.run.return_value.__aenter__ = AsyncMock(return_value=None)
+            instance.run.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            async def started_then_slow_handler(
+                scope: object, receive: object, send: object
+            ) -> None:
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 202,
+                        "headers": [],
+                    }
+                )
+                await asyncio.sleep(10.0)
+
+            instance.handle_request = started_then_slow_handler
+
+            app = create_http_app(mcp_server, request_timeout=0.05)
+            client = TestClient(app, raise_server_exceptions=False)
+
+        r = client.post(
+            "/mcp",
+            content=b'{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}',
+        )
+        assert r.status_code == 202
+
     def test_fast_request_does_not_timeout(self) -> None:
         """Request that completes before timeout → not 504."""
         # handler returns immediately (0s delay), timeout is 60s

--- a/uv.lock
+++ b/uv.lock
@@ -196,17 +196,17 @@ wheels = [
 
 [[package]]
 name = "baml-py"
-version = "0.219.0"
+version = "0.221.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/eb/570b5f97496ef513f08214085796bf68e1499035cd39523cdb92a43731f3/baml_py-0.219.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:db10e488436465774b2503386d220a559df8dcbe4e8f832cc10d42fccb4fd747", size = 21581187, upload-time = "2026-02-12T22:30:05.542Z" },
-    { url = "https://files.pythonhosted.org/packages/01/cf/992dbbab9cfc0423fc742426330529940c524f6e11e97e5355d9a86ccdd8/baml_py-0.219.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:e6b5b4fa38c4cef2a0f69afce5f2feb8cfa6075fbe529ef849ce71573a47e22d", size = 20394449, upload-time = "2026-02-12T22:30:08.382Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/c5/739fae4d513f05e8d65f9b11d2e1533f25d8ef9493fba55d578b993968b0/baml_py-0.219.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9cecd2f4491c3df698be14cdcacda17e15358667358725dd14e2722669b21df3", size = 24120733, upload-time = "2026-02-12T22:30:10.541Z" },
-    { url = "https://files.pythonhosted.org/packages/db/d9/9a3b13fb674de657e8bbd95d057112d83676b2d2fa3add33abd2e0736378/baml_py-0.219.0-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:7defb27b9fb479c72a4fd550561f74d1bd155ac6f949ab75a6755030076a54ff", size = 23502079, upload-time = "2026-02-12T22:30:13.683Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ee/378d495775100f324f7591293c54e2f1045bfd4fbe1835fcdf784cfc2fee/baml_py-0.219.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:b5a7ff103c46cd7a8d34c0c9d612d3dc0716c9fbec68161d7d51a85b0e8e5189", size = 23895539, upload-time = "2026-02-12T22:30:17.144Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e8/716b9aef15f2362c979123bc09649ea5325dd48525b78708f1a71ac53c6f/baml_py-0.219.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:8c7de9c7248117687407007efdd4891b331ae187d2f7794e56072b219216daf1", size = 24349171, upload-time = "2026-02-12T22:30:20.028Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/b3/62cb4d31316e7a90e41ad28d4ff17d5dba0c8abb2707d3ce94df0ee26418/baml_py-0.219.0-cp38-abi3-win_amd64.whl", hash = "sha256:019b70c88097825918b9f2a2f80266f0cefc768ea9dcf6cd0740f48bfe471b72", size = 21765159, upload-time = "2026-02-12T22:30:24.252Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/b5/805f206d3ceba1b9382aad76a1e083612bef669f1a15c57e806872b657ff/baml_py-0.219.0-cp38-abi3-win_arm64.whl", hash = "sha256:7965609753ba11dbc12b7c3853ba81ee4d90eef19b629165c837472f5f334f4f", size = 20216236, upload-time = "2026-02-12T22:30:27.002Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8b/c327e7afccaf43fb1f3ae17d10f8ff1c53818b9e98a5ed157e10a508f0e8/baml_py-0.221.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:492c58e462324a44eb8fc8fc9594f218472781f53679bc9373dc144af01fc996", size = 21814592, upload-time = "2026-04-15T19:50:27.773Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/be/92ebd6f0633877a21e57abe968db83b685540eb2a25a66b1c9cc6db762b1/baml_py-0.221.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:e7491f9c35aa57aced7a8e79c98d6b2a2552e67f1a0037306c1999451ee86ffe", size = 20654921, upload-time = "2026-04-15T19:50:30.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/00/eeff6f283dec358be737fd858d709da263a7df5e2e1645a2cda6f6be5a4c/baml_py-0.221.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f3e578a81a78eff3b65d54b8f02fb87c65dc5c77815bace9687685de92e3055", size = 24367896, upload-time = "2026-04-15T19:50:33.616Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/5da6bbbbc9d5778ceea805cdbdd9e34d29aed23f43d706a83956d9b887df/baml_py-0.221.0-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:da382fc9ddc4d7f089242f79b6ed760a356799f41d12e05bef1719234d636ffb", size = 23740744, upload-time = "2026-04-15T19:50:36.498Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/76/7e7179d16ea814dcc2e4a756347b0efeda0f21aa4ce2207a9c81a1347156/baml_py-0.221.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0daaa87da4bbd30529c45826283a2018ded2b80580e9c3a1be81bfc6734e7b0e", size = 24119636, upload-time = "2026-04-15T19:50:39.643Z" },
+    { url = "https://files.pythonhosted.org/packages/05/08/6883257302c4f2f0f9ca2e59bfa2bf3bd4880739a269034841ba313cc639/baml_py-0.221.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:8e691bc386237677ff9fcb0d42bf8b97daaa86b653ebcec8677a3444c67dec6a", size = 24615148, upload-time = "2026-04-15T19:50:43.062Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4e/ba9e0e1301939880b4339d0ad1013d87bb7a5b8a96b107e94db3e2e3fa86/baml_py-0.221.0-cp38-abi3-win_amd64.whl", hash = "sha256:96fb0dfce070b0c0b88d105dcc637990788268d4920f17f0aef25d980aee4313", size = 22013809, upload-time = "2026-04-15T19:50:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/4bdaa7a376b540a5fc52bdf551b0223dc6c5a2e8f4dc03c85c40a0702796/baml_py-0.221.0-cp38-abi3-win_arm64.whl", hash = "sha256:841537ae241fde5f2ae1829a4dd4c820a3a1a3ea75f8f65dce82f64917adf4a1", size = 20379767, upload-time = "2026-04-15T19:50:49.328Z" },
 ]
 
 [[package]]
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.9.0"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1082,7 +1082,7 @@ llm = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "baml-py", specifier = "==0.219.0" },
+    { name = "baml-py", specifier = "==0.221.0" },
     { name = "baml-py", marker = "extra == 'llm'", specifier = ">=0.215.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.9.2"
+version = "1.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- route remote HTTP/streamable-HTTP configs through the MCP streamable HTTP client
- switch direct gateway CLI commands to streamable HTTP with clear connection-failure handling
- update baml-py lock resolution and bump package version to 1.9.3
- ignore local runtime/browser artifacts

## Verification
- uv lock --check
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- uv run pytest tests/test_client_manager.py tests/test_cli.py tests/test_transport_http.py tests/test_version_checker.py
- uv run pytest

Closes #58