### PR TITLE
fix(#79,#78): browser/gateway session stability + provisionable-server discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (including JSON progress notifications, which now count toward per-request
   liveness in both the stdio and SSE readers). An absolute backstop caps total
   wall-clock time so a chatty-but-never-completing call cannot hang forever —
-  configurable via `PMCP_REQUEST_CEILING_MS` (default 600000ms / 10 min). This
-  unblocks legitimately long browser/automation operations driven through the
-  gateway.
+  configurable via `PMCP_REQUEST_CEILING_MS` (default 600000ms / 10 min). The
+  long ceiling applies only to tool invocations; control-plane requests
+  (initialize, list calls) keep the tighter idle deadline so one stuck server
+  can't stall startup/refresh. This unblocks legitimately long browser/
+  automation operations driven through the gateway.
 - Stdio servers are now spawned in their own session/process group
   (`start_new_session=True`) and reaped as a whole tree on disconnect (issue
   #79, symptom 1c). Previously, killing a stdio server (e.g. `@playwright/mcp`)
   left the browser it launched orphaned to init, holding the profile's
   SingletonLock and breaking the next launch. A new group-aware
   `_terminate_process_tree` helper (SIGTERM the group, wait, then SIGKILL, with
-  a single-process fallback when the process is not a group leader) now backs
-  all four downstream shutdown paths.
+  a single-process fallback when the process is not a group leader, or on
+  Windows where process groups are unavailable) now backs all four downstream
+  shutdown paths.
 - `gateway.refresh` is now diff-based and non-destructive (issue #79, symptom
   2). Servers whose resolved config is unchanged are left connected and
   running; only servers that were removed or whose config changed are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   refresh tore down **every** server and reconnected only the eager set, which
   dropped previously-running lazy/provisioned servers to offline (the reported
   "105 seen, 0 online") and needlessly respawned unchanged processes (e.g. a
-  live browser) on every refresh.
+  live browser) on every refresh. The diff keeps only servers that are actually
+  ONLINE — a crashed eager server is reconnected (recovery path preserved);
+  reconciles the lazy registry to the resolved keep-set so removed/policy-denied
+  servers can no longer be lazily started; and reconnects a remote server when
+  its `${VAR}` auth token has rotated in the env store (compared against the
+  connect-time resolved headers), instead of keeping stale/revoked auth.
+- Process-tree reaping now escalates to a group `SIGKILL` when the leader exits
+  but a grandchild (e.g. a `SIGTERM`-ignoring browser) survives the `SIGTERM`
+  grace period, and reaps servers concurrently at shutdown so multiple hung
+  servers can't exceed the shutdown budget and orphan browsers (issue #79/1c).
 
 ### Added
 - `gateway.catalog_search` with `include_offline=true` now surfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configurable via `PMCP_REQUEST_CEILING_MS` (default 600000ms / 10 min). This
   unblocks legitimately long browser/automation operations driven through the
   gateway.
