### PR TITLE
Add Excalidraw remote MCP manifest support

### DIFF
--- a/src/pmcp/config/loader.py
+++ b/src/pmcp/config/loader.py
@@ -353,6 +353,23 @@ def manifest_server_to_config(server: "ManifestServerConfig") -> ResolvedServerC
     Returns:
         ResolvedServerConfig compatible with ClientManager
     """
+    if server.url:
+        remote_type = server.transport
+        if remote_type == "local":
+            remote_type = "streamable-http"
+        return ResolvedServerConfig(
+            name=server.name,
+            source="manifest",
+            config=RemoteMcpServerConfig(
+                type=cast(
+                    Literal["remote", "sse", "http", "streamable-http"],
+                    remote_type,
+                ),
+                url=server.url,
+                headers=server.headers,
+            ),
+        )
+
     # Build env dict if server requires API key
     env: dict[str, str] | None = None
     if server.env_var:

--- a/src/pmcp/manifest/loader.py
+++ b/src/pmcp/manifest/loader.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import yaml
 
 logger = logging.getLogger(__name__)
 
 Platform = Literal["mac", "wsl", "linux", "windows"]
+ServerTransport = Literal["local", "remote", "sse", "http", "streamable-http"]
 
 
 @dataclass
@@ -40,6 +41,9 @@ class ServerConfig:
     env_var: str | None = None
     env_instructions: str | None = None
     auto_start: bool = False
+    transport: ServerTransport = "local"
+    url: str | None = None
+    headers: dict[str, str] | None = None
 
 
 # Category taxonomy used by Manifest.get_category_summary() and get_servers_in_category()
@@ -118,7 +122,7 @@ _CATEGORY_MAP: dict[str, list[str]] = {
         "todoist",
         "plane",
     ],
-    "design & media": ["figma", "miro", "mux", "elevenlabs"],
+    "design & media": ["figma", "miro", "excalidraw", "mux", "elevenlabs"],
     "monitoring": ["datadog", "grafana", "dynatrace", "langfuse"],
     "CMS & content": [
         "airtable",
@@ -290,6 +294,11 @@ def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
         if platform in install_data:
             install[platform] = install_data[platform]  # type: ignore
 
+    transport = cast(
+        ServerTransport,
+        data.get("transport", "streamable-http" if data.get("url") else "local"),
+    )
+
     return ServerConfig(
         name=name,
         description=data.get("description", ""),
@@ -301,6 +310,9 @@ def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
         env_var=data.get("env_var"),
         env_instructions=data.get("env_instructions"),
         auto_start=data.get("auto_start", False),
+        transport=transport,
+        url=data.get("url"),
+        headers=data.get("headers"),
     )
 
 

--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -1000,6 +1000,16 @@ servers:
     env_var: "MIRO_ACCESS_TOKEN"
     env_instructions: "Create app and get access token at https://miro.com/app/settings/user-profile/apps"
 
+  excalidraw:
+    description: "Excalidraw whiteboard - create and edit hand-drawn diagrams and scenes"
+    keywords: [excalidraw, whiteboard, diagram, drawing, sketch, canvas, scene, shapes, app]
+    install: {}
+    transport: "streamable-http"
+    url: "https://mcp.excalidraw.com"
+    command: ""
+    args: []
+    requires_api_key: false
+
   mux:
     description: "Mux video API - manage video assets, live streams, transcoding, analytics"
     keywords: [mux, video, streaming, media, transcoding, playback, live-stream, hls, encoding]

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -1417,6 +1417,15 @@ class GatewayTools:
                 command=command,
                 args=args,
                 requires_api_key=False,
+                transport=config.config.type
+                if isinstance(config.config, RemoteMcpServerConfig)
+                else "local",
+                url=config.config.url
+                if isinstance(config.config, RemoteMcpServerConfig)
+                else None,
+                headers=config.config.headers
+                if isinstance(config.config, RemoteMcpServerConfig)
+                else None,
             )
 
         return Manifest(
@@ -1929,6 +1938,79 @@ class GatewayTools:
                     auth_mode="api_key",
                     auth_methods=self._auth_methods_for_server(server_name),
                     alternative_env_vars=auth_env_options,
+                    update_warning=update_warning,
+                    feedback_hint=self._feedback_hint(),
+                )
+
+        # Remote manifest entries do not install packages; connect them directly.
+        if server_config.url:
+            try:
+                resolved_config = manifest_server_to_config(server_config)
+                errors = await self._client_manager.connect_all([resolved_config])
+                if errors:
+                    message = "; ".join(errors)
+                    self._record_feedback_event(
+                        "provision_failure",
+                        {
+                            "server": server_name,
+                            "reason": "remote_connect_error",
+                            "error": self._sanitize_error(Exception(message)),
+                        },
+                    )
+                    return ProvisionOutput(
+                        ok=False,
+                        server=server_name,
+                        status="failed",
+                        message=message,
+                        update_warning=update_warning,
+                        feedback_hint=self._feedback_hint(),
+                    )
+
+                self._register_provisioned_server(
+                    server_name,
+                    server_config.env_var if server_config else None,
+                )
+                tools = [
+                    t
+                    for t in self._client_manager.get_all_tools()
+                    if t.server_name == server_name
+                ]
+                return ProvisionOutput(
+                    ok=True,
+                    server=server_name,
+                    status="complete",
+                    message=f"Remote server '{server_name}' connected with {len(tools)} tools.",
+                    new_tools=[
+                        CapabilityCard(
+                            tool_id=t.tool_id,
+                            server=t.server_name,
+                            tool_name=t.tool_name,
+                            short_description=t.short_description,
+                            tags=t.tags,
+                            availability="online",
+                            risk_hint=t.risk_hint.value,
+                        )
+                        for t in tools[:10]
+                    ],
+                    update_warning=update_warning,
+                    feedback_hint=None,
+                )
+
+            except Exception as e:
+                logger.error(f"Failed to connect remote server {server_name}: {e}")
+                self._record_feedback_event(
+                    "provision_failure",
+                    {
+                        "server": server_name,
+                        "reason": "remote_connect_exception",
+                        "error": self._sanitize_error(e),
+                    },
+                )
+                return ProvisionOutput(
+                    ok=False,
+                    server=server_name,
+                    status="failed",
+                    message=f"Failed to connect remote server '{server_name}': {self._sanitize_error(e)}",
                     update_warning=update_warning,
                     feedback_hint=self._feedback_hint(),
                 )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -9,8 +9,10 @@ from pathlib import Path
 from pmcp.config.loader import (
     load_configs,
     make_tool_id,
+    manifest_server_to_config,
     parse_tool_id,
 )
+from pmcp.manifest.loader import ServerConfig
 
 
 class TestMakeToolId:
@@ -187,6 +189,25 @@ class TestLoadConfigs:
         assert configs[0].name == "gateway"
         assert configs[0].config.type == "remote"
         assert configs[0].config.url == "https://example.com/mcp"
+
+    def test_converts_remote_manifest_server_to_remote_config(self) -> None:
+        server = ServerConfig(
+            name="excalidraw",
+            description="Excalidraw whiteboard",
+            keywords=["excalidraw"],
+            install={},
+            command="",
+            args=[],
+            transport="streamable-http",
+            url="https://mcp.excalidraw.com",
+        )
+
+        resolved = manifest_server_to_config(server)
+
+        assert resolved.name == "excalidraw"
+        assert resolved.source == "manifest"
+        assert resolved.config.type == "streamable-http"
+        assert resolved.config.url == "https://mcp.excalidraw.com"
 
     def test_merges_manifest_defaults_for_partial_server_config(
         self, tmp_path: Path

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -123,6 +123,7 @@ def test_manifest_has_expected_servers():
         "supabase",
         "firecrawl",
         "tavily",
+        "excalidraw",
     ]
     for server in expected_servers:
         assert server in manifest.servers, f"Missing server: {server}"
@@ -172,6 +173,18 @@ def test_manifest_server_config():
     assert playwright.command == "npx"
     assert playwright.requires_api_key is False
     assert playwright.auto_start is True
+
+
+def test_manifest_remote_server_config():
+    """Test remote server config structure."""
+    manifest = load_manifest()
+
+    excalidraw = manifest.get_server("excalidraw")
+    assert excalidraw is not None
+    assert excalidraw.transport == "streamable-http"
+    assert excalidraw.url == "https://mcp.excalidraw.com"
+    assert excalidraw.command == ""
+    assert excalidraw.install == {}
 
 
 def test_manifest_cli_config():

--- a/tests/test_manifest_provision.py
+++ b/tests/test_manifest_provision.py
@@ -1,7 +1,7 @@
 """Manifest provisioning test suite.
 
 Fast unit tier (~300 parametrized cases, <10s):
