### PR TITLE
style: ruff format files from PR #80 (fix CI lint)

### DIFF
--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -1685,9 +1685,7 @@ class ClientManager:
         # can't stall startup/refresh/connect_all for the full ceiling.
         idle_timeout_s = timeout_ms / 1000.0
         ceiling_s = (
-            _request_ceiling_ms() / 1000.0
-            if method == "tools/call"
-            else idle_timeout_s
+            _request_ceiling_ms() / 1000.0 if method == "tools/call" else idle_timeout_s
         )
         try:
             result = await self._await_with_idle_timeout(
@@ -1726,9 +1724,7 @@ class ClientManager:
         slice_s = min(idle_timeout_s, 1.0)
         while True:
             try:
-                return await asyncio.wait_for(
-                    asyncio.shield(future), timeout=slice_s
-                )
+                return await asyncio.wait_for(asyncio.shield(future), timeout=slice_s)
             except asyncio.TimeoutError:
                 if future.done():
                     return future.result()

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -2206,9 +2206,7 @@ class GatewayTools:
             # must NOT be torn down.
             current_configs = self._client_manager.get_connected_configs()
             header_env_lookup = build_remote_header_env_lookup(self._project_root)
-            eager_by_name = {
-                config.name: config for config in resolution.eager_configs
-            }
+            eager_by_name = {config.name: config for config in resolution.eager_configs}
             keep_by_name = {
                 config.name: config
                 for config in resolution.eager_configs + resolution.lazy_configs
@@ -2234,9 +2232,7 @@ class GatewayTools:
                     )
                 )
 
-            to_disconnect = [
-                name for name in current_configs if not _live_keep(name)
-            ]
+            to_disconnect = [name for name in current_configs if not _live_keep(name)]
             to_connect = [
                 config
                 for name, config in eager_by_name.items()

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -2662,9 +2662,7 @@ class TestDisconnectAllPostKill:
 
         with (
             patch("pmcp.client.manager.logger") as mock_logger,
-            patch(
-                "pmcp.client.manager.os.getpgid", side_effect=ProcessLookupError
-            ),
+            patch("pmcp.client.manager.os.getpgid", side_effect=ProcessLookupError),
         ):
             await manager.disconnect_all()
 
@@ -2696,9 +2694,7 @@ class TestDisconnectAllPostKill:
 
         with (
             patch("pmcp.client.manager.logger") as mock_logger,
-            patch(
-                "pmcp.client.manager.os.getpgid", side_effect=ProcessLookupError
-            ),
+            patch("pmcp.client.manager.os.getpgid", side_effect=ProcessLookupError),
         ):
             await manager.disconnect_all()
 
@@ -2891,9 +2887,7 @@ class TestIdleTimeout:
         """Build a ManagedClient with a mock process suitable for _send_request."""
         config = MagicMock()
         config.name = "test"
-        status = ServerStatus(
-            name="test", status=ServerStatusEnum.ONLINE, tool_count=0
-        )
+        status = ServerStatus(name="test", status=ServerStatusEnum.ONLINE, tool_count=0)
         process = MagicMock()
         process.returncode = None
         process.stdin = MagicMock()
@@ -3185,9 +3179,7 @@ class TestTerminateProcessTree:
             await _terminate_process_tree(process, "browser")
 
         # SIGTERM was delivered to the group...
-        assert any(
-            c.args == (4321, signal.SIGTERM) for c in mock_killpg.call_args_list
-        )
+        assert any(c.args == (4321, signal.SIGTERM) for c in mock_killpg.call_args_list)
         # ...and since the group probe reported it gone, no SIGKILL escalation.
         assert not any(
             c.args == (4321, signal.SIGKILL) for c in mock_killpg.call_args_list
@@ -3206,9 +3198,7 @@ class TestTerminateProcessTree:
 
         with (
             patch("pmcp.client.manager.os.getpgid", return_value=4321),
-            patch(
-                "pmcp.client.manager.os.killpg", side_effect=ProcessLookupError
-            ),
+            patch("pmcp.client.manager.os.killpg", side_effect=ProcessLookupError),
         ):
             await _terminate_process_tree(process, "browser")
 
@@ -3254,7 +3244,9 @@ class TestTerminateProcessTree:
             start_new_session=True,
         )
         assert process.stdout is not None
-        child_pid = int((await asyncio.wait_for(process.stdout.readline(), 10.0)).strip())
+        child_pid = int(
+            (await asyncio.wait_for(process.stdout.readline(), 10.0)).strip()
+        )
         parent_pid = process.pid
 
         # Both are alive before reaping.
@@ -3308,7 +3300,9 @@ class TestTerminateProcessTree:
             start_new_session=True,
         )
         assert process.stdout is not None
-        child_pid = int((await asyncio.wait_for(process.stdout.readline(), 10.0)).strip())
+        child_pid = int(
+            (await asyncio.wait_for(process.stdout.readline(), 10.0)).strip()
+        )
         parent_pid = process.pid
         os.kill(parent_pid, 0)
         os.kill(child_pid, 0)
@@ -3325,9 +3319,9 @@ class TestTerminateProcessTree:
             return False
 
         assert await _gone(parent_pid), "parent was not reaped"
-        assert await _gone(
-            child_pid
-        ), "SIGTERM-ignoring grandchild was not group-SIGKILLed"
+        assert await _gone(child_pid), (
+            "SIGTERM-ignoring grandchild was not group-SIGKILLed"
+        )
 
     @pytest.mark.asyncio
     async def test_windows_falls_back_without_killpg(

--- a/tests/test_offline_discovery.py
+++ b/tests/test_offline_discovery.py
@@ -639,9 +639,9 @@ class TestManifestCandidatesDiscovery:
             {"query": "web research", "include_offline": True}
         )
 
-        assert any(
-            c.name == "brightdata" for c in result.manifest_candidates
-        ), "enriched 'web research' keyword should surface brightdata"
+        assert any(c.name == "brightdata" for c in result.manifest_candidates), (
+            "enriched 'web research' keyword should surface brightdata"
+        )
 
     @pytest.mark.asyncio
     async def test_manifest_candidates_require_include_offline(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1113,6 +1113,7 @@ class TestRefreshCompatibility:
                 headers={"Authorization": "Bearer ${TOKEN}"},
             ),
         )
+
         # Env store now resolves TOKEN to "new-secret".
         def lookup(var: str) -> str | None:
             return "new-secret" if var == "TOKEN" else None


### PR DESCRIPTION
PR #80 was verified locally with `ruff check` but CI also runs `ruff format --check`, which flagged 5 files. This applies `ruff format` — formatting only, no behavior change. All tests pass on 3.10/3.11/3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)