+- Stdio servers are now spawned in their own session/process group
+  (`start_new_session=True`) and reaped as a whole tree on disconnect (issue
+  #79, symptom 1c). Previously, killing a stdio server (e.g. `@playwright/mcp`)
+  left the browser it launched orphaned to init, holding the profile's
+  SingletonLock and breaking the next launch. A new group-aware
+  `_terminate_process_tree` helper (SIGTERM the group, wait, then SIGKILL, with
+  a single-process fallback when the process is not a group leader) now backs
+  all four downstream shutdown paths.
+- `gateway.refresh` is now diff-based and non-destructive (issue #79, symptom
+  2). Servers whose resolved config is unchanged are left connected and
+  running; only servers that were removed or whose config changed are
+  disconnected, and only newly-added eager servers are connected. Previously
+  refresh tore down **every** server and reconnected only the eager set, which
+  dropped previously-running lazy/provisioned servers to offline (the reported
+  "105 seen, 0 online") and needlessly respawned unchanged processes (e.g. a
+  live browser) on every refresh.
 
 ### Added
 - `gateway.catalog_search` with `include_offline=true` now surfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Downstream tool calls are no longer killed by a fixed wall-clock deadline
+  (issue #79, symptom 1a). `timeout_ms` is now an **inactivity (idle) timeout**:
+  a call survives as long as the downstream MCP server keeps producing output
+  (including JSON progress notifications, which now count toward per-request
+  liveness in both the stdio and SSE readers). An absolute backstop caps total
+  wall-clock time so a chatty-but-never-completing call cannot hang forever —
+  configurable via `PMCP_REQUEST_CEILING_MS` (default 600000ms / 10 min). This
+  unblocks legitimately long browser/automation operations driven through the
+  gateway.
+
+### Added
+- `gateway.catalog_search` with `include_offline=true` now surfaces
+  manifest-only provisionable servers in a dedicated `manifest_candidates` field
+  when the query matches a manifest server by name or keyword but no cached
+  tools exist yet (issue #78). Candidates carry machine-readable next-action
+  metadata (`provisionable`, `provision_tool`, `request_capability_tool`,
+  `auth_tool`, `requires_api_key`, `api_key_available`, `env_var`) so an agent
+  can provision the exact server instead of falling back to a plain web search.
+- Manifest: `brightdata` keywords extended with `web research`, `current web`,
+  `page fetch`, and `external research` so research-oriented prompts match
+  without the exact brand name.
+
+### Changed
+- `gateway.request_capability` tool description now states it **recommends** a
+  server to provision (and that `gateway.provision` does the actual install/
+  start), matching the implementation — it previously claimed to auto-provision
+  (issue #78).
+
 ## [1.16.0] - 2026-06-25
 
 ### Added

--- a/plans/detailed-idle-timeout-downstream-calls-20260628-0646.md
+++ b/plans/detailed-idle-timeout-downstream-calls-20260628-0646.md
@@ -1,0 +1,88 @@
+# Detailed plan: convert downstream-call timeout to an inactivity (idle) timeout (#79 symptom 1a)
+
+> **Plan Mode was NOT active when this was produced.** This is a planning artifact only — no implementation has begun.
+
+## Task
+
+Fix PMCP issue #79 symptom 1a: long downstream MCP tool calls (e.g. a multi-step `browser_run_code_unsafe` loop) are killed by a hard wall-clock timeout. In `src/pmcp/client/manager.py`, `_send_request` (line 1527) waits on `asyncio.wait_for(future, timeout=timeout_ms/1000.0)` — a fixed *total* deadline. `PendingRequest.last_heartbeat` is updated on downstream output and a health monitor observes it, but nothing uses it to extend the deadline.
+
+Convert `timeout_ms` semantics into an **inactivity (idle) timeout**: the call survives as long as the downstream keeps producing output, and only fails after `idle` seconds of silence — with a generous, env-configurable **absolute ceiling** as a backstop so a chatty-but-never-completing call cannot hang forever. Bounded to `manager.py` timeout logic + tests. Refresh (#79/2) and process-group reaping (#79/1c) are separate plans.
+
+## Research summary
+
+All findings are from direct reads of `src/pmcp/client/manager.py`, `src/pmcp/tools/handlers.py`, and `tests/test_client_manager.py` this session.
+
+- **The hard wait** is `manager.py:1527`: `result = await asyncio.wait_for(future, timeout=timeout_ms/1000.0)`; on `asyncio.TimeoutError` it pops the pending request (1530) and raises `TimeoutError` (1532). `handlers.py:1656` catches that and returns `E303_TOOL_TIMEOUT` — that mapping must be preserved.
+- **`PendingRequest`** (`manager.py:294-306`) already carries `started_at`, `last_heartbeat`, `timeout_ms`, and `future` — no schema change needed.
+- **Heartbeat gap (must fix too):** in the stdio reader `_read_stdout` (`manager.py:1280-1323`), a matched JSON **response** pops+resolves its request (1294-1318); **non-JSON** output bumps *all* pending heartbeats (1321-1322); but a JSON **notification** (`msg_id is None`, e.g. `notifications/progress`) updates only server-level `status.last_activity_at` (1289), **not** per-request `last_heartbeat`. The remote reader `_read_sse` (`manager.py:1420-1448`) has the identical structure and the identical gap. **MCP progress notifications are the natural keepalive during a long browser op, so the idle timeout is only effective if per-request `last_heartbeat` is bumped on *all* downstream output.** This is the second half of the fix.
+- **Health monitor** (`_health_monitor_loop`, `manager.py:2111-2167`) only **logs** stalled/slow requests (thresholds `HEARTBEAT_WARN_THRESHOLD=60.0`, `HEARTBEAT_STALL_THRESHOLD=120.0`, `HEALTH_CHECK_INTERVAL=30.0` at lines 75-77). It never cancels futures — so the wait loop in `_send_request` is the **sole** timeout-enforcement point. No change needed here.
+- **Callers of `_send_request`** all share the same wait and inherit the new semantics uniformly (desirable): `initialize` (1542/1548), `tools/list`/`resources/list`/`prompts/list` (1026/1029/1030), `call_tool` (1831), `tasks/*` (1883/1905/1930/1974), `read_resource` (2005/2042). Most use the `timeout_ms=30000` default (`_send_request` signature, `manager.py:1483`).
+- **Env-var pattern to mirror:** `_stdio_read_limit()` + `DEFAULT_STDIO_READ_LIMIT` (`manager.py:96-118`) reads `PMCP_STDIO_READ_LIMIT`, int-parses with a logged fallback on bad/non-positive values. The new ceiling helper should copy this exactly.
+- **Test harness:** `tests/test_client_manager.py` (uses `pytest.mark.asyncio`, `AsyncMock`/`MagicMock`). The fixture around line 532 builds a `ManagedClient` with a mock process; `test_disconnect_all_cancels_pending_requests` (579-602) constructs a real `PendingRequest`, injects it into `managed.pending_requests`, and drives the future — directly reusable for idle-timeout tests.
+
+## Changes
+
+### `src/pmcp/client/manager.py` (modify)
+
+- **Module constants (near lines 74-77)** — add `DEFAULT_REQUEST_CEILING_MS = 600000` (10 min absolute backstop) — add — gives the idle wait a hard upper bound independent of the idle threshold. Keep next to the heartbeat thresholds for discoverability.
+- **`_request_ceiling_ms()` helper (new, mirror `_stdio_read_limit` at 96-118)** — add — reads `PMCP_REQUEST_CEILING_MS`, int-parses with logged fallback to `DEFAULT_REQUEST_CEILING_MS` on missing/invalid/non-positive, identical structure to the stdio-limit helper. Reason: env-configurable backstop per the task; reuse the established config idiom.
+- **`_read_stdout` heartbeat bump (`manager.py:1287-1289`)** — modify — immediately after computing `now` and setting `managed.status.last_activity_at`, also bump every in-flight request: `for req in managed.pending_requests.values(): req.last_heartbeat = now`. Reason: makes JSON progress notifications (and any output) count as per-request liveness; remove the now-redundant per-branch bumps at 1296 (the popped response) and 1321-1322 (non-JSON) since the single top-of-loop bump covers all cases.
+- **`_read_sse` heartbeat bump (`manager.py:1426-1431`)** — modify — same change: after `now`/`last_activity_at`, bump all pending `last_heartbeat`; drop the redundant Exception-branch (1430-1431) and matched-response (1442) bumps. Reason: parity with stdio so remote/HTTP downstreams also benefit from the idle timeout.
+- **`_send_request` wait logic (`manager.py:1525-1532`)** — modify — replace the single `asyncio.wait_for(future, timeout=timeout_ms/1000.0)` with a call to a new `_await_with_idle_timeout(...)` (below). Preserve the existing cleanup (`managed.pending_requests.pop(request_id, None)` + recount) and `raise TimeoutError(f"Request {method} timed out")` on timeout, so `handlers.py:1656` still maps to E303. Reason: core behavior change, kept minimal at the call site.
+- **`_await_with_idle_timeout(self, managed, request_id, pending, future, idle_timeout_s, ceiling_s)` (new private method)** — add — loop: `await asyncio.wait_for(asyncio.shield(future), timeout=slice_s)` in slices (`slice_s = min(idle_timeout_s, ~1.0s)`); on each `TimeoutError`, if `future.done()` return its result, elif `time.time() - pending.started_at >= ceiling_s` raise `TimeoutError` (ceiling hit), elif `time.time() - pending.last_heartbeat >= idle_timeout_s` raise `TimeoutError` (idle hit), else continue. `idle_timeout_s = timeout_ms/1000.0`; `ceiling_s = _request_ceiling_ms()/1000.0`. Use `asyncio.shield` so a slice timeout never cancels the real future. Reason: isolating the loop makes it unit-testable without a live process and keeps `_send_request` readable.
+
+### `tests/test_client_manager.py` (modify)
+
+- **`test_idle_timeout_survives_periodic_output`** — add — drive `_send_request` (or `_await_with_idle_timeout` directly) with a small idle threshold (e.g. 0.3s); a background task bumps `pending.last_heartbeat` every ~0.1s for longer than the old hard window, then sets the future result → assert it returns the result, no timeout.
+- **`test_idle_timeout_fires_when_silent`** — add — no heartbeat bumps; assert `TimeoutError` raised after ~idle threshold and the request is removed from `managed.pending_requests`.
+- **`test_absolute_ceiling_fires_for_chatty_call`** — add — bump `last_heartbeat` continuously (never idle) but never resolve the future, with a small ceiling (e.g. `PMCP_REQUEST_CEILING_MS` via `monkeypatch.setenv` → ~0.5s) → assert `TimeoutError` raised at the ceiling despite ongoing heartbeats.
+- **`test_progress_notification_bumps_pending_heartbeat`** — add — feed the stdio reader (or call the extracted bump path) a JSON notification with `id: null` and assert in-flight `pending.last_heartbeat` advanced — guards the heartbeat-gap regression.
+- **`test_request_ceiling_ms_env_parsing`** — add — mirror existing `_stdio_read_limit` tests: valid value, non-int, non-positive → assert fallback to `DEFAULT_REQUEST_CEILING_MS` (parametrized).
+
+## Documentation impact
+
+- `CHANGELOG.md` — modify — add an entry under the next unreleased version: idle/inactivity-based downstream timeout + `PMCP_REQUEST_CEILING_MS`; note that `timeout_ms` is now an inactivity timeout, not a total deadline (behavior change worth flagging).
+- `README.md` — modify **only if** it documents `PMCP_STDIO_READ_LIMIT` or a tunables/env-var list — add `PMCP_REQUEST_CEILING_MS` alongside it. (Verify during implementation; if no such section exists, skip — do not invent one.)
+
+## Dependencies & order
+
+1. Add module constant + `_request_ceiling_ms()` helper (no dependencies).
+2. Add `_await_with_idle_timeout` (uses the helper).
+3. Switch `_send_request` to call it (uses step 2).
+4. Close the heartbeat gap in `_read_stdout` and `_read_sse` (independent of 1-3, but **required** for the idle timeout to actually help notification-driven ops — land in the same change).
+5. Tests last.
+
+No blocking external dependencies. No migrations.
+
+## Verification
+
+```bash
+# Targeted unit tests
+pytest tests/test_client_manager.py -k "idle_timeout or ceiling or progress_notification or request_ceiling" -v
+
+# Full client-manager suite — guard against regressing initialize/call_tool/read_resource,
+# all of which route through _send_request
+pytest tests/test_client_manager.py -v
+
+# Type/lint per repo tooling (confirm exact commands from pyproject/CI)
+ruff check src/pmcp/client/manager.py
+mypy src/pmcp/client/manager.py   # if mypy is configured
+
+# Full suite sanity
+pytest -q
+```
+
+Edge cases to confirm by test or inspection:
+- A truly idle downstream still times out at the idle threshold (no infinite hang).
+- A continuously-chatty-but-never-completing call is killed by the ceiling.
+- `initialize` handshake (no/late response) still times out within the idle window — no regression to startup behavior.
+- The slice loop never cancels the real future (use `asyncio.shield`); a response arriving mid-slice is returned, not dropped.
+- Pending request is removed from `managed.pending_requests` on timeout (no leak), matching today's line 1530 cleanup.
+
+## Acceptance criteria
+
+- [ ] `pytest tests/test_client_manager.py -v` passes, including the 5 new tests.
+- [ ] A downstream that emits output every ~0.1s past the old fixed window completes successfully (idle timeout does not fire while output flows).
+- [ ] A silent downstream raises `TimeoutError` at ~`idle_timeout_s` and is removed from `pending_requests`; `handlers.py` still returns `E303_TOOL_TIMEOUT` for it (unchanged mapping).
+- [ ] A continuously-heartbeating call that never resolves raises `TimeoutError` at `_request_ceiling_ms()` (default 600000ms, overridable via `PMCP_REQUEST_CEILING_MS`).
+- [ ] A JSON notification with `id: null` advances in-flight `pending.last_heartbeat` in both `_read_stdout` and `_read_sse`.

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -711,6 +711,28 @@
       "task_summary": null,
       "type": "phase",
       "updated_at": "2026-06-25T02:26:25Z"
+    },
+    {
+      "acceptance_criteria_count": 5,
+      "created_at": "2026-06-28T06:46:00Z",
+      "file": "plans/detailed-idle-timeout-downstream-calls-20260628-0646.md",
+      "handoff_ref": ".dev-skills/handoffs/claude-plan-detailed/20260628T0646Z-idle-timeout.md",
+      "lifecycle": [
+        {
+          "at": "2026-06-28T06:46:00Z",
+          "by": "claude-plan-detailed",
+          "metadata": {
+            "artifact_state": "staged"
+          },
+          "transition": "planned"
+        }
+      ],
+      "owner_skill": "claude-plan-detailed",
+      "slug": "detailed-idle-timeout-downstream-calls",
+      "status": "staged",
+      "task_summary": "Convert downstream-call timeout to inactivity (idle) timeout with absolute ceiling (#79 symptom 1a)",
+      "type": "detailed",
+      "updated_at": "2026-06-28T06:46:00Z"
     }
   ],
   "schema_version": 1

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -123,6 +123,36 @@ def _stdio_read_limit() -> int:
     return value
 
 
+# Absolute backstop for a single downstream request. ``timeout_ms`` is now an
+# inactivity (idle) timeout: a call survives as long as the downstream keeps
+# producing output. This ceiling caps the total wall-clock time so a chatty but
+# never-completing call cannot hang forever. Override via PMCP_REQUEST_CEILING_MS.
+DEFAULT_REQUEST_CEILING_MS = 600000  # 10 minutes
+
+
+def _request_ceiling_ms() -> int:
+    raw = os.environ.get("PMCP_REQUEST_CEILING_MS")
+    if not raw:
+        return DEFAULT_REQUEST_CEILING_MS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "PMCP_REQUEST_CEILING_MS=%r is not an integer; using default %d",
+            raw,
+            DEFAULT_REQUEST_CEILING_MS,
+        )
+        return DEFAULT_REQUEST_CEILING_MS
+    if value <= 0:
+        logger.warning(
+            "PMCP_REQUEST_CEILING_MS=%d must be positive; using default %d",
+            value,
+            DEFAULT_REQUEST_CEILING_MS,
+        )
+        return DEFAULT_REQUEST_CEILING_MS
+    return value
+
+
 def _get_memory_usage_mb() -> float:
     """Get current process memory usage in MB."""
     try:
@@ -1284,16 +1314,19 @@ class ClientManager:
                     # EOF - server process has exited
                     break
 
-                # UPDATE heartbeat on ANY output from server
+                # UPDATE heartbeat on ANY output from server. This includes JSON
+                # progress notifications (id: null) that don't resolve a request,
+                # so per-request liveness drives the idle timeout in _send_request.
                 now = time.time()
                 managed.status.last_activity_at = now
+                for req in managed.pending_requests.values():
+                    req.last_heartbeat = now
 
                 try:
                     message = json.loads(line.decode())
                     msg_id = message.get("id")
                     if msg_id is not None and msg_id in managed.pending_requests:
                         pending = managed.pending_requests.pop(msg_id)
-                        pending.last_heartbeat = now  # Update request heartbeat
 
                         # Track response time
                         elapsed_ms = (now - pending.started_at) * 1000
@@ -1317,9 +1350,7 @@ class ClientManager:
                         else:
                             pending.future.set_result(message.get("result", {}))
                 except json.JSONDecodeError:
-                    # Non-JSON output still counts as heartbeat for all pending
-                    for req in managed.pending_requests.values():
-                        req.last_heartbeat = now
+                    # Non-JSON output already counted as a heartbeat above.
                     logger.debug(f"[{name}] Non-JSON output: {line.decode().strip()}")
         except asyncio.LimitOverrunError as e:
             limit = _stdio_read_limit()
@@ -1423,12 +1454,14 @@ class ClientManager:
         """Read JSON-RPC messages from an SSE stream."""
         try:
             async for message in read_stream:
+                # Any output counts as per-request liveness, including progress
+                # notifications (id: null), so the idle timeout sees the keepalive.
                 now = time.time()
                 managed.status.last_activity_at = now
+                for req in managed.pending_requests.values():
+                    req.last_heartbeat = now
 
                 if isinstance(message, Exception):
-                    for req in managed.pending_requests.values():
-                        req.last_heartbeat = now
                     raise message
 
                 payload = message.message.model_dump(
@@ -1439,7 +1472,6 @@ class ClientManager:
                 msg_id = payload.get("id")
                 if msg_id is not None and msg_id in managed.pending_requests:
                     pending = managed.pending_requests.pop(msg_id)
-                    pending.last_heartbeat = now
 
                     elapsed_ms = (now - pending.started_at) * 1000
                     managed.response_times.append(elapsed_ms)
@@ -1522,14 +1554,64 @@ class ClientManager:
             managed.process.stdin.write(data.encode())
             await managed.process.stdin.drain()
 
-        # Wait for response with timeout
+        # Wait for response with an inactivity (idle) timeout: the call survives
+        # as long as the downstream keeps producing output (per-request
+        # last_heartbeat), bounded by an absolute ceiling backstop.
         try:
-            result = await asyncio.wait_for(future, timeout=timeout_ms / 1000.0)
+            result = await self._await_with_idle_timeout(
+                managed,
+                request_id,
+                pending,
+                future,
+                idle_timeout_s=timeout_ms / 1000.0,
+                ceiling_s=_request_ceiling_ms() / 1000.0,
+            )
             return result
         except asyncio.TimeoutError:
             managed.pending_requests.pop(request_id, None)
             managed.status.pending_request_count = len(managed.pending_requests)
             raise TimeoutError(f"Request {method} timed out")
+
+    async def _await_with_idle_timeout(
+        self,
+        managed: ManagedClient,
+        request_id: int,
+        pending: PendingRequest,
+        future: asyncio.Future[Any],
+        idle_timeout_s: float,
+        ceiling_s: float,
+    ) -> Any:
+        """Await ``future`` until it resolves, the downstream goes idle, or the
+        absolute ceiling is hit.
+
+        Waits in short slices so per-request liveness (``pending.last_heartbeat``,
+        bumped by the stdout/SSE readers on any downstream output) can extend the
+        deadline. ``asyncio.shield`` ensures a slice timeout never cancels the real
+        future, so a response arriving mid-slice is returned rather than dropped.
+        Raises ``asyncio.TimeoutError`` on idle/ceiling so the caller maps it to the
+        usual ``TimeoutError``.
+        """
+        slice_s = min(idle_timeout_s, 1.0)
+        while True:
+            try:
+                return await asyncio.wait_for(
+                    asyncio.shield(future), timeout=slice_s
+                )
+            except asyncio.TimeoutError:
+                if future.done():
+                    return future.result()
+                now = time.time()
+                if now - pending.started_at >= ceiling_s:
+                    logger.warning(
+                        "[%s] request %d hit absolute ceiling (%.1fs)",
+                        managed.config.name,
+                        request_id,
+                        ceiling_s,
+                    )
+                    raise
+                if now - pending.last_heartbeat >= idle_timeout_s:
+                    raise
+                # Downstream is still active; keep waiting.
 
     async def _send_initialize(self, managed: ManagedClient) -> None:
         """Send initialize handshake."""

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -9,6 +9,7 @@ import logging
 import os
 from pathlib import Path
 import random
+import signal
 import string
 import time
 from collections import deque
@@ -69,6 +70,65 @@ def _is_cancel_scope_task_mismatch_error(exc: BaseException) -> bool:
         and "entered" in msg
         and "exit" in msg
     )
+
+
+async def _terminate_process_tree(
+    process: asyncio.subprocess.Process | None, name: str
+) -> None:
+    """Terminate a downstream process and its whole process group.
+
+    stdio servers are spawned with ``start_new_session=True``, so the child is a
+    process-group leader; signalling the group also reaps grandchildren (e.g. the
+    Chrome that ``@playwright/mcp`` launches) that would otherwise orphan to init
+    and keep the browser profile's SingletonLock, breaking the next launch.
+
+    Falls back to single-process signals when the process is not a group leader
+    (e.g. an adopted install-time process) or the group is already gone, so this
+    never accidentally signals an unrelated group such as the gateway's own.
+    """
+    if process is None or process.returncode is not None:
+        return
+
+    def _signal(sig: int) -> None:
+        pid = process.pid
+        pgid: int | None = None
+        if isinstance(pid, int):
+            try:
+                pgid = os.getpgid(pid)
+            except (ProcessLookupError, PermissionError, OSError):
+                pgid = None
+        # Only signal the group if this process leads it; otherwise signalling
+        # its group could hit unrelated processes (including the gateway, for an
+        # adopted process that was not given its own session).
+        if pgid is not None and pgid == pid:
+            try:
+                os.killpg(pgid, sig)
+                return
+            except (ProcessLookupError, PermissionError):
+                pass
+        try:
+            if sig == signal.SIGKILL:
+                process.kill()
+            else:
+                process.terminate()
+        except ProcessLookupError:
+            pass
+
+    _signal(signal.SIGTERM)
+    try:
+        await asyncio.wait_for(process.wait(), timeout=5.0)
+        return
+    except asyncio.TimeoutError:
+        pass
+
+    _signal(signal.SIGKILL)
+    try:
+        await asyncio.wait_for(process.wait(), timeout=3.0)
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"[{name}] Process PID={process.pid} did not exit after SIGKILL "
+            "(possible D-state / uninterruptible I/O wait)"
+        )
 
 
 # Heartbeat thresholds for health monitoring
@@ -688,19 +748,8 @@ class ClientManager:
                                 )
                             else:
                                 raise