-- Schema completeness for all 99 manifest servers
+- Schema completeness for manifest servers
 - Install command consistency (linux[0] == server.command)
 - Mocked provision routing for all servers
 
@@ -29,6 +29,12 @@ _manifest = load_manifest()
 _all_servers = list(_manifest.servers.values())
 _api_key_servers = [s for s in _all_servers if s.requires_api_key]
 _no_key_servers = [s for s in _all_servers if not s.requires_api_key]
+_remote_servers = [s for s in _all_servers if s.url]
+_installable_servers = [s for s in _all_servers if not s.url]
+_no_key_installable_servers = [
+    s for s in _installable_servers if not s.requires_api_key
+]
+_no_key_remote_servers = [s for s in _remote_servers if not s.requires_api_key]
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +69,9 @@ class _MinimalClientManager:
     async def refresh(self, configs):
         return []
 
+    async def connect_all(self, configs, retry=True):
+        return []
+
 
 def _make_gateway_tools() -> GatewayTools:
     return GatewayTools(
@@ -87,17 +96,17 @@ class TestManifestSchemaCompleteness:
     def test_keywords_non_empty(self, server):
         assert isinstance(server.keywords, list) and len(server.keywords) > 0
 
-    @pytest.mark.parametrize("server", _all_servers, ids=lambda s: s.name)
+    @pytest.mark.parametrize("server", _installable_servers, ids=lambda s: s.name)
     def test_install_dict_non_empty(self, server):
         assert isinstance(server.install, dict) and len(server.install) > 0
 
-    @pytest.mark.parametrize("server", _all_servers, ids=lambda s: s.name)
+    @pytest.mark.parametrize("server", _installable_servers, ids=lambda s: s.name)
     def test_linux_platform_present(self, server):
         assert "linux" in server.install, (
             f"Server '{server.name}' missing 'linux' key in install"
         )
 
-    @pytest.mark.parametrize("server", _all_servers, ids=lambda s: s.name)
+    @pytest.mark.parametrize("server", _installable_servers, ids=lambda s: s.name)
     def test_command_non_empty(self, server):
         assert isinstance(server.command, str) and server.command.strip()
 
@@ -117,6 +126,11 @@ class TestManifestSchemaCompleteness:
             f"Server '{server.name}' requires_api_key=True but env_instructions is empty"
         )
 
