### PR TITLE
Release v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-06-28
+
 ### Fixed
 - A single downstream stdout line larger than the read limit (default 10 MiB,
   `PMCP_STDIO_READ_LIMIT`) no longer disconnects the whole server (issue #79,

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ compliance matrix and next-revision tracking checklist.
 
 | Tool | Purpose |
 |------|---------|
-| `gateway.catalog_search` | Search available tools, returns compact capability cards with small metadata such as title, icons, execution hints, and schema dialect, plus additive compact CLI hints and registry candidates when relevant |
+| `gateway.catalog_search` | Search available tools, returns compact capability cards with small metadata such as title, icons, execution hints, and schema dialect, plus additive compact CLI hints, registry candidates, and (with `include_offline=true`) manifest provision candidates (`manifest_candidates`) carrying `provisionable`/`provision_tool`/`requires_api_key`/`api_key_available`/`env_var` so an agent can provision the exact server |
 | `gateway.describe` | Get detailed schema and richer metadata for a specific tool, including output schema, annotations, execution/task support, icons, and schema dialect |
 | `gateway.invoke` | Call a downstream tool with argument validation, including task-augmented execution for task-capable tools |
 | `gateway.refresh` | Reload backend configs and reconnect; refuses while requests or active MCP tasks are pending unless `force=true` |
@@ -1201,6 +1201,21 @@ pmcp
 
 ```bash
 pmcp --lock-dir ./.mcp-gateway
+```
+
+### Downstream call tunables
+
+```bash
+# Per-line stdout read limit for downstream stdio servers (default 10 MiB).
+# A single response line larger than this is dropped (failing only that call,
+# with the server kept connected) rather than disconnecting the server.
+export PMCP_STDIO_READ_LIMIT=$((20 * 1024 * 1024))
+
+# Absolute backstop for a single downstream tool call (default 600000ms / 10 min).
+# `timeout_ms` is an INACTIVITY timeout — a call survives as long as the server
+# keeps producing output; this ceiling caps total wall-clock time for tool calls
+# so a chatty-but-never-completing call cannot hang forever.
+export PMCP_REQUEST_CEILING_MS=600000
 ```
 
 ## Deprecations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.16.0"
+version = "1.17.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.16.0"
+__version__ = "1.17.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **v1.17.0** — bundles the now-merged #79 (browser/gateway session stability) and #78 (provisionable-server discovery) work.

- Version bumped 1.16.0 → 1.17.0 (pyproject, `__init__`, uv.lock).
- CHANGELOG `[Unreleased]` promoted to `[1.17.0] - 2026-06-28`.
- Docs: README documents `PMCP_STDIO_READ_LIMIT` + `PMCP_REQUEST_CEILING_MS` tunables and the `catalog_search` `manifest_candidates` field.

After merge, pushing the `v1.17.0` tag triggers `release.yml` → tests → build → PyPI trusted publish → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)