-                elif managed.process and managed.process.returncode is None:
-                    managed.process.terminate()
-                    try:
-                        await asyncio.wait_for(managed.process.wait(), timeout=5.0)
-                    except asyncio.TimeoutError:
-                        managed.process.kill()
-                        try:
-                            await asyncio.wait_for(managed.process.wait(), timeout=3.0)
-                        except asyncio.TimeoutError:
-                            logger.warning(
-                                f"[{name}] Process PID={managed.process.pid} did not exit "
-                                "after SIGKILL (possible D-state / uninterruptible I/O wait)"
-                            )
+                else:
+                    await _terminate_process_tree(managed.process, name)
             except Exception as e:
                 logger.warning(f"Error disconnecting from {name}: {e}")
                 return (False, cancelled, str(e))
@@ -1130,6 +1179,9 @@ class ClientManager:
                 cwd=local_config.cwd,
                 env=env,
                 limit=_stdio_read_limit(),
+                # New session/process group so we can reap the whole tree
+                # (e.g. browsers launched by the server) on disconnect.
+                start_new_session=True,
             )
 
         managed = ManagedClient(
@@ -1181,8 +1233,7 @@ class ClientManager:
                     await asyncio.shield(managed.read_task)
                 except (asyncio.CancelledError, Exception):
                     pass
-            if process.returncode is None:
-                process.kill()
+            await _terminate_process_tree(process, name)
             raise
 
     async def _connect_sse(self, config: ResolvedServerConfig) -> None:
@@ -1709,19 +1760,8 @@ class ClientManager:
                                 )
                             else:
                                 raise
-                elif managed.process and managed.process.returncode is None:
-                    managed.process.terminate()
-                    try:
-                        await asyncio.wait_for(managed.process.wait(), timeout=5.0)
-                    except asyncio.TimeoutError:
-                        managed.process.kill()
-                        try:
-                            await asyncio.wait_for(managed.process.wait(), timeout=3.0)
-                        except asyncio.TimeoutError:
-                            logger.warning(
-                                f"[{name}] Process PID={managed.process.pid} did not exit "
-                                f"after SIGKILL (possible D-state / uninterruptible I/O wait)"
-                            )
+                else:
+                    await _terminate_process_tree(managed.process, name)
             except Exception as e:
                 logger.warning(f"Error disconnecting from {name}: {e}")
 
@@ -1751,14 +1791,7 @@ class ClientManager:
             except (asyncio.CancelledError, Exception):
                 pass
         await self._cancel_background_tasks(server_name=name)
-        if managed.process and managed.process.returncode is None:
-            managed.process.kill()
-            try:
-                await asyncio.wait_for(managed.process.wait(), timeout=3.0)
-            except asyncio.TimeoutError:
-                logger.warning(
-                    f"[{name}] Process did not exit after SIGKILL in _cleanup_client"
-                )
+        await _terminate_process_tree(managed.process, name)
         self._clients.pop(name, None)
         self._servers.pop(name, None)
         self._remove_server_indexes(name)
@@ -2163,6 +2196,14 @@ class ClientManager:
     def get_all_server_statuses(self) -> list[ServerStatus]:
         """Get all server statuses."""
         return sorted(self._servers.values(), key=lambda status: status.name)
