### PR TITLE
fix(#84): cross-platform singleton lock + release v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.1] - 2026-06-29
+
+### Fixed
+- Native Windows gateway startup no longer crashes with `No module named 'fcntl'`
+  (issue #84). `acquire_singleton_lock`/`release_singleton_lock` imported the
+  Unix-only `fcntl` unconditionally; they now take the per-user single-instance
+  lock via `msvcrt.locking` on Windows and `fcntl.flock` on POSIX (selected by a
+  literal `sys.platform` check so type checkers narrow the platform-only
+  imports). WSL is unaffected. (`resource` was already import-guarded.)
+
 ## [1.17.0] - 2026-06-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.17.0"
+version = "1.17.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.17.0"
+__version__ = "1.17.1"

--- a/src/pmcp/identity.py
+++ b/src/pmcp/identity.py
@@ -10,7 +10,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TextIO
 
 from pmcp.types import LocalMcpServerConfig
 
@@ -133,7 +133,7 @@ _LOCK_FILE: Path | None = None
 _LOCK_FD = None
 
 
-def _lock_fd_exclusive(fd: Any) -> None:
+def _lock_fd_exclusive(fd: TextIO) -> None:
     """Take a non-blocking exclusive advisory lock on an open file.
 
     Raises ``OSError``/``BlockingIOError`` if another process holds the lock.
@@ -153,7 +153,7 @@ def _lock_fd_exclusive(fd: Any) -> None:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
 
-def _unlock_fd(fd: Any) -> None:
+def _unlock_fd(fd: TextIO) -> None:
     """Release a lock taken by :func:`_lock_fd_exclusive` (best-effort).
 
     Closing the descriptor also releases the lock on both platforms, so failures
@@ -197,28 +197,53 @@ def acquire_singleton_lock(lock_dir: Path | str | None = None) -> bool:
     lock_dir.mkdir(parents=True, exist_ok=True)
     _LOCK_FILE = lock_dir / "gateway.lock"
 
+    # Open WITHOUT truncating ("r+" on an ensured-existing file) so a losing
+    # second instance cannot wipe the holder's PID before its lock attempt
+    # fails. We truncate + write our own PID only after we win the lock.
     try:
-        fd = open(_LOCK_FILE, "w")
+        _LOCK_FILE.touch(exist_ok=True)
+        fd = open(_LOCK_FILE, "r+")
+    except OSError as e:
+        logger.warning(f"Could not open singleton lock file {_LOCK_FILE}: {e}")
+        return False
+
+    try:
         _lock_fd_exclusive(fd)
-        _LOCK_FD = fd
-        _LOCK_FD.write(str(os.getpid()))
-        _LOCK_FD.flush()
-        logger.debug(f"Acquired singleton lock: {_LOCK_FILE}")
-        return True
     except (BlockingIOError, OSError) as e:
         pid_info = ""
         try:
-            if _LOCK_FILE and _LOCK_FILE.exists():
-                pid_info = f" PID {_LOCK_FILE.read_text().strip()},"
+            fd.seek(0)
+            existing = fd.read().strip()
+            if existing:
+                pid_info = f" PID {existing},"
         except Exception:
             pass
         logger.warning(
             f"Another gateway instance is running ({pid_info} lock: {_LOCK_FILE}): {e}"
         )
-        if _LOCK_FD:
-            _LOCK_FD.close()
-            _LOCK_FD = None
+        fd.close()
         return False
+    except ImportError as e:
+        # No platform locking primitive available (e.g. an exotic Windows build
+        # without msvcrt). Don't crash startup — proceed without single-instance
+        # protection rather than re-introducing the #84 import-crash class.
+        logger.warning(
+            f"Singleton lock primitive unavailable ({e}); proceeding without "
+            "single-instance protection."
+        )
+        fd.close()
+        return True
+
+    _LOCK_FD = fd
+    try:
+        _LOCK_FD.seek(0)
+        _LOCK_FD.truncate(0)
+        _LOCK_FD.write(str(os.getpid()))
+        _LOCK_FD.flush()
+    except Exception:
+        pass
+    logger.debug(f"Acquired singleton lock: {_LOCK_FILE}")
+    return True
 
 
 def release_singleton_lock() -> None:
@@ -226,8 +251,13 @@ def release_singleton_lock() -> None:
     global _LOCK_FD
 
     if _LOCK_FD:
+        # Unlock and close independently so a failing unlock cannot skip close()
+        # (closing the fd releases the OS lock regardless).
         try:
             _unlock_fd(_LOCK_FD)
+        except Exception:
+            pass
+        try:
             _LOCK_FD.close()
         except Exception:
             pass

--- a/src/pmcp/identity.py
+++ b/src/pmcp/identity.py
@@ -10,7 +10,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pmcp.types import LocalMcpServerConfig
 
@@ -133,6 +133,46 @@ _LOCK_FILE: Path | None = None
 _LOCK_FD = None
 
 
+def _lock_fd_exclusive(fd: Any) -> None:
+    """Take a non-blocking exclusive advisory lock on an open file.
+
+    Raises ``OSError``/``BlockingIOError`` if another process holds the lock.
+    Cross-platform: ``fcntl.flock`` on POSIX, ``msvcrt.locking`` on Windows —
+    PMCP supports native Windows, where importing ``fcntl`` would fail (#84).
+    The literal ``sys.platform`` check (not a module-level alias) lets type
+    checkers narrow the platform-only ``msvcrt``/``fcntl`` imports.
+    """
+    if sys.platform == "win32":
+        import msvcrt
+
+        fd.seek(0)
+        msvcrt.locking(fd.fileno(), msvcrt.LK_NBLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_fd(fd: Any) -> None:
+    """Release a lock taken by :func:`_lock_fd_exclusive` (best-effort).
+
+    Closing the descriptor also releases the lock on both platforms, so failures
+    here are non-fatal.
+    """
+    if sys.platform == "win32":
+        import msvcrt
+
+        try:
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    else:
+        import fcntl
+
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
 def acquire_singleton_lock(lock_dir: Path | str | None = None) -> bool:
     """Ensure only one gateway instance runs per user.
 
@@ -143,8 +183,6 @@ def acquire_singleton_lock(lock_dir: Path | str | None = None) -> bool:
         True if lock acquired, False if another instance is running
     """
     global _LOCK_FILE, _LOCK_FD
-
-    import fcntl
 
     # Already holding a lock
     if _LOCK_FD is not None:
@@ -161,7 +199,7 @@ def acquire_singleton_lock(lock_dir: Path | str | None = None) -> bool:
 
     try:
         fd = open(_LOCK_FILE, "w")
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        _lock_fd_exclusive(fd)
         _LOCK_FD = fd
         _LOCK_FD.write(str(os.getpid()))
         _LOCK_FD.flush()
@@ -187,11 +225,9 @@ def release_singleton_lock() -> None:
     """Release the singleton lock."""
     global _LOCK_FD
 
-    import fcntl
-
     if _LOCK_FD:
         try:
-            fcntl.flock(_LOCK_FD, fcntl.LOCK_UN)
+            _unlock_fd(_LOCK_FD)
             _LOCK_FD.close()
         except Exception:
             pass

--- a/tests/test_singleton_lock_scope.py
+++ b/tests/test_singleton_lock_scope.py
@@ -189,3 +189,48 @@ class TestLockDirDocumentation:
         assert "--lock-dir" in readme_content, (
             "README should document --lock-dir CLI option"
         )
+
+
+class TestWindowsLockPath:
+    """On native Windows the singleton lock must use msvcrt, never the Unix-only
+    fcntl module whose import crashed gateway startup (issue #84)."""
+
+    def setup_method(self) -> None:
+        release_singleton_lock()
+
+    def teardown_method(self) -> None:
+        release_singleton_lock()
+
+    def test_windows_uses_msvcrt_and_never_imports_fcntl(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import types
+
+        import pmcp.identity as identity
+
+        calls: list[int] = []
+
+        fake_msvcrt = types.ModuleType("msvcrt")
+        fake_msvcrt.LK_NBLCK = 2  # type: ignore[attr-defined]
+        fake_msvcrt.LK_UNLCK = 0  # type: ignore[attr-defined]
+
+        def _locking(fileno: int, mode: int, nbytes: int) -> None:
+            calls.append(mode)
+
+        fake_msvcrt.locking = _locking  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+        # Force the Windows branch, and make `import fcntl` raise — so if the code
+        # ever falls back to fcntl on Windows the test fails (the #84 regression).
+        monkeypatch.setattr(identity.sys, "platform", "win32")
+        monkeypatch.setitem(sys.modules, "fcntl", None)
+
+        lock_dir = tmp_path / "locks"
+        assert acquire_singleton_lock(lock_dir) is True
+        assert (lock_dir / "gateway.lock").exists()
+        # Took a non-blocking exclusive lock via msvcrt.
+        assert fake_msvcrt.LK_NBLCK in calls  # type: ignore[attr-defined]
+
+        release_singleton_lock()
+        # Released via msvcrt as well.
+        assert fake_msvcrt.LK_UNLCK in calls  # type: ignore[attr-defined]

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.17.0"
+version = "1.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fixes #84.

## Problem
On **native Windows**, `pmcp --transport http` crashed at startup with `No module named 'fcntl'` — `pmcp/identity.py` imported the Unix-only `fcntl` unconditionally in `acquire_singleton_lock`/`release_singleton_lock`, so the gateway exited before binding the port (`pmcp doctor` then reported `/health` unreachable). Windows is a declared supported OS.

## Fix
The per-user single-instance lock now branches by platform: `msvcrt.locking(fd.fileno(), LK_NBLCK, 1)` on Windows, `fcntl.flock(fd, LOCK_EX | LOCK_NB)` on POSIX (matching the reporter's validated workaround). A **literal `sys.platform == "win32"` check** is used so mypy narrows the platform-only imports. WSL is unaffected (it's Linux). Swept for siblings — `resource` in `manager.py` was already `try/except ImportError`-guarded; `fcntl` was the only unguarded POSIX-only import.

## Tests
New `TestWindowsLockPath` injects a fake `msvcrt` module, forces the Windows branch via `sys.platform`, and makes `import fcntl` raise — proving the lock acquires/releases via msvcrt and **never** touches fcntl (the regression guard). Existing POSIX lock tests unchanged.

Full suite **2094 passed, 11 skipped**; ruff (lint + format) + mypy clean.

## Release
Bundles the **v1.17.1** patch bump (pyproject, `__init__`, uv.lock) + CHANGELOG. After merge, tagging `v1.17.1` triggers `release.yml` → PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)