+    @pytest.mark.parametrize("server", _remote_servers, ids=lambda s: s.name)
+    def test_remote_servers_have_url_and_transport(self, server):
+        assert server.url
+        assert server.transport in {"remote", "sse", "http", "streamable-http"}
+
 
 # ---------------------------------------------------------------------------
 # Class 2 — Install command consistency
@@ -126,7 +140,7 @@ class TestManifestSchemaCompleteness:
 class TestManifestInstallCommandConsistency:
     """server.install['linux'][0] must equal server.command."""
 
-    @pytest.mark.parametrize("server", _all_servers, ids=lambda s: s.name)
+    @pytest.mark.parametrize("server", _installable_servers, ids=lambda s: s.name)
     def test_linux_install_first_token_matches_command(self, server):
         linux_cmd = server.install["linux"]
         assert linux_cmd, f"Server '{server.name}': linux install list is empty"
@@ -144,7 +158,9 @@ class TestManifestInstallCommandConsistency:
 class TestProvisionRoutingAllServers:
     """Provision routing returns correct shape for every server — no I/O."""
 
-    @pytest.mark.parametrize("server", _no_key_servers, ids=lambda s: s.name)
+    @pytest.mark.parametrize(
+        "server", _no_key_installable_servers, ids=lambda s: s.name
+    )
     async def test_provision_no_key_server(self, server, monkeypatch):
         """No-API-key servers should start installation and return status='started'."""
         tools = _make_gateway_tools()
@@ -164,6 +180,27 @@ class TestProvisionRoutingAllServers:
         )
         assert result.job_id == "fake-job-id"
         assert result.server == server.name