+
+    def get_connected_configs(self) -> dict[str, ResolvedServerConfig]:
+        """Return resolved configs for currently-connected servers, keyed by name.
+
+        Used by gateway.refresh to diff the running set against a freshly
+        resolved config set so unchanged servers are left running.
+        """
+        return {name: managed.config for name, managed in self._clients.items()}
 
     def get_registry_meta(self) -> tuple[str, float]:
         """Get registry metadata (revision_id, last_refresh_ts)."""

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -89,10 +89,13 @@ async def _terminate_process_tree(
     if process is None or process.returncode is not None:
         return
 
-    def _signal(sig: int) -> None:
+    def _signal(kill: bool) -> None:
+        # Process-group signalling is POSIX-only. On Windows os.getpgid/os.killpg
+        # (and signal.SIGKILL) don't exist, so fall back to the cross-platform
+        # process.terminate()/kill() — preserving the pre-process-group behavior.
         pid = process.pid
         pgid: int | None = None
-        if isinstance(pid, int):
+        if isinstance(pid, int) and hasattr(os, "getpgid"):
             try:
                 pgid = os.getpgid(pid)
             except (ProcessLookupError, PermissionError, OSError):
@@ -100,28 +103,28 @@ async def _terminate_process_tree(
         # Only signal the group if this process leads it; otherwise signalling
         # its group could hit unrelated processes (including the gateway, for an
         # adopted process that was not given its own session).
-        if pgid is not None and pgid == pid:
+        if pgid is not None and pgid == pid and hasattr(os, "killpg"):
             try:
-                os.killpg(pgid, sig)
+                os.killpg(pgid, signal.SIGKILL if kill else signal.SIGTERM)
                 return
             except (ProcessLookupError, PermissionError):
                 pass
         try:
-            if sig == signal.SIGKILL:
+            if kill:
                 process.kill()
             else:
                 process.terminate()
         except ProcessLookupError:
             pass
 
-    _signal(signal.SIGTERM)
+    _signal(kill=False)
     try:
         await asyncio.wait_for(process.wait(), timeout=5.0)
         return
     except asyncio.TimeoutError:
         pass
 
-    _signal(signal.SIGKILL)
+    _signal(kill=True)
     try:
         await asyncio.wait_for(process.wait(), timeout=3.0)
     except asyncio.TimeoutError:
@@ -1608,14 +1611,26 @@ class ClientManager:
         # Wait for response with an inactivity (idle) timeout: the call survives
         # as long as the downstream keeps producing output (per-request
         # last_heartbeat), bounded by an absolute ceiling backstop.
+        #
+        # The generous absolute ceiling applies only to tool invocations, which
+        # can legitimately run long (e.g. browser automation). Control-plane
+        # requests (initialize, tools/list, resources/list, tasks/*) keep the
+        # tighter idle deadline as their ceiling, so one chatty-but-stuck server
+        # can't stall startup/refresh/connect_all for the full ceiling.
+        idle_timeout_s = timeout_ms / 1000.0
+        ceiling_s = (
+            _request_ceiling_ms() / 1000.0
+            if method == "tools/call"
+            else idle_timeout_s
+        )
         try:
             result = await self._await_with_idle_timeout(
                 managed,
                 request_id,
                 pending,
                 future,
-                idle_timeout_s=timeout_ms / 1000.0,
-                ceiling_s=_request_ceiling_ms() / 1000.0,
+                idle_timeout_s=idle_timeout_s,
+                ceiling_s=ceiling_s,
             )
             return result
         except asyncio.TimeoutError:

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -117,21 +117,62 @@ async def _terminate_process_tree(
         except ProcessLookupError:
             pass
 
+    # Cache the process group up front: once the leader exits, os.getpgid(pid)
+    # fails, so we could no longer find the group to escalate against. Only set
+    # when this process leads its own group (POSIX, start_new_session=True).
+    group_pgid: int | None = None
+    pid = process.pid
+    if isinstance(pid, int) and hasattr(os, "getpgid") and hasattr(os, "killpg"):
+        try:
+            if os.getpgid(pid) == pid:
+                group_pgid = pid
+        except (ProcessLookupError, PermissionError, OSError):
+            group_pgid = None
+
+    def _group_alive() -> bool:
+        if group_pgid is None:
+            return False
+        try:
+            os.killpg(group_pgid, 0)  # signal 0 == liveness probe
+            return True
+        except (ProcessLookupError, PermissionError, OSError):
+            return False
+
     _signal(kill=False)
     try:
         await asyncio.wait_for(process.wait(), timeout=5.0)
-        return
+        leader_exited = True
     except asyncio.TimeoutError:
-        pass
+        leader_exited = False
 
-    _signal(kill=True)
-    try:
-        await asyncio.wait_for(process.wait(), timeout=3.0)
-    except asyncio.TimeoutError:
-        logger.warning(
-            f"[{name}] Process PID={process.pid} did not exit after SIGKILL "
-            "(possible D-state / uninterruptible I/O wait)"
-        )
+    # If the leader is still alive, SIGKILL it (and, when it leads a group, the
+    # whole group). The leader exiting is NOT sufficient: a grandchild (e.g. a
+    # SIGTERM-ignoring browser) can outlive the leader inside the group and keep
+    # the profile SingletonLock — so we still escalate to a group SIGKILL below.
+    if not leader_exited:
+        _signal(kill=True)
+        try:
+            await asyncio.wait_for(process.wait(), timeout=3.0)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"[{name}] Process PID={process.pid} did not exit after SIGKILL "
+                "(possible D-state / uninterruptible I/O wait)"
+            )
+
+    if _group_alive():
+        try:
+            os.killpg(group_pgid, signal.SIGKILL)  # type: ignore[arg-type]
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        for _ in range(30):  # up to ~3s for the OS to reap the group
+            if not _group_alive():
+                break
+            await asyncio.sleep(0.1)
+        else:
+            logger.warning(
+                f"[{name}] process group {group_pgid} survived SIGKILL "
+                "(possible orphaned grandchild / D-state)"
+            )
 
 
 # Heartbeat thresholds for health monitoring
@@ -418,6 +459,10 @@ class ManagedClient:
     request_id: int = 0
     pending_requests: dict[int, PendingRequest] = field(default_factory=dict)
     read_task: asyncio.Task[None] | None = None
+    # Remote auth headers as RESOLVED at connect time (placeholders expanded).
+    # gateway.refresh compares these against freshly-resolved headers to detect
+    # token rotation in the env store, which leaves the raw config unchanged.
+    resolved_remote_headers: dict[str, str] | None = None
     # Health monitoring: rolling window of response times for avg calculation
     response_times: deque[float] = field(default_factory=lambda: deque(maxlen=100))
     # Reconnect storm guard: True while a _reconnect_loop task is in flight
@@ -595,6 +640,23 @@ class ClientManager:
                 tool_count=0,
             )
             logger.info(f"Registered lazy server: {name}")
+
+    def prune_lazy_configs(self, keep_names: set[str]) -> None:
+        """Drop on-demand (lazy) configs whose name is not in ``keep_names``.
+
+        Used by ``gateway.refresh`` to reconcile the lazy set to the freshly
+        resolved keep-set so a server that is now removed / policy-denied /
+        missing-auth can no longer be lazily started via ``ensure_connected()``.
+        Also clears its lingering ``LAZY`` status entry. Connected servers are
+        untouched (they are reconciled by the refresh diff, not here).
+        """
+        for name in list(self._lazy_configs):
+            if name in keep_names:
+                continue
+            self._lazy_configs.pop(name, None)
+            status = self._servers.get(name)
+            if status is not None and status.status == ServerStatusEnum.LAZY:
+                self._servers.pop(name, None)
 
     async def ensure_connected(self, server_name: str) -> bool:
         """Ensure a server is connected, triggering lazy-start if needed.
@@ -1252,6 +1314,7 @@ class ClientManager:
             config,
             sse_client(remote_config.url, headers=headers),
             transport_name="SSE",
+            resolved_headers=headers,
         )
 
     async def _connect_streamable_http(self, config: ResolvedServerConfig) -> None:
@@ -1267,6 +1330,7 @@ class ClientManager:
             config,
             streamablehttp_client(remote_config.url, headers=headers),
             transport_name="streamable HTTP",
+            resolved_headers=headers,
         )
 
     async def _connect_remote_stream(
@@ -1275,6 +1339,7 @@ class ClientManager:
         transport_context: Any,
         *,
         transport_name: str,
+        resolved_headers: dict[str, str] | None = None,
     ) -> None:
         """Connect to a remote MCP server using a read/write stream transport."""
         name = config.name
@@ -1308,6 +1373,7 @@ class ClientManager:
             sse_exit_stack=remote_stack,
             write_stream=write_stream,
             status=status,
+            resolved_remote_headers=resolved_headers,
         )
         self._clients[name] = managed
 
@@ -1737,8 +1803,7 @@ class ClientManager:
         # Stop health monitor if running
         self.stop_health_monitor()
 
-        clients = list(self._clients.items())
-        for name, managed in clients:
+        async def _shutdown_one(name: str, managed: ManagedClient) -> None:
             try:
                 logger.info(f"Disconnecting from {name}")
 
@@ -1779,6 +1844,19 @@ class ClientManager:
                     await _terminate_process_tree(managed.process, name)
             except Exception as e:
                 logger.warning(f"Error disconnecting from {name}: {e}")
+
+        # Reap servers concurrently: each _terminate_process_tree can cost up to
+        # ~8s for a hung stdio server, and disconnect_all() runs under a bounded
+        # shutdown budget (server.py wraps it in wait_for). A sequential loop
+        # would let two+ hung servers blow that budget and leave later groups
+        # unsignalled — orphaning browsers (issue #79/1c) at shutdown. Concurrent
+        # reaping makes total time ≈ the slowest single server.
+        clients = list(self._clients.items())
+        if clients:
+            await asyncio.gather(
+                *(_shutdown_one(name, managed) for name, managed in clients),
+                return_exceptions=True,
+            )
 
         current = asyncio.current_task()
         exclude = {current} if current is not None else set()
@@ -2219,6 +2297,18 @@ class ClientManager:
         resolved config set so unchanged servers are left running.
         """
         return {name: managed.config for name, managed in self._clients.items()}
+
+    def get_connected_resolved_headers(self, name: str) -> dict[str, str] | None:
+        """Return the remote auth headers a connected server was actually
+        connected with (placeholders resolved at connect time), or None.
+
+        Used by gateway.refresh to detect token rotation in the env store: the
+        raw config keeps the same ``${VAR}`` placeholder, so only comparing the
+        connect-time resolved value against a freshly-resolved value reveals the
+        change.
+        """
+        managed = self._clients.get(name)
+        return managed.resolved_remote_headers if managed is not None else None
 
     def get_registry_meta(self) -> tuple[str, float]:
         """Get registry metadata (revision_id, last_refresh_ts)."""

--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -600,7 +600,7 @@ servers:
 
   brightdata:
     description: "Bright Data MCP - search, scraping, and browser automation"
-    keywords: [bright data, brightdata, proxy, scraping, web data, web search, search, unlocker, browser automation]
+    keywords: [bright data, brightdata, proxy, scraping, web data, web search, search, unlocker, browser automation, web research, current web, page fetch, external research]
     install:
       mac: ["npx", "-y", "@brightdata/mcp"]
       linux: ["npx", "-y", "@brightdata/mcp"]

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -12,6 +12,7 @@ import platform
 import shutil
 from collections import deque
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any, Literal, cast
 from urllib.request import urlopen
 from urllib.parse import urlencode
@@ -159,7 +160,11 @@ FEEDBACK_TOKEN_LIMIT = 4000
 
 
 def _refresh_config_unchanged(
-    old: ResolvedServerConfig, new: ResolvedServerConfig
+    old: ResolvedServerConfig,
+    new: ResolvedServerConfig,
+    *,
+    header_env_lookup: Callable[[str], str | None] | None = None,
+    old_resolved_headers: dict[str, str] | None = None,
 ) -> bool:
     """Return True if two resolved configs describe the same downstream process.
 
@@ -179,9 +184,19 @@ def _refresh_config_unchanged(
       first, so an override that merely mirrors ``os.environ`` is a no-op. Naively
       comparing ``env`` would spuriously tear down running provisioned servers on
       every refresh (issue #79); comparing only the genuine override still
-      detects a real env change.
+      detects a real env change. (Known limitation: rotation of an *ambient*
+      secret that is not an explicit override cannot be detected here without a
+      spawn-time env snapshot.)
     * ``source`` is excluded (e.g. ``manifest`` vs the configured source for the
       same effective server).
+
+    Remote ``headers`` are compared *after* resolving ``${VAR}`` placeholders.
+    The raw config keeps the same placeholder across a token rotation, so the
+    only way to detect rotation is to compare the value the server was actually
+    connected with — ``old_resolved_headers`` (captured at connect time) — against
+    the freshly-resolved ``new`` headers (via ``header_env_lookup``). Without that
+    the remote connection would silently keep stale/revoked auth across a refresh.
+    When neither is supplied (e.g. unit tests), the raw headers are compared.
     """
     if old.name != new.name:
         return False
@@ -209,9 +224,27 @@ def _refresh_config_unchanged(
     if isinstance(old_cfg, RemoteMcpServerConfig) and isinstance(
         new_cfg, RemoteMcpServerConfig
     ):
+        old_headers: dict[str, str] | None
+        new_headers: dict[str, str] | None
+        if header_env_lookup is not None:
+            new_headers = resolve_remote_headers(
+                new_cfg.headers, header_env_lookup
+            ).resolved_headers
+        else:
+            new_headers = new_cfg.headers
+        if old_resolved_headers is not None:
+            # The value the running server was actually connected with — this is
+            # what reveals an env-store token rotation.
+            old_headers = old_resolved_headers
+        elif header_env_lookup is not None:
+            old_headers = resolve_remote_headers(
+                old_cfg.headers, header_env_lookup
+            ).resolved_headers
+        else:
+            old_headers = old_cfg.headers
         return (
             old_cfg.url == new_cfg.url
-            and old_cfg.headers == new_cfg.headers
+            and old_headers == new_headers
             and old_cfg.type == new_cfg.type
         )
     return False
@@ -2172,6 +2205,7 @@ class GatewayTools:
             # put into _clients by ensure_connected) resolves as lazy here, and
             # must NOT be torn down.
             current_configs = self._client_manager.get_connected_configs()
+            header_env_lookup = build_remote_header_env_lookup(self._project_root)
             eager_by_name = {
                 config.name: config for config in resolution.eager_configs
             }
@@ -2179,17 +2213,45 @@ class GatewayTools:
                 config.name: config
                 for config in resolution.eager_configs + resolution.lazy_configs
             }
+
+            def _live_keep(name: str) -> bool:
+                # Keep a server connected only if it is actually ONLINE, still in
+                # the resolved keep-set, and its (resolved) config is unchanged.
+                # A present-but-not-ONLINE entry (e.g. a crashed eager server left
+                # in _clients with status ERROR after its reconnect attempts
+                # exhausted) is NOT a live keep — it is torn down here and, if
+                # eager, reconnected below, so `gateway.refresh` heals it again.
+                return (
+                    name in keep_by_name
+                    and self._client_manager.is_server_online(name)
+                    and _refresh_config_unchanged(
+                        current_configs[name],
+                        keep_by_name[name],
+                        header_env_lookup=header_env_lookup,
+                        old_resolved_headers=(
+                            self._client_manager.get_connected_resolved_headers(name)
+                        ),
+                    )
+                )
+
             to_disconnect = [
-                name
-                for name, current in current_configs.items()
-                if name not in keep_by_name
-                or not _refresh_config_unchanged(current, keep_by_name[name])
+                name for name in current_configs if not _live_keep(name)
             ]
             to_connect = [
                 config
                 for name, config in eager_by_name.items()
-                if name not in current_configs
-                or not _refresh_config_unchanged(current_configs[name], config)
+                if not (
+                    name in current_configs
+                    and self._client_manager.is_server_online(name)
+                    and _refresh_config_unchanged(
+                        current_configs[name],
+                        config,
+                        header_env_lookup=header_env_lookup,
+                        old_resolved_headers=(
+                            self._client_manager.get_connected_resolved_headers(name)
+                        ),
+                    )
+                )
             ]
 
             for name in to_disconnect:
@@ -2197,13 +2259,13 @@ class GatewayTools:
                 # above, so force the per-server disconnect here.
                 await self._client_manager.disconnect_server(name, force=True)
 
-            # Lazy configs are still (re)registered as today. We intentionally do
-            # not aggressively prune _lazy_configs for servers that vanished: a
-            # removed-but-connected server is disconnected above, and any stale
-            # on-demand entry is harmless (it only matters if later explicitly
-            # ensure_connected'd). This keeps the change minimal and avoids
-            # touching disconnect_server's existing lazy-retention semantics.
             self._client_manager.register_lazy_configs(resolution.lazy_configs)
+            # Reconcile the lazy set to the resolved keep-set: drop on-demand
+            # entries for servers that are now removed / policy-denied /
+            # missing-auth (and undo disconnect_server's re-registration of the
+            # ones we just tore down) so they can no longer be lazily started via
+            # ensure_connected().
+            self._client_manager.prune_lazy_configs(set(keep_by_name))
 
             errors: list[str] = []
             if to_connect:

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -56,7 +56,11 @@ from pmcp.manifest.installer import (
     InstallError,
 )
 from pmcp.manifest.loader import load_manifest
-from pmcp.manifest.matcher import rank_cli_hints
+from pmcp.manifest.matcher import (
+    _keyword_match_score,
+    _manifest_keyword_weights,
+    rank_cli_hints,
+)
 from pmcp.manifest.registry import (
     DEFAULT_REGISTRY_ENDPOINT,
     RegistryCache,
@@ -420,9 +424,10 @@ def get_gateway_tool_definitions() -> list[Tool]:
         Tool(
             name="gateway.request_capability",
             description=(
-                "Find and auto-provision the right tool for a task — describe what you need in natural language. "
+                "Recommend the right tool for a task — describe what you need in natural language. "
                 "Examples: 'scrape a website', 'search Slack messages', 'query Postgres', 'browse the web'. "
-                "Matches against installed CLIs and 90+ provisionable MCP servers; starts the server automatically if needed. "
+                "Matches against installed CLIs and 90+ provisionable MCP servers and returns ranked candidates; "
+                "it does NOT start anything — call gateway.provision to actually install/start the recommended server. "
                 "Prefer this over gateway.provision when you don't already know the exact server name."
             ),
             inputSchema={
@@ -1158,6 +1163,90 @@ class GatewayTools:
 
         return cached_tools
 
+    def _manifest_candidates_for_query(
+        self,
+        query: str,
+        *,
+        manifest: Manifest,
+        configured_servers: dict[str, ResolvedServerConfig],
+        exclude_servers: set[str],
+        limit: int = 5,
+    ) -> list[CapabilityCandidate]:
+        """Match a query against manifest servers and emit provision candidates.
+
+        Surfaces manifest-only servers (never started, so no cached tools are
+        represented in catalog_search) so an agent can provision the exact
+        server instead of falling back to a plain web search (issue #78).
+        Scoring reuses the manifest keyword matcher; a normalized name match is
+        also accepted so servers that don't list their own name still surface.
+        """
+        query = (query or "").strip()
+        if not query:
+            return []
+
+        query_words = query.lower().replace("-", " ").replace("_", " ").split()
+        keyword_weights = _manifest_keyword_weights(manifest)
+
+        scored: list[tuple[float, str, ServerConfig]] = []
+        for name, server in manifest.servers.items():
+            if name in exclude_servers:
+                continue
+            if not self._policy_manager.is_server_allowed(name):
+                continue
+
+            score = _keyword_match_score(query, server.keywords, keyword_weights)
+
+            # Normalized name match (e.g. "bright data" -> "brightdata").
+            norm_name = name.lower().replace("-", "").replace("_", "")
+            for window_size in (3, 2, 1):
+                for i in range(len(query_words) - window_size + 1):
+                    window = "".join(query_words[i : i + window_size])
+                    if window == norm_name:
+                        score = max(score, 1.0)
+                        break
+
+            if score >= 0.2:  # Same minimum threshold as the matcher
+                scored.append((score, name, server))
+
+        scored.sort(key=lambda item: (-item[0], item[1]))
+
+        running_servers = {
+            s.name
+            for s in self._client_manager.get_all_server_statuses()
+            if s.status.value == "online"
+        }
+
+        candidates: list[CapabilityCandidate] = []
+        for score, name, server in scored[:limit]:
+            requires_api_key, env_var, env_instructions = self._get_server_env_metadata(
+                name, manifest, configured_servers
+            )
+            candidates.append(
+                CapabilityCandidate(
+                    name=name,
+                    candidate_type="server",
+                    relevance_score=min(1.0, score),
+                    reasoning=server.description,
+                    requires_api_key=requires_api_key,
+                    api_key_available=self._check_api_key_available(env_var),
+                    env_var=env_var,
+                    env_instructions=env_instructions,
+                    is_running=name in running_servers,
+                    source="manifest",
+                    transport=server.transport,
+                    url=server.url,
+                    package=server.package,
+                    server_card_url=server.server_card_url,
+                    declared_scopes=server.declared_scopes,
+                    declared_capabilities=server.declared_capabilities,
+                    provisionable=True,
+                    provision_tool="gateway.provision",
+                    request_capability_tool="gateway.request_capability",
+                    auth_tool="gateway.auth_connect",
+                )
+            )
+        return candidates
+
     async def catalog_search(self, input_data: dict[str, Any]) -> CatalogSearchOutput:
         """gateway.catalog_search - Search for available tools."""
         parsed = CatalogSearchInput.model_validate(input_data)
@@ -1205,6 +1294,11 @@ class GatewayTools:
             ]
 
         total_available = len(tools)
+
+        # Capture servers already represented by online/cached tools BEFORE any
+        # narrowing filters, so manifest candidates only cover "never started"
+        # servers (no cached tools at all) rather than ones merely filtered out.
+        represented_servers = {t.server_name for t in tools}
 
         # Filter by server name
         if parsed.filters and parsed.filters.server:
@@ -1261,6 +1355,18 @@ class GatewayTools:
                 parsed.query, limit=min(5, parsed.limit)
             )
 
+        # Surface manifest-provisionable servers that have never been started
+        # (no cached tools) so agents can provision them directly (#78).
+        manifest_candidates: list[CapabilityCandidate] = []
+        if parsed.include_offline and parsed.query:
+            manifest_candidates = self._manifest_candidates_for_query(
+                parsed.query,
+                manifest=load_manifest(),
+                configured_servers=self._load_configured_servers(),
+                exclude_servers=represented_servers,
+                limit=min(5, parsed.limit),
+            )
+
         truncated = len(tools) > parsed.limit
         tools = tools[: parsed.limit]
 
@@ -1312,6 +1418,7 @@ class GatewayTools:
             truncated=truncated,
             cli_hints=cli_hints,
             registry_candidates=registry_candidates,
+            manifest_candidates=manifest_candidates,
             stale_updates=stale_updates,
         )
 

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -157,6 +157,66 @@ logger = logging.getLogger(__name__)
 
 FEEDBACK_TOKEN_LIMIT = 4000
 
+
+def _refresh_config_unchanged(
+    old: ResolvedServerConfig, new: ResolvedServerConfig
+) -> bool:
+    """Return True if two resolved configs describe the same downstream process.
+
+    Used by gateway.refresh's diff so unchanged servers are left running.
+
+    We compare only the fields that actually affect the spawned process
+    (command/args/cwd/env for local, url/headers/transport for remote) rather
+    than using full-model equality, for two reasons:
+
+    * ``env`` is compared by its *effective* override only — entries that
+      actually differ from ``os.environ``. The same logical server can be stored
+      with different env representations depending on how it entered the manager:
+      an adopted/provisioned server keeps env resolved from ``os.environ``
+      (``manifest_server_to_config``), while the loader resolves the identical
+      server with ``env=None`` (``_manifest_server_to_config(..., lambda: None)``).
+      Both spawn identically because ``_connect_stdio`` seeds ``os.environ.copy()``
+      first, so an override that merely mirrors ``os.environ`` is a no-op. Naively
+      comparing ``env`` would spuriously tear down running provisioned servers on
+      every refresh (issue #79); comparing only the genuine override still
+      detects a real env change.
+    * ``source`` is excluded (e.g. ``manifest`` vs the configured source for the
+      same effective server).
+    """
+    if old.name != new.name:
+        return False
+    old_cfg, new_cfg = old.config, new.config
+    if type(old_cfg) is not type(new_cfg):
+        return False
+    if isinstance(old_cfg, LocalMcpServerConfig) and isinstance(
+        new_cfg, LocalMcpServerConfig
+    ):
+
+        def _effective_env(env: dict[str, str] | None) -> dict[str, str]:
+            # Only overrides that actually change the spawned environment.
+            return {
+                key: value
+                for key, value in (env or {}).items()
+                if os.environ.get(key) != value
+            }
+
+        return (
+            old_cfg.command == new_cfg.command
+            and old_cfg.args == new_cfg.args
+            and old_cfg.cwd == new_cfg.cwd
+            and _effective_env(old_cfg.env) == _effective_env(new_cfg.env)
+        )
+    if isinstance(old_cfg, RemoteMcpServerConfig) and isinstance(
+        new_cfg, RemoteMcpServerConfig
+    ):
+        return (
+            old_cfg.url == new_cfg.url
+            and old_cfg.headers == new_cfg.headers
+            and old_cfg.type == new_cfg.type
+        )
+    return False
+
+
 # Risk level ordering for filtering
 RISK_ORDER = {"low": 1, "medium": 2, "high": 3, "unknown": 4}
 TRACE_CONTEXT_KEYS = ("traceparent", "tracestate", "baggage")
@@ -2095,9 +2155,59 @@ class GatewayTools:
             self.set_startup_observations(
                 build_startup_observation_snapshot(resolution)
             )
-            await self._client_manager.disconnect_all()
+
+            # Diff-based refresh: leave servers whose resolved config is
+            # unchanged connected and running. Only disconnect servers that were
+            # removed (or are no longer in the resolved set at all, e.g. now
+            # policy-denied/missing-auth) or whose config changed, and only
+            # eagerly connect newly-added/changed eager servers. This avoids
+            # dropping previously-running lazy/provisioned servers to offline
+            # and avoids needlessly respawning unchanged processes (e.g. a live
+            # browser) on every refresh.
+            #
+            # Equality uses _refresh_config_unchanged, which compares the fields
+            # that affect the spawned process (command/args/cwd for local,
+            # url/headers/transport for remote). The keep-set is the union of
+            # eager AND lazy: a lazily-started server (e.g. a provisioned browser
+            # put into _clients by ensure_connected) resolves as lazy here, and
+            # must NOT be torn down.
+            current_configs = self._client_manager.get_connected_configs()
+            eager_by_name = {
+                config.name: config for config in resolution.eager_configs
+            }
+            keep_by_name = {
+                config.name: config
+                for config in resolution.eager_configs + resolution.lazy_configs
+            }
+            to_disconnect = [
+                name
+                for name, current in current_configs.items()
+                if name not in keep_by_name
+                or not _refresh_config_unchanged(current, keep_by_name[name])
+            ]
+            to_connect = [
+                config
+                for name, config in eager_by_name.items()
+                if name not in current_configs
+                or not _refresh_config_unchanged(current_configs[name], config)
+            ]
+
+            for name in to_disconnect:
+                # Pending/active work was already gated (and force-cancelled)
+                # above, so force the per-server disconnect here.
+                await self._client_manager.disconnect_server(name, force=True)
+
+            # Lazy configs are still (re)registered as today. We intentionally do
+            # not aggressively prune _lazy_configs for servers that vanished: a
+            # removed-but-connected server is disconnected above, and any stale
+            # on-demand entry is harmless (it only matters if later explicitly
+            # ensure_connected'd). This keeps the change minimal and avoids
+            # touching disconnect_server's existing lazy-retention semantics.
             self._client_manager.register_lazy_configs(resolution.lazy_configs)
-            errors = await self._client_manager.connect_all(resolution.eager_configs)
+
+            errors: list[str] = []
+            if to_connect:
+                errors = await self._client_manager.connect_all(to_connect)
             pending_remaining = len(self._client_manager.get_pending_requests())
 
             revision_id, _ = self._client_manager.get_registry_meta()

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -627,6 +627,10 @@ class CatalogSearchOutput(BaseModel):
     truncated: bool
     cli_hints: list[CLIHint] = Field(default_factory=list)
     registry_candidates: list[CapabilityCandidate] = Field(default_factory=list)
+    # Manifest-provisionable servers that match the query but have never been
+    # started (no cached tools). Surfaced when include_offline=True so agents can
+    # provision the exact server instead of falling back to web search (#78).
+    manifest_candidates: list[CapabilityCandidate] = Field(default_factory=list)
     stale_updates: list[str] | None = None
 
 
@@ -977,6 +981,13 @@ class CapabilityCandidate(BaseModel):
     authorization_server_metadata_url: str | None = None
     declared_scopes: list[str] = Field(default_factory=list)
     declared_capabilities: list[str] = Field(default_factory=list)
+    # Machine-readable next-action metadata (issue #78). Lets an agent act on a
+    # candidate without knowing the gateway's magic tool names. Defaults keep
+    # existing consumers (e.g. registry/category candidates) unchanged.
+    provisionable: bool = False  # True if gateway.provision can install/start it
+    provision_tool: str | None = None  # e.g. "gateway.provision"
+    request_capability_tool: str | None = None  # e.g. "gateway.request_capability"
+    auth_tool: str | None = None  # e.g. "gateway.auth_connect"
 
 
 class CapabilityMatchResponse(BaseModel):

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -7,7 +7,10 @@ import contextlib
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 import json
+import os
 from pathlib import Path
+import signal
+import sys
 import time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -3161,8 +3164,6 @@ class TestTerminateProcessTree:
     @pytest.mark.asyncio
     async def test_terminates_whole_process_group(self) -> None:
         """When the process leads its group, SIGTERM goes to the group."""
-        import signal
-
         process = MagicMock()
         process.pid = 4321
         process.returncode = None
@@ -3208,6 +3209,74 @@ class TestTerminateProcessTree:
 
         mock_killpg.assert_not_called()
         process.terminate.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not hasattr(os, "killpg"), reason="process-group reaping is POSIX-only"
+    )
+    async def test_real_process_tree_is_reaped(self) -> None:
+        """End-to-end: a grandchild spawned by the downstream process is killed.
+
+        The mocked tests above only prove killpg is *called*; this proves the
+        whole tree actually dies — the regression guard for orphaned Chrome
+        holding the browser profile's SingletonLock (issue #79, symptom 1c).
+        """
+        # Parent (its own session, like _connect_stdio) spawns a child; the
+        # parent prints the child PID then both sleep.
+        script = (
+            "import subprocess, time;"
+            "c = subprocess.Popen(['sleep', '30']);"
+            "print(c.pid, flush=True);"
+            "time.sleep(30)"
+        )
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            script,
+            stdout=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        assert process.stdout is not None
+        child_pid = int((await asyncio.wait_for(process.stdout.readline(), 10.0)).strip())
+        parent_pid = process.pid
+
+        # Both are alive before reaping.
+        os.kill(parent_pid, 0)
+        os.kill(child_pid, 0)
+
+        await _terminate_process_tree(process, "real")
+
+        async def _gone(pid: int) -> bool:
+            for _ in range(30):
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    return True
+                await asyncio.sleep(0.1)
+            return False
+
+        assert await _gone(parent_pid), "parent process was not reaped"
+        assert await _gone(child_pid), "grandchild process was orphaned, not reaped"
+
+    @pytest.mark.asyncio
+    async def test_windows_falls_back_without_killpg(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On platforms without os.killpg/os.getpgid (Windows), the helper must
+        fall back to process.terminate()/kill() instead of raising AttributeError."""
+        import pmcp.client.manager as mgr
+
+        monkeypatch.delattr(mgr.os, "killpg", raising=False)
+        monkeypatch.delattr(mgr.os, "getpgid", raising=False)
+
+        process = MagicMock()
+        process.pid = 4321
+        process.returncode = None
+        process.wait = AsyncMock(return_value=0)
+
+        # Must not raise; must use the cross-platform single-process path.
+        await _terminate_process_tree(process, "browser")
+        process.terminate.assert_called_once()
 
 
 class TestReadStdoutFailureSurfacing:

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -23,6 +23,7 @@ from pmcp.client.manager import (
     _extract_tags,
     _infer_risk_hint,
     _remote_headers,
+    _terminate_process_tree,
     _truncate_description,
 )
 from pmcp.env_store import write_env_file
@@ -2568,7 +2569,9 @@ class TestCleanupClient:
         await manager._cleanup_client("test", managed)
 
         managed.read_task.cancel.assert_called_once()  # type: ignore[union-attr]
-        managed.process.kill.assert_called_once()  # type: ignore[union-attr]
+        # _terminate_process_tree gracefully SIGTERMs first (the process exits
+        # within the wait window, so SIGKILL is never needed).
+        managed.process.terminate.assert_called_once()  # type: ignore[union-attr]
         assert "test" not in manager._clients
         assert "test" not in manager._servers
 
@@ -2582,7 +2585,7 @@ class TestCleanupClient:
         await manager._cleanup_client("test", managed)
 
         managed.read_task.cancel.assert_not_called()  # type: ignore[union-attr]
-        managed.process.kill.assert_called_once()  # type: ignore[union-attr]
+        managed.process.terminate.assert_called_once()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio
     async def test_cleanup_client_skips_kill_if_process_exited(self) -> None:
@@ -2654,7 +2657,12 @@ class TestDisconnectAllPostKill:
         manager._clients["slow"] = managed
         manager._servers["slow"] = status
 
-        with patch("pmcp.client.manager.logger") as mock_logger:
+        with (
+            patch("pmcp.client.manager.logger") as mock_logger,
+            patch(
+                "pmcp.client.manager.os.getpgid", side_effect=ProcessLookupError
+            ),
+        ):
             await manager.disconnect_all()
 
         mock_process.kill.assert_called_once()
@@ -2683,7 +2691,12 @@ class TestDisconnectAllPostKill:
         manager._clients["slow2"] = managed
         manager._servers["slow2"] = status
 
-        with patch("pmcp.client.manager.logger") as mock_logger:
+        with (
+            patch("pmcp.client.manager.logger") as mock_logger,
+            patch(
+                "pmcp.client.manager.os.getpgid", side_effect=ProcessLookupError
+            ),
+        ):
             await manager.disconnect_all()
 
         mock_process.kill.assert_called_once()
@@ -3118,6 +3131,83 @@ class TestStdioReadLimit:
 
         assert "limit" in captured, "create_subprocess_exec must be called with limit="
         assert captured["limit"] == 10 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_connect_stdio_starts_new_session(self) -> None:
+        """_connect_stdio must spawn with start_new_session=True so the whole
+        process tree (e.g. browsers) can be reaped on disconnect (issue #79)."""
+        manager = ClientManager()
+        captured: dict[str, Any] = {}
+
+        async def fake_create(*args: Any, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            raise RuntimeError("stop here")
+
+        config = ResolvedServerConfig(
+            name="x",
+            source="project",
+            config=LocalMcpServerConfig(command="fake", args=[]),
+        )
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_create):
+            with pytest.raises(RuntimeError, match="stop here"):
+                await manager._connect_stdio(config)
+
+        assert captured.get("start_new_session") is True
+
+
+class TestTerminateProcessTree:
+    """Tests for the group-aware _terminate_process_tree helper (issue #79)."""
+
+    @pytest.mark.asyncio
+    async def test_terminates_whole_process_group(self) -> None:
+        """When the process leads its group, SIGTERM goes to the group."""
+        import signal
+
+        process = MagicMock()
+        process.pid = 4321
+        process.returncode = None
+        process.wait = AsyncMock(return_value=0)
+
+        with (
+            patch("pmcp.client.manager.os.getpgid", return_value=4321),
+            patch("pmcp.client.manager.os.killpg") as mock_killpg,
+        ):
+            await _terminate_process_tree(process, "browser")
+
+        mock_killpg.assert_called_once_with(4321, signal.SIGTERM)
+        # Group signal succeeded, so we never fall back to single-process kill.
+        process.terminate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_single_process_on_process_lookup_error(self) -> None:
+        """If killpg raises ProcessLookupError, fall back to process.terminate()."""
+        process = MagicMock()
+        process.pid = 4321
+        process.returncode = None
+        process.wait = AsyncMock(return_value=0)
+
+        with (
+            patch("pmcp.client.manager.os.getpgid", return_value=4321),
+            patch(
+                "pmcp.client.manager.os.killpg", side_effect=ProcessLookupError
+            ),
+        ):
+            await _terminate_process_tree(process, "browser")
+
+        process.terminate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_process_already_exited(self) -> None:
+        """A process that already exited must not be signalled."""
+        process = MagicMock()
+        process.pid = 4321
+        process.returncode = 0
+
+        with patch("pmcp.client.manager.os.killpg") as mock_killpg:
+            await _terminate_process_tree(process, "browser")
+
+        mock_killpg.assert_not_called()
+        process.terminate.assert_not_called()
 
 
 class TestReadStdoutFailureSurfacing:

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -3163,7 +3163,14 @@ class TestTerminateProcessTree:
 
     @pytest.mark.asyncio
     async def test_terminates_whole_process_group(self) -> None:
-        """When the process leads its group, SIGTERM goes to the group."""
+        """When the process leads its group, SIGTERM goes to the group; once the
+        group is gone (probe raises) no SIGKILL escalation happens."""
+
+        def killpg_side(pgid: int, sig: int) -> None:
+            if sig == 0:  # liveness probe: report the group already gone
+                raise ProcessLookupError
+            return None
+
         process = MagicMock()
         process.pid = 4321
         process.returncode = None
@@ -3171,13 +3178,23 @@ class TestTerminateProcessTree:
 
         with (
             patch("pmcp.client.manager.os.getpgid", return_value=4321),
-            patch("pmcp.client.manager.os.killpg") as mock_killpg,
+            patch(
+                "pmcp.client.manager.os.killpg", side_effect=killpg_side
+            ) as mock_killpg,
         ):
             await _terminate_process_tree(process, "browser")
 
-        mock_killpg.assert_called_once_with(4321, signal.SIGTERM)
+        # SIGTERM was delivered to the group...
+        assert any(
+            c.args == (4321, signal.SIGTERM) for c in mock_killpg.call_args_list
+        )
+        # ...and since the group probe reported it gone, no SIGKILL escalation.
+        assert not any(
+            c.args == (4321, signal.SIGKILL) for c in mock_killpg.call_args_list
+        )
         # Group signal succeeded, so we never fall back to single-process kill.
         process.terminate.assert_not_called()
+        process.kill.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_falls_back_to_single_process_on_process_lookup_error(self) -> None:
@@ -3257,6 +3274,60 @@ class TestTerminateProcessTree:
 
         assert await _gone(parent_pid), "parent process was not reaped"
         assert await _gone(child_pid), "grandchild process was orphaned, not reaped"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not hasattr(os, "killpg"), reason="process-group reaping is POSIX-only"
+    )
+    async def test_sigterm_ignoring_grandchild_is_group_sigkilled(self) -> None:
+        """A grandchild that ignores SIGTERM and outlives the leader must still be
+        reaped via the group SIGKILL escalation (issue #79/1c — codex finding).
+
+        The parent dies on SIGTERM (default disposition); the grandchild installs
+        SIG_IGN for SIGTERM, so it survives the SIGTERM phase. The helper must
+        then SIGKILL the surviving group rather than returning once the leader is
+        gone.
+        """
+        child_code = (
+            "import signal, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "print('ready', flush=True)\n"
+            "time.sleep(60)\n"
+        )
+        parent_code = (
+            "import subprocess, sys, time\n"
+            f"c = subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+            "print(c.pid, flush=True)\n"
+            "time.sleep(60)\n"
+        )
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            parent_code,
+            stdout=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        assert process.stdout is not None
+        child_pid = int((await asyncio.wait_for(process.stdout.readline(), 10.0)).strip())
+        parent_pid = process.pid
+        os.kill(parent_pid, 0)
+        os.kill(child_pid, 0)
+
+        await _terminate_process_tree(process, "ignore")
+
+        async def _gone(pid: int) -> bool:
+            for _ in range(30):
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    return True
+                await asyncio.sleep(0.1)
+            return False
+
+        assert await _gone(parent_pid), "parent was not reaped"
+        assert await _gone(
+            child_pid
+        ), "SIGTERM-ignoring grandchild was not group-SIGKILLed"
 
     @pytest.mark.asyncio
     async def test_windows_falls_back_without_killpg(

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+import json
 from pathlib import Path
 import time
 from typing import Any, cast
@@ -2863,6 +2865,204 @@ class TestReconnectStormGuard:
 
         await asyncio.sleep(0)  # let tasks run
         assert len(tasks_created) == 1, "Only one reconnect task should be created"
+
+
+class TestIdleTimeout:
+    """Tests for the inactivity (idle) timeout on downstream requests (#79/1a)."""
+
+    @staticmethod
+    def _managed(remote: bool = False) -> ManagedClient:
+        """Build a ManagedClient with a mock process suitable for _send_request."""
+        config = MagicMock()
+        config.name = "test"
+        status = ServerStatus(
+            name="test", status=ServerStatusEnum.ONLINE, tool_count=0
+        )
+        process = MagicMock()
+        process.returncode = None
+        process.stdin = MagicMock()
+        process.stdin.write = MagicMock()
+        process.stdin.drain = AsyncMock()
+        process.stdout = MagicMock()
+        return ManagedClient(
+            config=config, process=process, status=status, is_remote=remote
+        )
+
+    @pytest.mark.asyncio
+    async def test_idle_timeout_survives_periodic_output(self) -> None:
+        """A call that keeps producing output past the idle window completes."""
+        manager = ClientManager()
+        managed = self._managed()
+        future: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        now = time.time()
+        pending = PendingRequest(
+            request_id=1,
+            server_name="test",
+            tool_id="t::x",
+            started_at=now,
+            last_heartbeat=now,
+            timeout_ms=300,
+            future=future,
+        )
+        managed.pending_requests[1] = pending
+
+        async def keepalive() -> None:
+            # Bump well past the 0.3s idle window, then resolve.
+            for _ in range(5):
+                await asyncio.sleep(0.1)
+                pending.last_heartbeat = time.time()
+            future.set_result({"ok": True})
+
+        task = asyncio.create_task(keepalive())
+        result = await manager._await_with_idle_timeout(
+            managed, 1, pending, future, idle_timeout_s=0.3, ceiling_s=100.0
+        )
+        await task
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_idle_timeout_fires_when_silent(self) -> None:
+        """A silent downstream times out at the idle threshold and is removed."""
+        manager = ClientManager()
+        managed = self._managed()
+
+        with pytest.raises(TimeoutError):
+            await manager._send_request(
+                managed, "tools/call", {}, tool_id="t::x", timeout_ms=200
+            )
+
+        assert managed.pending_requests == {}
+        assert managed.status.pending_request_count == 0
+
+    @pytest.mark.asyncio
+    async def test_absolute_ceiling_fires_for_chatty_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A continuously-heartbeating call that never resolves hits the ceiling."""
+        monkeypatch.setenv("PMCP_REQUEST_CEILING_MS", "200")
+        manager = ClientManager()
+        managed = self._managed()
+
+        async def chatty() -> None:
+            try:
+                while True:
+                    await asyncio.sleep(0.05)
+                    for req in managed.pending_requests.values():
+                        req.last_heartbeat = time.time()
+            except asyncio.CancelledError:
+                pass
+
+        task = asyncio.create_task(chatty())
+        try:
+            with pytest.raises(TimeoutError):
+                # idle window (400ms) never elapses thanks to chatty bumps, so the
+                # 200ms ceiling is what fires.
+                await manager._send_request(
+                    managed, "tools/call", {}, tool_id="t::x", timeout_ms=400
+                )
+        finally:
+            task.cancel()
+            await task
+
+        assert managed.pending_requests == {}
+
+    @pytest.mark.asyncio
+    async def test_progress_notification_bumps_pending_heartbeat_stdout(self) -> None:
+        """An id:null JSON notification advances in-flight last_heartbeat (stdio)."""
+        manager = ClientManager()
+        managed = self._managed()
+        # Graceful branch in finally; avoid scheduling a reconnect task.
+        managed.status.status = ServerStatusEnum.OFFLINE
+        stale = time.time() - 10
+        future: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        pending = PendingRequest(
+            request_id=1,
+            server_name="test",
+            tool_id="t::x",
+            started_at=stale,
+            last_heartbeat=stale,
+            timeout_ms=30000,
+            future=future,
+        )
+        managed.pending_requests[1] = pending
+
+        notif = (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "notifications/progress",
+                    "params": {"progress": 1},
+                }
+            )
+            + "\n"
+        )
+        cast(Any, managed.process).stdout.readline = AsyncMock(
+            side_effect=[notif.encode(), b""]
+        )
+
+        await manager._read_stdout("test", managed)
+
+        assert pending.last_heartbeat > stale
+        # Retrieve the ConnectionError set by the EOF finally so it is not logged.
+        with contextlib.suppress(Exception):
+            pending.future.exception()
+
+    @pytest.mark.asyncio
+    async def test_progress_notification_bumps_pending_heartbeat_sse(self) -> None:
+        """An id:null JSON notification advances in-flight last_heartbeat (SSE)."""
+        manager = ClientManager()
+        managed = self._managed(remote=True)
+        managed.status.status = ServerStatusEnum.OFFLINE
+        stale = time.time() - 10
+        future: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        pending = PendingRequest(
+            request_id=1,
+            server_name="test",
+            tool_id="t::x",
+            started_at=stale,
+            last_heartbeat=stale,
+            timeout_ms=30000,
+            future=future,
+        )
+        managed.pending_requests[1] = pending
+
+        msg = MagicMock()
+        msg.message.model_dump.return_value = {
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": {},
+        }
+
+        async def stream() -> Any:
+            yield msg
+
+        await manager._read_sse("test", managed, stream())
+
+        assert pending.last_heartbeat > stale
+        with contextlib.suppress(Exception):
+            pending.future.exception()
+
+    def test_request_ceiling_ms_env_parsing(self) -> None:
+        """_request_ceiling_ms parses valid values and falls back on bad ones."""
+        from pmcp.client.manager import (
+            DEFAULT_REQUEST_CEILING_MS,
+            _request_ceiling_ms,
+        )
+
+        assert DEFAULT_REQUEST_CEILING_MS == 600000
+
+        import os as _os
+
+        with patch.dict("os.environ", {}, clear=False):
+            _os.environ.pop("PMCP_REQUEST_CEILING_MS", None)
+            assert _request_ceiling_ms() == DEFAULT_REQUEST_CEILING_MS
+
+        with patch.dict("os.environ", {"PMCP_REQUEST_CEILING_MS": "1234"}):
+            assert _request_ceiling_ms() == 1234
+
+        for bad in ("not-a-number", "-1", "0"):
+            with patch.dict("os.environ", {"PMCP_REQUEST_CEILING_MS": bad}):
+                assert _request_ceiling_ms() == DEFAULT_REQUEST_CEILING_MS
 
 
 class TestStdioReadLimit:

--- a/tests/test_offline_discovery.py
+++ b/tests/test_offline_discovery.py
@@ -580,3 +580,75 @@ class TestNoCacheScenario:
         # Should return only live tools
         assert len(result.results) == 1
         assert result.results[0].tool_id == "live-server::live_tool"
+
+
+class TestManifestCandidatesDiscovery:
+    """Verify catalog_search surfaces manifest-provisionable servers (#78)."""
+
+    @pytest.fixture
+    def gateway_tools_no_cache(self) -> GatewayTools:
+        """GatewayTools with no live tools and no cache (manifest-only world)."""
+        mock_client_manager = MagicMock()
+        mock_client_manager.get_all_tools.return_value = []
+        mock_client_manager.is_server_online.return_value = False
+        mock_client_manager.get_all_server_statuses.return_value = []
+
+        mock_policy_manager = MagicMock()
+        mock_policy_manager.is_tool_allowed.return_value = True
+        mock_policy_manager.is_server_allowed.return_value = True
+
+        return GatewayTools(
+            client_manager=mock_client_manager,
+            policy_manager=mock_policy_manager,
+            descriptions_cache=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_manifest_only_server_surfaced_as_candidate(
+        self, gateway_tools_no_cache: GatewayTools
+    ) -> None:
+        """A query matching a manifest-only server returns it as a candidate."""
+        result = await gateway_tools_no_cache.catalog_search(
+            {"query": "bright data web research", "include_offline": True}
+        )
+
+        names = [c.name for c in result.manifest_candidates]
+        assert "brightdata" in names, (
+            f"brightdata should surface as a manifest candidate, got {names}"
+        )
+
+        candidate = next(
+            c for c in result.manifest_candidates if c.name == "brightdata"
+        )
+        # API-key metadata is populated from the manifest (deterministic).
+        assert candidate.requires_api_key is True
+        assert candidate.env_var == "API_TOKEN"
+        # Machine-readable next-action metadata for agents to act on.
+        assert candidate.provisionable is True
+        assert candidate.source == "manifest"
+        assert candidate.provision_tool == "gateway.provision"
+        assert candidate.request_capability_tool == "gateway.request_capability"
+        assert candidate.auth_tool == "gateway.auth_connect"
+
+    @pytest.mark.asyncio
+    async def test_enriched_research_keyword_matches_brightdata(
+        self, gateway_tools_no_cache: GatewayTools
+    ) -> None:
+        """The newly added 'web research' keyword surfaces brightdata."""
+        result = await gateway_tools_no_cache.catalog_search(
+            {"query": "web research", "include_offline": True}
+        )
+
+        assert any(
+            c.name == "brightdata" for c in result.manifest_candidates
+        ), "enriched 'web research' keyword should surface brightdata"
+
+    @pytest.mark.asyncio
+    async def test_manifest_candidates_require_include_offline(
+        self, gateway_tools_no_cache: GatewayTools
+    ) -> None:
+        """Manifest candidates are gated on include_offline=True."""
+        result = await gateway_tools_no_cache.catalog_search(
+            {"query": "bright data web research"}
+        )
+        assert result.manifest_candidates == []

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -114,6 +114,7 @@ class MockClientManager:
         self._last_refresh_ts = 1234567890.0
         self.connected_configs: list[Any] = []
         self.connected_config_map: dict[str, Any] = {}
+        self.connected_resolved_headers: dict[str, dict[str, str]] = {}
         self.refreshed_configs: list[Any] = []
         self.lazy_configs: list[Any] = []
         self.disconnected = False
@@ -311,18 +312,43 @@ class MockClientManager:
     def get_connected_configs(self) -> dict[str, Any]:
         return dict(self.connected_config_map)
 
-    def add_connected_server(self, config: Any) -> None:
-        """Pre-populate an already-connected, online server (test helper)."""
+    def get_connected_resolved_headers(self, name: str) -> dict[str, str] | None:
+        return self.connected_resolved_headers.get(name)
+
+    def add_connected_server(
+        self,
+        config: Any,
+        *,
+        online: bool = True,
+        resolved_headers: dict[str, str] | None = None,
+    ) -> None:
+        """Pre-populate an already-connected server (test helper).
+
+        ``online=False`` models a crashed server still present in ``_clients``
+        with ERROR status (its reconnect attempts exhausted) — it appears in
+        get_connected_configs() but is NOT ONLINE. ``resolved_headers`` records
+        the auth headers the server was connected with (placeholders resolved).
+        """
         self.connected_config_map[config.name] = config
-        self._online_servers.add(config.name)
+        if resolved_headers is not None:
+            self.connected_resolved_headers[config.name] = resolved_headers
         self._server_statuses = [
             status for status in self._server_statuses if status.name != config.name
         ]
-        self._server_statuses.append(
-            ServerStatus(
-                name=config.name, status=ServerStatusEnum.ONLINE, tool_count=0
+        if online:
+            self._online_servers.add(config.name)
+            self._server_statuses.append(
+                ServerStatus(
+                    name=config.name, status=ServerStatusEnum.ONLINE, tool_count=0
+                )
             )
-        )
+        else:
+            self._online_servers.discard(config.name)
+            self._server_statuses.append(
+                ServerStatus(
+                    name=config.name, status=ServerStatusEnum.ERROR, tool_count=0
+                )
+            )
 
     async def disconnect_all(self) -> None:
         self.events.append("disconnect")
@@ -334,6 +360,18 @@ class MockClientManager:
         self.lazy_configs = list(configs)
         for config in configs:
             self._lazy_servers.add(config.name)
+
+    def prune_lazy_configs(self, keep_names: set[str]) -> None:
+        self.events.append("prune_lazy")
+        self.lazy_configs = [c for c in self.lazy_configs if c.name in keep_names]
+        for name in list(self._lazy_servers):
+            if name not in keep_names:
+                self._lazy_servers.discard(name)
+                self._server_statuses = [
+                    s
+                    for s in self._server_statuses
+                    if not (s.name == name and s.status == ServerStatusEnum.LAZY)
+                ]
 
     async def connect_all(self, configs: list[Any], retry: bool = True) -> list[str]:
         self.events.append("connect")
@@ -1005,6 +1043,102 @@ class TestRefreshCompatibility:
         assert client_manager.is_server_online("srv") is True
 
     @pytest.mark.asyncio
+    async def test_refresh_heals_crashed_eager_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A present-but-not-ONLINE eager server (crashed, reconnect exhausted) is
+        torn down and reconnected by refresh — the recovery path must not regress."""
+        client_manager = MockClientManager()
+        config = ResolvedServerConfig(
+            name="eager",
+            source="project",
+            config=LocalMcpServerConfig(command="eager-cmd"),
+        )
+        # In _clients with ERROR status (crashed), NOT online.
+        client_manager.add_connected_server(config, online=False)
+        assert client_manager.is_server_online("eager") is False
+        gateway_tools = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        patch_refresh_config_sources(monkeypatch, [config])
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.load_enabled_auto_start",
+            lambda **_: {"eager"},
+        )
+        monkeypatch.setattr(gateway_tools, "_load_provisioned_registry", lambda: {})
+
+        result = await gateway_tools.refresh({"reason": "test"})
+
+        assert result.ok is True
+        # Stale entry cleared, then reconnected.
+        assert "disconnect_server:eager:True" in client_manager.events
+        assert "eager" in [c.name for c in client_manager.connected_configs]
+        assert client_manager.is_server_online("eager") is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_prunes_removed_lazy_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A previously-lazy server that is no longer in the resolved set is pruned
+        from the lazy registry so it can't be lazily started after refresh."""
+        client_manager = MockClientManager()
+        client_manager.add_lazy_server("stale")
+        assert "stale" in client_manager.get_lazy_server_names()
+        gateway_tools = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        patch_refresh_config_sources(monkeypatch, [])
+        monkeypatch.setattr(gateway_tools, "_load_provisioned_registry", lambda: {})
+
+        result = await gateway_tools.refresh({"reason": "test"})
+
+        assert result.ok is True
+        assert "stale" not in client_manager.get_lazy_server_names()
+
+    def test_refresh_config_unchanged_detects_remote_token_rotation(self) -> None:
+        """_refresh_config_unchanged compares the connect-time RESOLVED headers
+        against a fresh resolution, so a rotated env-store token (raw config
+        unchanged) is detected as CHANGED — guarding against stale/revoked auth
+        surviving a refresh (issue #79, codex+gemini finding)."""
+        from pmcp.tools.handlers import _refresh_config_unchanged
+
+        cfg = ResolvedServerConfig(
+            name="remote",
+            source="project",
+            config=RemoteMcpServerConfig(
+                type="streamable-http",
+                url="https://example/mcp",
+                headers={"Authorization": "Bearer ${TOKEN}"},
+            ),
+        )
+        # Env store now resolves TOKEN to "new-secret".
+        def lookup(var: str) -> str | None:
+            return "new-secret" if var == "TOKEN" else None
+
+        # Connected with the OLD secret -> rotation must read as CHANGED.
+        assert (
+            _refresh_config_unchanged(
+                cfg,
+                cfg,
+                header_env_lookup=lookup,
+                old_resolved_headers={"Authorization": "Bearer old-secret"},
+            )
+            is False
+        )
+        # Same secret as connect time -> unchanged, keep connected.
+        assert (
+            _refresh_config_unchanged(
+                cfg,
+                cfg,
+                header_env_lookup=lookup,
+                old_resolved_headers={"Authorization": "Bearer new-secret"},
+            )
+            is True
+        )
+
+    @pytest.mark.asyncio
     async def test_refresh_refuses_pending_requests_by_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1094,6 +1228,7 @@ class TestRefreshCompatibility:
         assert client_manager.events == [
             "cancel_all",
             "register_lazy",
+            "prune_lazy",
             "connect",
         ]
 
@@ -1158,11 +1293,12 @@ class TestRefreshCompatibility:
         assert refused.ok is False
         assert refused.pending_requests_refused == 1
         # Diff-based refresh with no configured/eager servers: the forced refresh
-        # cancels pending then only re-registers lazy configs (nothing to
+        # cancels pending then re-registers and prunes lazy configs (nothing to
         # disconnect or connect).
         assert client_manager.events == [
             "cancel_all",
             "register_lazy",
+            "prune_lazy",
         ]
         assert forced.ok is True
         assert forced.pending_requests_cancelled == 1

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -24,10 +24,14 @@ from pmcp.manifest.registry import (
     RegistryServerEntry,
 )
 from pmcp.config.guidance import GuidanceConfig
-from pmcp.config.loader import StartupObservation
+from pmcp.config.loader import StartupObservation, manifest_server_to_config
 from pmcp.errors import GatewayException
 from pmcp.policy.policy import PolicyManager
-from pmcp.tools.handlers import GatewayTools, get_gateway_tool_definitions
+from pmcp.tools.handlers import (
+    GatewayTools,
+    _refresh_config_unchanged,
+    get_gateway_tool_definitions,
+)
 from pmcp.types import (
     CLIHint,
     CLIResolution,
@@ -109,6 +113,7 @@ class MockClientManager:
         self._revision_id = "test-rev"
         self._last_refresh_ts = 1234567890.0
         self.connected_configs: list[Any] = []
+        self.connected_config_map: dict[str, Any] = {}
         self.refreshed_configs: list[Any] = []
         self.lazy_configs: list[Any] = []
         self.disconnected = False
@@ -303,9 +308,26 @@ class MockClientManager:
         self.refreshed_configs = list(configs)
         return []
 
+    def get_connected_configs(self) -> dict[str, Any]:
+        return dict(self.connected_config_map)
+
+    def add_connected_server(self, config: Any) -> None:
+        """Pre-populate an already-connected, online server (test helper)."""
+        self.connected_config_map[config.name] = config
+        self._online_servers.add(config.name)
+        self._server_statuses = [
+            status for status in self._server_statuses if status.name != config.name
+        ]
+        self._server_statuses.append(
+            ServerStatus(
+                name=config.name, status=ServerStatusEnum.ONLINE, tool_count=0
+            )
+        )
+
     async def disconnect_all(self) -> None:
         self.events.append("disconnect")
         self.disconnected = True
+        self.connected_config_map.clear()
 
     def register_lazy_configs(self, configs: list[Any]) -> None:
         self.events.append("register_lazy")
@@ -318,6 +340,7 @@ class MockClientManager:
         self.connected_configs.extend(configs)
         for config in configs:
             self._online_servers.add(config.name)
+            self.connected_config_map[config.name] = config
         return []
 
     async def connect_server(self, config: Any, retry: bool = True) -> list[str]:
@@ -326,6 +349,7 @@ class MockClientManager:
         if config.name == "fails-connect":
             return [f"Failed to connect to {config.name}: boom"]
         self._online_servers.add(config.name)
+        self.connected_config_map[config.name] = config
         self._lazy_servers.discard(config.name)
         self._server_statuses = [
             status for status in self._server_statuses if status.name != config.name
@@ -349,6 +373,7 @@ class MockClientManager:
             )
         cancelled = self.cancel_pending_requests(name) if pending else 0
         self._online_servers.discard(name)
+        self.connected_config_map.pop(name, None)
         self._lazy_servers.add(name)
         self._server_statuses = [
             status for status in self._server_statuses if status.name != name
@@ -630,7 +655,9 @@ class TestRefreshCompatibility:
         result = await gateway_tools.refresh({"reason": "test"})
 
         assert result.ok is True
-        assert client_manager.disconnected is True
+        # Diff-based refresh no longer tears everything down; nothing was
+        # connected and the resolution is all-lazy, so no disconnect happens.
+        assert client_manager.disconnected is False
         assert client_manager.refreshed_configs == []
         assert [config.name for config in client_manager.lazy_configs] == [
             "configured",
@@ -789,6 +816,195 @@ class TestRefreshCompatibility:
         assert client_manager.connected_configs == []
 
     @pytest.mark.asyncio
+    async def test_refresh_keeps_unchanged_lazy_server_online(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A connected server that resolves as lazy must stay online (issue #79).
+
+        This is the discriminating case: a lazily-started server (e.g. a
+        provisioned browser put into _clients by ensure_connected) resolves as
+        lazy on refresh. The diff must keep it, not tear it down.
+        """
+        client_manager = MockClientManager()
+        config = ResolvedServerConfig(
+            name="browser",
+            source="project",
+            config=LocalMcpServerConfig(command="browser-cmd"),
+        )
+        client_manager.add_connected_server(config)
+        gateway_tools = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        # No auto_start -> "browser" resolves as lazy on this refresh.
+        patch_refresh_config_sources(monkeypatch, [config])
+        monkeypatch.setattr(gateway_tools, "_load_provisioned_registry", lambda: {})
+
+        result = await gateway_tools.refresh({"reason": "test"})
+
+        assert result.ok is True
+        assert "disconnect_server:browser:True" not in client_manager.events
+        assert "connect" not in client_manager.events
+        assert client_manager.is_server_online("browser") is True
+        assert result.servers_online == 1
+        assert [c.name for c in client_manager.lazy_configs] == ["browser"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_keeps_adopted_provisioned_server_online(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A runtime-adopted provisioned server must survive refresh (issue #79).
+
+        This is the scenario that produced "105 seen, 0 online": the adopted
+        config stores env resolved from os.environ
+        (manifest_server_to_config), while the loader resolves the same server
+        with env=None. Full-model equality would differ and tear it down; the
+        diff must treat them as the same process and keep it.
+        """
+        monkeypatch.setenv("PROV_KEY", "secret-value")
+        manifest = Manifest(
+            version="1.0",
+            cli_alternatives={},
+            servers={
+                "prov": ServerConfig(
+                    name="prov",
+                    description="Provisioned w/ api key",
+                    keywords=["prov"],
+                    install={},
+                    command="prov-cmd",
+                    args=[],
+                    requires_api_key=True,
+                    env_var="PROV_KEY",
+                )
+            },
+            discovery_queue_path=".mcp-gateway/discovery_queue.json",
+        )
+        client_manager = MockClientManager()
+        # Connected config carries env resolved from os.environ (adopt path).
+        adopted = manifest_server_to_config(manifest.servers["prov"])
+        assert adopted.config.env == {"PROV_KEY": "secret-value"}
+        client_manager.add_connected_server(adopted)
+        gateway_tools = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: [])
+        monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: manifest)
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.load_enabled_auto_start", lambda **_: set()
+        )
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.load_disabled_auto_start", lambda **_: set()
+        )
+        monkeypatch.setattr(
+            gateway_tools,
+            "_load_provisioned_registry",
+            lambda: {"prov": "PROV_KEY"},
+        )
+
+        result = await gateway_tools.refresh({"reason": "test"})
+
+        assert result.ok is True
+        assert "disconnect_server:prov:True" not in client_manager.events
+        assert "connect" not in client_manager.events
+        assert client_manager.is_server_online("prov") is True
+        assert result.servers_online == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_keeps_unchanged_eager_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unchanged eager server is left running, not respawned."""
+        client_manager = MockClientManager()
+        config = ResolvedServerConfig(
+            name="eager",
+            source="project",
+            config=LocalMcpServerConfig(command="eager-cmd"),
+        )
+        client_manager.add_connected_server(config)
+        gateway_tools = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        patch_refresh_config_sources(monkeypatch, [config])
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.load_enabled_auto_start",
+            lambda **_: {"eager"},
+        )
+        monkeypatch.setattr(gateway_tools, "_load_provisioned_registry", lambda: {})
+
+        result = await gateway_tools.refresh({"reason": "test"})
+
+        assert result.ok is True
+        assert "disconnect_server:eager:True" not in client_manager.events
+        assert "connect" not in client_manager.events
+        assert client_manager.is_server_online("eager") is True
+        assert result.servers_online == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_disconnects_removed_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server removed from config is disconnected on refresh."""
+        client_manager = MockClientManager()
+        client_manager.add_connected_server(
+            ResolvedServerConfig(
+                name="gone",
+                source="project",
+                config=LocalMcpServerConfig(command="gone-cmd"),
+            )
+        )
+        gateway_tools = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        patch_refresh_config_sources(monkeypatch, [])
+        monkeypatch.setattr(gateway_tools, "_load_provisioned_registry", lambda: {})
+
+        result = await gateway_tools.refresh({"reason": "test"})
+
+        assert result.ok is True
+        assert "disconnect_server:gone:True" in client_manager.events
+        assert client_manager.is_server_online("gone") is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_reconnects_changed_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server whose config changed is disconnected and reconnected."""
+        client_manager = MockClientManager()
+        client_manager.add_connected_server(
+            ResolvedServerConfig(
+                name="srv",
+                source="project",
+                config=LocalMcpServerConfig(command="old-cmd"),
+            )
+        )
+        new_config = ResolvedServerConfig(
+            name="srv",
+            source="project",
+            config=LocalMcpServerConfig(command="new-cmd"),
+        )
+        gateway_tools = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        patch_refresh_config_sources(monkeypatch, [new_config])
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.load_enabled_auto_start",
+            lambda **_: {"srv"},
+        )
+        monkeypatch.setattr(gateway_tools, "_load_provisioned_registry", lambda: {})
+
+        result = await gateway_tools.refresh({"reason": "test"})
+
+        assert result.ok is True
+        assert "disconnect_server:srv:True" in client_manager.events
+        assert [c.name for c in client_manager.connected_configs] == ["srv"]
+        assert client_manager.connected_config_map["srv"].config.command == "new-cmd"
+        assert client_manager.is_server_online("srv") is True
+
+    @pytest.mark.asyncio
     async def test_refresh_refuses_pending_requests_by_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -872,9 +1088,11 @@ class TestRefreshCompatibility:
         assert result.pending_requests_seen == 1
         assert result.pending_requests_cancelled == 1
         assert result.pending_requests_remaining == 0
+        # Diff-based refresh: force still cancels pending first, then (nothing
+        # was connected so no per-server disconnect) registers lazy and connects
+        # the newly-eager server.
         assert client_manager.events == [
             "cancel_all",
-            "disconnect",
             "register_lazy",
             "connect",
         ]
@@ -939,11 +1157,12 @@ class TestRefreshCompatibility:
 
         assert refused.ok is False
         assert refused.pending_requests_refused == 1
+        # Diff-based refresh with no configured/eager servers: the forced refresh
+        # cancels pending then only re-registers lazy configs (nothing to
+        # disconnect or connect).
         assert client_manager.events == [
             "cancel_all",
-            "disconnect",
             "register_lazy",
-            "connect",
         ]
         assert forced.ok is True
         assert forced.pending_requests_cancelled == 1
@@ -997,6 +1216,58 @@ class TestRefreshCompatibility:
         assert after_health.servers[0].status == "online"
         assert after_pending.requests[0].request_id == "active::1"
         assert client_manager.events == []
+
+
+class TestRefreshConfigUnchanged:
+    """Unit tests for the gateway.refresh config-equality helper (issue #79)."""
+
+    def _local(self, **kwargs: Any) -> ResolvedServerConfig:
+        return ResolvedServerConfig(
+            name=kwargs.pop("name", "srv"),
+            source=kwargs.pop("source", "project"),
+            config=LocalMcpServerConfig(**kwargs),
+        )
+
+    def test_same_process_is_unchanged(self) -> None:
+        a = self._local(command="c", args=["x"])
+        b = self._local(command="c", args=["x"])
+        assert _refresh_config_unchanged(a, b) is True
+
+    def test_command_change_detected(self) -> None:
+        a = self._local(command="old")
+        b = self._local(command="new")
+        assert _refresh_config_unchanged(a, b) is False
+
+    def test_source_difference_ignored(self) -> None:
+        a = self._local(command="c", source="manifest")
+        b = self._local(command="c", source="project")
+        assert _refresh_config_unchanged(a, b) is True
+
+    def test_env_mirroring_environ_is_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Adopt path stores env resolved from os.environ; loader stores None.
+        monkeypatch.setenv("KEY", "val")
+        adopted = self._local(command="c", env={"KEY": "val"})
+        loader = self._local(command="c", env=None)
+        assert _refresh_config_unchanged(adopted, loader) is True
+
+    def test_genuine_env_override_change_detected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OVERRIDE", raising=False)
+        a = self._local(command="c", env={"OVERRIDE": "old"})
+        b = self._local(command="c", env={"OVERRIDE": "new"})
+        assert _refresh_config_unchanged(a, b) is False
+
+    def test_type_mismatch_detected(self) -> None:
+        local = self._local(command="c")
+        remote = ResolvedServerConfig(
+            name="srv",
+            source="project",
+            config=RemoteMcpServerConfig(url="https://x"),
+        )
+        assert _refresh_config_unchanged(local, remote) is False
 
 
 class TestCatalogSearch:


### PR DESCRIPTION
Fixes #78 and addresses #79 (symptoms 1a, 1c, 2; symptom 1b deferred — see below).

## #79 — Browser/gateway session stability

**1a — Inactivity (idle) timeout for downstream calls.** `_send_request` previously waited on a fixed wall-clock deadline, so a legitimately long browser op (e.g. a multi-step `browser_run_code_unsafe` loop) was killed at ~30s. `timeout_ms` is now an **inactivity timeout**: the call survives as long as the downstream keeps producing output. JSON progress notifications (`id: null`) now count toward per-request liveness in both the stdio and SSE readers (previously they bumped only server-level activity). An absolute backstop (`PMCP_REQUEST_CEILING_MS`, default 10 min) caps total time and applies **only to tool invocations** — control-plane calls (initialize, list, tasks) keep the tighter idle deadline so one stuck server can't stall startup/refresh. `TimeoutError → E303_TOOL_TIMEOUT` mapping preserved.

**1c — Process-tree reaping.** stdio servers are now spawned with `start_new_session=True` and reaped as a whole group via a new `_terminate_process_tree` helper, wired into all four shutdown paths. This kills grandchildren (e.g. the Chrome `@playwright/mcp` launches) that previously orphaned to init and held the profile's `SingletonLock`, breaking the next launch. The helper only signals the group when the process leads it (never the gateway's own group) and falls back to `process.terminate()/kill()` when not a leader **or on Windows**, where process groups are unavailable.

**2 — Non-destructive, diff-based refresh.** `gateway.refresh` previously did `disconnect_all()` + reconnect-eager-only, dropping previously-running lazy/provisioned servers to offline (the reported "105 seen, 0 online") and respawning unchanged processes (e.g. a live browser) every refresh. It now diffs: servers whose resolved config is unchanged stay connected and running; only removed/changed servers disconnect; only newly-added eager servers connect. Config equality compares process-affecting fields and only env overrides that genuinely differ from `os.environ`, so adopted/provisioned servers aren't spuriously torn down.

**1b — deferred (not in this PR).** The "MCP server pmcp session expired" string is emitted by the Claude Code client, not pmcp — it's the *outer* streamable-HTTP session. Three candidate causes remain (outer-session teardown during a long in-flight call / 10 MiB stdio read-limit disconnect / orphaned-future desync) and need a reproduce-with-logs pass to disambiguate before a fix can be committed. 1a should reduce its frequency.

## #78 — Advertise manifest-provisionable servers in discovery

`gateway.catalog_search(include_offline=true)` now surfaces manifest-only provisionable servers in a dedicated `manifest_candidates` field when the query matches a manifest server by name/keyword but no cached tools exist yet. Candidates carry machine-readable next-action metadata (`provisionable`, `provision_tool`, `request_capability_tool`, `auth_tool`, `requires_api_key`, `api_key_available`, `env_var`) so an agent can provision the exact server instead of falling back to a plain web search. `gateway.request_capability`'s description is corrected to say it *recommends* (it never auto-provisioned). `brightdata` keywords extended with research terms (`web research`, `current web`, `page fetch`, `external research`).

## Verification

- Full suite: **2089 passed, 11 skipped**; ruff + mypy (manager.py) clean.
- New tests include a **real** end-to-end reaping test (spawn parent→child, assert both PIDs actually die — not just that `killpg` was called), a Windows-fallback test, idle-timeout/ceiling/notification tests, and diff-refresh tests covering the lazy/provisioned-preservation and removed/changed cases.
- **Not** verified against the original runtime symptoms (a real long browser call, a real refresh with live servers, real Chrome death) — that needs the live gateway + a browser session.

## Follow-ups (not blocking)
- The install-time spawn in `installer.py` (`adopt_process`) could also take `start_new_session` to reap adopted browsers as a tree.
- Diff-refresh doesn't prune stale `_lazy_configs` for vanished servers (harmless; documented in-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