+
+    @pytest.mark.parametrize("server", _no_key_remote_servers, ids=lambda s: s.name)
+    async def test_provision_no_key_remote_server(self, server, monkeypatch):
+        """No-API-key remote servers should connect directly without installer jobs."""
+        tools = _make_gateway_tools()
+
+        fake_jm = MagicMock()
+        fake_jm.start_install = AsyncMock(return_value="fake-job-id")
+
+        monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: _manifest)
+        monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: [])
+        monkeypatch.setattr("pmcp.tools.handlers.get_job_manager", lambda: fake_jm)
+        monkeypatch.setattr(tools, "_save_provisioned_registry", lambda: None)
+
+        result = await tools.provision({"server_name": server.name})
+
+        assert result.ok is True, f"[{server.name}] provision failed: {result.message}"
+        assert result.status == "complete"
+        assert result.job_id is None
+        assert result.server == server.name
+        fake_jm.start_install.assert_not_awaited()
 
     @pytest.mark.parametrize("server", _api_key_servers, ids=lambda s: s.name)
     async def test_provision_missing_api_key(self, server, monkeypatch):
@@ -228,7 +265,9 @@ class TestLiveProvisionSmokeTest:
                         pass
         JobManager._instance = None
 
-    @pytest.mark.parametrize("server", _no_key_servers, ids=lambda s: s.name)
+    @pytest.mark.parametrize(
+        "server", _no_key_installable_servers, ids=lambda s: s.name
+    )
     @pytest.mark.timeout(130)
     async def test_live_install(self, server):
         """Start install and wait up to 120 s for server_ready or complete."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -33,6 +33,7 @@ class MockClientManager:
         self._server_statuses: list[ServerStatus] = []
         self._revision_id = "test-rev"
         self._last_refresh_ts = 1234567890.0
+        self.connected_configs: list[Any] = []
 
     def get_all_tools(self) -> list[ToolInfo]:
         return list(self._tools.values())
@@ -77,6 +78,12 @@ class MockClientManager:
         return {"content": [{"type": "text", "text": "result"}]}
 
     async def refresh(self, configs: list[Any]) -> list[str]:
+        return []
+
+    async def connect_all(self, configs: list[Any], retry: bool = True) -> list[str]:
+        self.connected_configs.extend(configs)
+        for config in configs:
+            self._online_servers.add(config.name)
         return []
 
 
@@ -890,6 +897,47 @@ class TestSearchRegistryAndRegister:
         assert result.ok is False
         assert result.needs_api_key is True
         assert result.env_var == "GITHUB_TOKEN"
+
+    @pytest.mark.asyncio
+    async def test_remote_manifest_server_provisions_without_installer(
+        self, gateway_tools: GatewayTools, monkeypatch
+    ) -> None:
+        """Remote manifest servers should connect directly instead of starting jobs."""
+        client_manager = cast(MockClientManager, gateway_tools._client_manager)
+        manifest = Manifest(
+            version="1.0",
+            cli_alternatives={},
+            servers={
+                "excalidraw": ServerConfig(
+                    name="excalidraw",
+                    description="Excalidraw whiteboard",
+                    keywords=["excalidraw", "whiteboard"],
+                    install={},
+                    command="",
+                    args=[],
+                    requires_api_key=False,
+                    transport="streamable-http",
+                    url="https://mcp.excalidraw.com",
+                )
+            },
+            discovery_queue_path=".mcp-gateway/discovery_queue.json",
+        )
+        fake_jm = types.SimpleNamespace(start_install=pytest.fail)
+
+        monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: manifest)
+        monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: [])
+        monkeypatch.setattr("pmcp.tools.handlers.get_job_manager", lambda: fake_jm)
+        monkeypatch.setattr(gateway_tools, "_save_provisioned_registry", lambda: None)
+
+        result = await gateway_tools.provision({"server_name": "excalidraw"})
+
+        assert result.ok is True
+        assert result.status == "complete"
+        assert len(client_manager.connected_configs) == 1
+        connected = client_manager.connected_configs[0]
+        assert connected.name == "excalidraw"
+        assert connected.config.type == "streamable-http"
+        assert connected.config.url == "https://mcp.excalidraw.com"
 
 
 class TestStaleIndexer:


### PR DESCRIPTION
## Summary
- Add remote manifest fields so manifest entries can point at hosted MCP endpoints
- Register Excalidraw as a streamable HTTP MCP server at https://mcp.excalidraw.com
- Provision remote manifest servers directly through ClientManager instead of installer jobs

## Verification
- uv run pytest -q
- uv run pytest tests/test_manifest.py tests/test_config_loader.py tests/test_manifest_provision.py tests/test_tools.py -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy src/pmcp --exclude baml_client
- live ClientManager connection to excalidraw returned online with 5 tools and 1 resource
