### PR TITLE
feat: private/custom MCP manifest overlay (v1.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Private/custom manifest overlay: define your own provisionable MCP servers in
+  `~/.pmcp/manifest.yaml` (user), `<project>/.pmcp/manifest.yaml` (project), or a
+  file pointed to by `PMCP_MANIFEST_PATH`, merged over the shipped manifest
+  without editing it. Precedence is shipped < user < project < `PMCP_MANIFEST_PATH`
+  (same-named entries are replaced whole). Overlay parsing is fail-soft — a
+  missing file is skipped, and a malformed file or a single bad entry logs a
+  warning and is skipped without crashing the gateway. Merged servers
+  participate identically in `gateway.request_capability`, `gateway.catalog_search`,
+  `gateway.provision`, and startup `refresh` resolution, gated by the same
+  policy/auth checks.
+
 ## [1.17.1] - 2026-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-06-29
+
 ### Added
 - Private/custom manifest overlay: define your own provisionable MCP servers in
   `~/.pmcp/manifest.yaml` (user), `<project>/.pmcp/manifest.yaml` (project), or a

--- a/README.md
+++ b/README.md
@@ -869,6 +869,53 @@ PMCP discovers MCP servers from:
 2. **User config**: `~/.mcp.json` or `~/.claude/.mcp.json`
 3. **Custom config**: Via `--config` flag or `PMCP_CONFIG` env var
 
+### Private manifest overlay
+
+If you built your own MCP servers (or want private provisionable definitions),
+you can add manifest entries **without editing the shipped manifest**. PMCP
+merges these overlay files over the built-in manifest, so your servers get
+first-class treatment in `gateway.request_capability` keyword matching,
+`gateway.catalog_search` offline discovery, `gateway.provision`, and startup
+resolution — answering "can I add my own private manifest items?" with yes.
+
+Overlay locations, lowest → highest precedence (later overrides earlier, by
+server name; a same-named entry is replaced whole, not deep-merged):
+
+1. **Shipped manifest** (base)
+2. **User**: `~/.pmcp/manifest.yaml`
+3. **Project**: `<project>/.pmcp/manifest.yaml` (nearest ancestor of the cwd)
+4. **Explicit**: `PMCP_MANIFEST_PATH` env var (wins over all)
+
+Overlays use the same entry schema as the shipped manifest. Example
+`~/.pmcp/manifest.yaml`:
+
+```yaml
+servers:
+  # Local (stdio) server provisioned via a command
+  my-private:
+    description: "My private internal server"
+    keywords: [myprivate, internal widget]
+    command: "npx"
+    args: ["-y", "@me/my-mcp"]
+    requires_api_key: true
+    env_var: MY_TOKEN
+  # Remote server reached over streamable HTTP
+  my-remote:
+    description: "My private remote server"
+    keywords: [myremote, internal api]
+    url: "https://mcp.internal.example.com/sse"
+    headers:
+      Authorization: "Bearer ${MY_REMOTE_TOKEN}"
+```
+
+Overlay loading is **fail-soft**: a missing file is skipped silently, and a
+malformed file or a single bad entry logs a warning and is skipped without
+crashing the gateway — the shipped manifest always still loads.
+
+> **Security:** a manifest entry can specify an arbitrary `command`/`args` to
+> run when provisioned — treat an overlay file with the same trust as your own
+> `.mcp.json`. Policy still applies (denied servers stay denied).
+
 ### Adding Custom Servers
 
 For MCP servers not in the manifest, add them to `~/.mcp.json`:

--- a/plans/detailed-private-manifest-overlay-20260629-0841.md
+++ b/plans/detailed-private-manifest-overlay-20260629-0841.md
@@ -1,0 +1,93 @@
+# Detailed plan: private/custom MCP manifest overlay
+
+> **Plan Mode was NOT active when this was produced.** Planning artifact only — no implementation has begun.
+
+## Task
+Let users who built their own MCP servers add private manifest entries (provisionable definitions: `keywords`, `install`/`command`/`args`, `requires_api_key`/`env_var`, `transport`, `auto_start`, remote `url`/`headers`, etc.) as a customization **without editing the shipped `src/pmcp/manifest/manifest.yaml`**, so their servers get first-class treatment in `gateway.request_capability` keyword matching, `gateway.catalog_search` `manifest_candidates`/`include_offline` discovery, `gateway.provision`, and `refresh` startup resolution. Backward compatible; ships as **v1.18.0**.
+
+## Research summary
+- `load_manifest(manifest_path=None)` (`manifest/loader.py:358-393`) loads ONLY the packaged `manifest.yaml`; **no caching**, and the `open()`/`yaml.safe_load()` (`:366-367`) have **no try/except**. It builds `Manifest(version, cli_alternatives, servers, discovery_queue_path)` from `data.get(...)` keys.
+- All **19 `load_manifest()` call sites** (handlers ×13, cli ×2, config/loader, refresher ×2, secrets, server) call it with **no args**, so centralizing overlay discovery+merge inside `load_manifest()` reaches every consumer with **zero call-site changes**.
+- Consumers all read `manifest.servers`/`get_server`: `_manifest_candidates_for_query` (`handlers.py:1284`, gated by `is_server_allowed`), `request_capability` (`:3192,3243,3257,3475,3578,3670`), `provision` (`:3062,3895,4302,4832`), `refresh` → `resolve_startup_configs(manifest_servers=manifest.servers, is_server_allowed=…, is_auth_available=self._check_api_key_available)` (`:2054,2078-2079`). **No code reads `manifest.yaml` directly or hardcodes server-name sets** outside the loader — so a merged `servers` dict flows everywhere and is policy/auth-gated identically.
+- `_parse_server_config(name, data)` (`loader.py:~302-355`) tolerates partials (`.get` with defaults; coerces bad types). `ServerConfig` (`:32-62`): required `name, description, keywords, install, command, args`; the rest optional with defaults (`requires_api_key=False`, `transport="local"` auto-upgraded to `streamable-http` when `url` present, etc.).
+- Precedence precedent (`config/loader.py`): `DEFAULT_USER_CONFIG_PATHS` (`:36`), `find_project_root` (`:202`, walks up for `.mcp.json`/`.git`/`package.json`/`pyproject.toml`, stops at tempdir), merge is **first-seen-wins** in order project → user → custom.
+- **Layering constraint:** `config/loader.py:613` imports `load_manifest`, so `manifest/loader.py` **must not import `config/loader`** (circular). Project-root discovery must be replicated locally (small, marker-based).
+
+## Design decisions (precedence + behavior)
+- **Overlay sources**, lowest→highest precedence (later overrides earlier, by server name):
+  1. shipped `manifest.yaml` (base)
+  2. user `~/.pmcp/manifest.yaml`
+  3. project `<project>/.pmcp/manifest.yaml` (nearest ancestor of cwd containing `.pmcp/manifest.yaml`)
+  4. `PMCP_MANIFEST_PATH` (explicit env override — **wins all**)
+  Rationale: more-specific/more-explicit wins. (Note: this makes the explicit env path *highest*, unlike `PMCP_CONFIG` which is lowest in config/loader — deliberate; documented. Flag at review if config-parity is preferred instead.)
+- **Override allowed:** an overlay entry with the same name as a shipped/earlier entry **replaces** it (whole-entry replace, not deep-merge) — simplest, predictable.
+- **Overlay applies only on the default path:** `load_manifest()` applies overlays only when called with `manifest_path is None` (all 19 callers). An explicit `manifest_path` loads just that file (preserves deterministic test/explicit behavior).
+- **Fail-soft:** a missing overlay file is skipped silently; a malformed overlay (bad YAML / OSError / bad entry) logs a `warning` naming the file and is skipped per-file, with per-entry try/except so one bad entry doesn't drop the whole file. The shipped manifest load is unchanged (its failure is a real bug, not user input). Never crashes any of the 19 callers — same robustness bar as #84.
+- `cli_alternatives` merged with the same precedence (cheap, consistent).
+
+## Changes
+
+### `src/pmcp/manifest/loader.py` (modify)
+- `DEFAULT_USER_MANIFEST_PATHS` — add — module constant `[Path.home() / ".pmcp" / "manifest.yaml"]` (mirrors `DEFAULT_USER_CONFIG_PATHS`).
+- `_find_project_manifest()` — add — walk up from `Path.cwd()` for the nearest ancestor containing `.pmcp/manifest.yaml` (stop at filesystem root and `tempfile.gettempdir()`); return that path or `None`. Replicates `find_project_root`'s walk locally to avoid the circular import; keyed directly on the `.pmcp/manifest.yaml` marker.
+- `_overlay_manifest_paths()` — add — return existing overlay file paths as `list[tuple[str, Path]]` in precedence order `[("user", ~/.pmcp/manifest.yaml), ("project", <proj>/.pmcp/manifest.yaml), ("env", $PMCP_MANIFEST_PATH)]`, filtering to files that exist.
+- `_load_overlay_file(path)` — add — fail-soft: `try` open+`yaml.safe_load`; on `OSError`/`yaml.YAMLError`/non-dict, `logger.warning` + return `({}, {})`. Parse `servers`/`cli_alternatives` per-entry, each in its own try/except (warn+skip bad entry), reusing `_parse_server_config`/`_parse_cli_alternative`. Returns `(servers_dict, cli_alts_dict)`.
+- `load_manifest(manifest_path=None)` — modify — capture `apply_overlays = manifest_path is None` BEFORE defaulting. After building the shipped `servers`/`cli_alternatives` dicts, if `apply_overlays`: for each `(label, path)` from `_overlay_manifest_paths()`, merge its servers/cli_alts over the accumulators (overlay wins by key; `logger.info` count per source). Construct `Manifest` from the merged dicts. Keep the existing explicit-path branch behavior unchanged. Update the final log line to note overlay counts when applied.
+
+### `tests/test_manifest_overlay.py` (create)
+- `test_user_overlay_adds_provisionable_server` — `monkeypatch` HOME to a tmp dir with `~/.pmcp/manifest.yaml` defining a private server with keywords; assert it appears in `load_manifest().servers` and that `_manifest_candidates_for_query`/`request_capability` keyword match surfaces it (drive via `GatewayTools` with a real `PolicyManager`, or assert `Manifest.search_by_keyword`).
+- `test_project_overrides_user_overrides_shipped` — same-named server in shipped vs user vs project tmp files; assert the project definition wins (e.g. distinct `command`).
+- `test_env_path_override_wins` — `monkeypatch.setenv("PMCP_MANIFEST_PATH", …)`; assert its entry wins over user/project.
+- `test_malformed_overlay_is_skipped` — write invalid YAML to `~/.pmcp/manifest.yaml`; assert `load_manifest()` still returns the shipped servers (non-empty) and does not raise.
+- `test_malformed_entry_skipped_rest_loaded` — overlay with one bad entry + one good; assert good one loaded, bad one skipped, no raise.
+- `test_explicit_path_skips_overlays` — call `load_manifest(tmp_manifest)` with HOME/project overlays present; assert overlays are NOT applied (only the explicit file's servers).
+
+### `README.md` (modify)
+- Add a "Private manifest overlay" subsection under `## Configuration` (near Config Discovery ~`:862`): the three overlay locations, `PMCP_MANIFEST_PATH`, precedence (project > user > shipped, env wins), a minimal example private entry (local + remote), and a security note. Cross-reference that this answers "can users add their own private manifest items."
+
+### `CHANGELOG.md` (modify)
+- Under `## [Unreleased]` `### Added`: private/custom manifest overlay (`~/.pmcp/manifest.yaml`, `<project>/.pmcp/manifest.yaml`, `PMCP_MANIFEST_PATH`) merged over the shipped manifest, fail-soft, participating in request_capability/catalog_search/provision/refresh. (Promote to `## [1.18.0]` at release.)
+
+## Documentation impact
+- `README.md` — modify — document the new overlay capability + precedence + security (above).
+- `CHANGELOG.md` — modify — Added entry for v1.18.0.
+- No other cross-cutting docs apply (no schema/openapi/AGENTS change; overlay reuses the existing `ServerConfig` schema — **no new manifest vocabulary introduced**).
+
+## Dependencies & order
+1. Constants + `_find_project_manifest` + `_overlay_manifest_paths` + `_load_overlay_file` (leaf helpers).
+2. Wire into `load_manifest` (uses 1).
+3. Tests (use 2).
+4. Docs. No external/migration dependencies.
+
+## Verification
+```bash
+cd /home/viperjuice/code/pmcp
+.venv/bin/python -m pytest tests/test_manifest_overlay.py -v
+# Guard the 19 consumers + existing manifest behavior:
+.venv/bin/python -m pytest tests/test_manifest.py tests/test_manifest_provision.py tests/test_offline_discovery.py tests/test_tools.py -q
+.venv/bin/python -m pytest -q                      # full suite (baseline 2094 passed)
+.venv/bin/python -m ruff check src/pmcp/manifest/loader.py tests/test_manifest_overlay.py
+.venv/bin/python -m ruff format --check src/pmcp/manifest/loader.py tests/test_manifest_overlay.py
+.venv/bin/python -m mypy src/pmcp/manifest/loader.py
+# Manual smoke (proves end-to-end discovery surfacing):
+mkdir -p ~/.pmcp && cat > ~/.pmcp/manifest.yaml <<'YAML'
+servers:
+  my-private:
+    description: "My private server"
+    keywords: [myprivate, internal widget]
+    command: "npx"
+    args: ["-y", "@me/my-mcp"]
+    requires_api_key: true
+    env_var: MY_TOKEN
+YAML
+.venv/bin/python -c "from pmcp.manifest.loader import load_manifest; m=load_manifest(); print('my-private' in m.servers, len(m.servers))"
+rm ~/.pmcp/manifest.yaml
+```
+Edge cases: missing overlay (silently skipped); bad YAML (warn, shipped still loads); explicit `manifest_path` ignores overlays; project discovery stops at tempdir (no infinite walk); a server present in shipped + overlay resolves to the overlay definition.
+
+## Acceptance criteria
+- [ ] A server defined only in `~/.pmcp/manifest.yaml` is present in `load_manifest().servers` and is returned by `_manifest_candidates_for_query` for a query matching its keywords (with a permissive `PolicyManager`).
+- [ ] For a same-named server, `<project>/.pmcp/manifest.yaml` wins over `~/.pmcp/manifest.yaml` which wins over the shipped entry; `PMCP_MANIFEST_PATH` wins over all.
+- [ ] A malformed overlay file causes a logged warning and `load_manifest()` still returns the full shipped server set without raising (and one bad entry doesn't drop a valid sibling).
+- [ ] `load_manifest(<explicit path>)` applies NO overlays (returns only that file's servers).
+- [ ] Full suite + ruff (lint+format) + mypy pass; the 19 call sites are unchanged.

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -733,6 +733,28 @@
       "task_summary": "Convert downstream-call timeout to inactivity (idle) timeout with absolute ceiling (#79 symptom 1a)",
       "type": "detailed",
       "updated_at": "2026-06-28T06:46:00Z"
+    },
+    {
+      "acceptance_criteria_count": 5,
+      "created_at": "2026-06-29T08:41:00Z",
+      "file": "plans/detailed-private-manifest-overlay-20260629-0841.md",
+      "handoff_ref": ".dev-skills/handoffs/claude-plan-detailed/20260629T0841Z-private-manifest-overlay.md",
+      "lifecycle": [
+        {
+          "at": "2026-06-29T08:41:00Z",
+          "by": "claude-plan-detailed",
+          "metadata": {
+            "artifact_state": "staged"
+          },
+          "transition": "planned"
+        }
+      ],
+      "owner_skill": "claude-plan-detailed",
+      "slug": "detailed-private-manifest-overlay",
+      "status": "staged",
+      "task_summary": "Private/custom MCP manifest overlay merged in load_manifest (user/project/PMCP_MANIFEST_PATH); ship v1.18.0",
+      "type": "detailed",
+      "updated_at": "2026-06-29T08:41:00Z"
     }
   ],
   "schema_version": 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.17.1"
+version = "1.18.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.17.1"
+__version__ = "1.18.0"

--- a/src/pmcp/manifest/loader.py
+++ b/src/pmcp/manifest/loader.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -13,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 Platform = Literal["mac", "wsl", "linux", "windows"]
 ServerTransport = Literal["local", "remote", "sse", "http", "streamable-http"]
+
+# Private/custom manifest overlay locations (mirrors config.loader's
+# DEFAULT_USER_CONFIG_PATHS). The user path is recomputed from Path.home() at
+# call time in _overlay_manifest_paths() so HOME monkeypatching works in tests;
+# this constant documents the default location.
+DEFAULT_USER_MANIFEST_PATHS = [Path.home() / ".pmcp" / "manifest.yaml"]
 
 
 @dataclass
@@ -355,8 +363,124 @@ def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
     )
 
 
+def _find_project_manifest() -> Path | None:
+    """Walk up from cwd for the nearest ancestor containing .pmcp/manifest.yaml.
+
+    Replicates config.loader.find_project_root's marker-based walk locally to
+    avoid a circular import (config/loader imports load_manifest). Stops at the
+    filesystem root and at the temp directory so test fixtures under tempdir do
+    not accidentally pick up an unrelated overlay.
+    """
+    try:
+        current = Path.cwd().resolve()
+    except OSError:
+        return None
+    temp_root = Path(tempfile.gettempdir()).resolve()
+
+    while current != current.parent:
+        if current == temp_root:
+            return None
+        candidate = current / ".pmcp" / "manifest.yaml"
+        if candidate.exists():
+            return candidate
+        current = current.parent
+
+    return None
+
+
+def _overlay_manifest_paths() -> list[tuple[str, Path]]:
+    """Return existing overlay manifest paths in precedence order (low → high).
+
+    Order: user (``~/.pmcp/manifest.yaml``), then project
+    (``<project>/.pmcp/manifest.yaml``), then ``$PMCP_MANIFEST_PATH``. Later
+    entries override earlier ones, so the env path wins over project, which wins
+    over user, which wins over the shipped manifest. Only files that exist are
+    returned. The user path is computed from ``Path.home()`` here (not the frozen
+    module constant) so HOME isolation in tests takes effect.
+    """
+    paths: list[tuple[str, Path]] = []
+
+    user_path = Path.home() / ".pmcp" / "manifest.yaml"
+    if user_path.exists():
+        paths.append(("user", user_path))
+
+    project_path = _find_project_manifest()
+    if project_path is not None:
+        paths.append(("project", project_path))
+
+    env_value = os.environ.get("PMCP_MANIFEST_PATH")
+    if env_value:
+        env_path = Path(env_value).expanduser()
+        if env_path.exists():
+            paths.append(("env", env_path))
+
+    return paths
+
+
+def _load_overlay_file(
+    path: Path,
+) -> tuple[dict[str, ServerConfig], dict[str, CLIAlternative]]:
+    """Parse an overlay manifest file, fail-soft.
+
+    Returns ``(servers, cli_alternatives)`` parsed from ``path``. A missing file,
+    OSError, YAML error, or non-mapping top-level document logs a warning naming
+    the file and returns empty dicts. Each server/CLI entry is parsed in its own
+    try/except so one malformed entry is skipped without dropping its siblings.
+    """
+    try:
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning(f"Skipping unreadable manifest overlay {path}: {exc}")
+        return {}, {}
+
+    if not isinstance(data, dict):
+        logger.warning(
+            f"Skipping manifest overlay {path}: top-level document is not a mapping"
+        )
+        return {}, {}
+
+    servers: dict[str, ServerConfig] = {}
+    raw_servers = data.get("servers", {})
+    if isinstance(raw_servers, dict):
+        for name, server_data in raw_servers.items():
+            try:
+                servers[name] = _parse_server_config(name, server_data)
+            except Exception as exc:
+                logger.warning(
+                    f"Skipping invalid server entry '{name}' in overlay {path}: {exc}"
+                )
+    elif raw_servers:
+        logger.warning(f"Skipping 'servers' in overlay {path}: not a mapping")
+
+    cli_alternatives: dict[str, CLIAlternative] = {}
+    raw_clis = data.get("cli_alternatives", {})
+    if isinstance(raw_clis, dict):
+        for name, cli_data in raw_clis.items():
+            try:
+                cli_alternatives[name] = _parse_cli_alternative(name, cli_data)
+            except Exception as exc:
+                logger.warning(
+                    f"Skipping invalid cli_alternative '{name}' in overlay "
+                    f"{path}: {exc}"
+                )
+    elif raw_clis:
+        logger.warning(f"Skipping 'cli_alternatives' in overlay {path}: not a mapping")
+
+    return servers, cli_alternatives
+
+
 def load_manifest(manifest_path: Path | None = None) -> Manifest:
-    """Load and parse the manifest.yaml file."""
+    """Load and parse the manifest.yaml file.
+
+    When called with no ``manifest_path`` (all internal callers), private/custom
+    overlay manifests are merged over the shipped manifest: user
+    (``~/.pmcp/manifest.yaml``) < project (``<project>/.pmcp/manifest.yaml``) <
+    ``$PMCP_MANIFEST_PATH``, each overriding the shipped entry of the same name
+    (whole-entry replace). An explicit ``manifest_path`` loads only that file
+    and applies no overlays. Overlay parsing is fail-soft and never raises.
+    """
+    apply_overlays = manifest_path is None
     if manifest_path is None:
         # Default to manifest.yaml in the same directory as this module
         manifest_path = Path(__file__).parent / "manifest.yaml"
@@ -375,6 +499,19 @@ def load_manifest(manifest_path: Path | None = None) -> Manifest:
     servers: dict[str, ServerConfig] = {}
     for name, server_data in data.get("servers", {}).items():
         servers[name] = _parse_server_config(name, server_data)
+
+    # Merge private/custom overlays over the shipped manifest (default path only).
+    if apply_overlays:
+        for label, overlay_path in _overlay_manifest_paths():
+            overlay_servers, overlay_clis = _load_overlay_file(overlay_path)
+            if overlay_servers or overlay_clis:
+                logger.info(
+                    f"Applying manifest overlay ({label}) from {overlay_path}: "
+                    f"{len(overlay_servers)} servers, "
+                    f"{len(overlay_clis)} CLI alternatives"
+                )
+            servers.update(overlay_servers)
+            cli_alternatives.update(overlay_clis)
 
     manifest = Manifest(
         version=data.get("version", "1.0"),

--- a/tests/test_manifest_overlay.py
+++ b/tests/test_manifest_overlay.py
@@ -1,0 +1,243 @@
+"""Tests for the private/custom manifest overlay in load_manifest()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pmcp.manifest.loader import load_manifest
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+
+
+@pytest.fixture(autouse=True)
+def _isolate_overlay_env(monkeypatch, tmp_path):
+    """Isolate overlay discovery: HOME → tmp, cwd → tmp, no env override.
+
+    Each test opts back in by creating the specific overlay files it needs.
+    Without this, tests could pick up a real ~/.pmcp/manifest.yaml or a
+    PMCP_MANIFEST_PATH from the developer's environment.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("PMCP_MANIFEST_PATH", raising=False)
+    # cwd defaults to a project-less dir so _find_project_manifest() returns None
+    # unless a test explicitly chdir's somewhere with a .pmcp/manifest.yaml.
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    return tmp_path
+
+
+class _StubClientManager:
+    """Minimal ClientManager stub: no servers running."""
+
+    def get_all_server_statuses(self) -> list:
+        return []
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_user_overlay_adds_provisionable_server(monkeypatch, tmp_path):
+    """A server defined only in ~/.pmcp/manifest.yaml surfaces in the manifest."""
+    _write(
+        Path.home() / ".pmcp" / "manifest.yaml",
+        """
+servers:
+  my-private:
+    description: "My private internal server"
+    keywords: [myprivatewidget, internalthing]
+    command: "npx"
+    args: ["-y", "@me/my-mcp"]
+    requires_api_key: true
+    env_var: MY_TOKEN
+""",
+    )
+
+    manifest = load_manifest()
+
+    assert "my-private" in manifest.servers
+    server = manifest.servers["my-private"]
+    assert server.command == "npx"
+    assert server.requires_api_key is True
+    assert server.env_var == "MY_TOKEN"
+
+    # Surfaces via keyword search.
+    _, matching_servers = manifest.search_by_keyword("myprivatewidget")
+    assert any(s.name == "my-private" for s in matching_servers)
+
+    # Surfaces as a provision candidate with a permissive policy.
+    gateway_tools = GatewayTools(
+        client_manager=_StubClientManager(),  # type: ignore[arg-type]
+        policy_manager=PolicyManager(),
+    )
+    candidates = gateway_tools._manifest_candidates_for_query(
+        "myprivatewidget",
+        manifest=manifest,
+        configured_servers={},
+        exclude_servers=set(),
+    )
+    assert any(c.name == "my-private" for c in candidates)
+
+
+def test_project_overrides_user_overrides_shipped(monkeypatch, tmp_path):
+    """project > user > shipped for a same-named server (whole-entry replace)."""
+    # Pick a real shipped server name so we override the base too.
+    shipped = load_manifest()
+    shipped_name = next(iter(shipped.servers))
+
+    _write(
+        Path.home() / ".pmcp" / "manifest.yaml",
+        f"""
+servers:
+  {shipped_name}:
+    description: "user override"
+    keywords: [userkw]
+    command: "user-command"
+    args: []
+""",
+    )
+
+    project_dir = tmp_path / "proj"
+    _write(
+        project_dir / ".pmcp" / "manifest.yaml",
+        f"""
+servers:
+  {shipped_name}:
+    description: "project override"
+    keywords: [projectkw]
+    command: "project-command"
+    args: []
+""",
+    )
+    monkeypatch.chdir(project_dir)
+
+    manifest = load_manifest()
+    assert manifest.servers[shipped_name].command == "project-command"
+
+    # Without the project file, the user override should win over shipped.
+    monkeypatch.chdir(tmp_path / "work")
+    manifest_user = load_manifest()
+    assert manifest_user.servers[shipped_name].command == "user-command"
+
+
+def test_env_path_override_wins(monkeypatch, tmp_path):
+    """PMCP_MANIFEST_PATH wins over user and project overlays."""
+    shipped = load_manifest()
+    shipped_name = next(iter(shipped.servers))
+
+    _write(
+        Path.home() / ".pmcp" / "manifest.yaml",
+        f"""
+servers:
+  {shipped_name}:
+    description: "user"
+    keywords: [u]
+    command: "user-command"
+    args: []
+""",
+    )
+
+    project_dir = tmp_path / "proj"
+    _write(
+        project_dir / ".pmcp" / "manifest.yaml",
+        f"""
+servers:
+  {shipped_name}:
+    description: "project"
+    keywords: [p]
+    command: "project-command"
+    args: []
+""",
+    )
+    monkeypatch.chdir(project_dir)
+
+    env_manifest = tmp_path / "env-manifest.yaml"
+    _write(
+        env_manifest,
+        f"""
+servers:
+  {shipped_name}:
+    description: "env"
+    keywords: [e]
+    command: "env-command"
+    args: []
+""",
+    )
+    monkeypatch.setenv("PMCP_MANIFEST_PATH", str(env_manifest))
+
+    manifest = load_manifest()
+    assert manifest.servers[shipped_name].command == "env-command"
+
+
+def test_malformed_overlay_is_skipped(monkeypatch, tmp_path):
+    """Malformed overlay YAML logs a warning and shipped manifest still loads."""
+    _write(
+        Path.home() / ".pmcp" / "manifest.yaml",
+        "servers: [this is not: valid: yaml: at all\n  - broken",
+    )
+
+    manifest = load_manifest()  # must not raise
+    assert len(manifest.servers) > 0  # shipped servers still present
+
+
+def test_malformed_entry_skipped_rest_loaded(monkeypatch, tmp_path):
+    """One bad entry is skipped while a valid sibling in the same file loads."""
+    _write(
+        Path.home() / ".pmcp" / "manifest.yaml",
+        """
+servers:
+  bad-entry: "this should be a mapping, not a string"
+  good-entry:
+    description: "valid"
+    keywords: [goodkw]
+    command: "good-command"
+    args: []
+""",
+    )
+
+    manifest = load_manifest()  # must not raise
+    assert "good-entry" in manifest.servers
+    assert manifest.servers["good-entry"].command == "good-command"
+    assert "bad-entry" not in manifest.servers
+
+
+def test_explicit_path_skips_overlays(monkeypatch, tmp_path):
+    """load_manifest(<explicit path>) applies no overlays even when they exist."""
+    # User overlay present — must be ignored for an explicit path.
+    _write(
+        Path.home() / ".pmcp" / "manifest.yaml",
+        """
+servers:
+  user-only:
+    description: "user"
+    keywords: [u]
+    command: "user-command"
+    args: []
+""",
+    )
+
+    explicit = tmp_path / "explicit.yaml"
+    _write(
+        explicit,
+        """
+version: "1.0"
+servers:
+  explicit-only:
+    description: "explicit"
+    keywords: [x]
+    command: "explicit-command"
+    args: []
+""",
+    )
+
+    manifest = load_manifest(explicit)
+    assert "explicit-only" in manifest.servers
+    assert "user-only" not in manifest.servers
+    assert len(manifest.servers) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.17.1"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Implements the private-manifest-overlay feature (plan: `plans/detailed-private-manifest-overlay-20260629-0841.md`) and cuts **v1.18.0**.

## What
Users who built their own MCP servers can now add **private manifest entries** without editing the shipped `manifest.yaml`. `load_manifest()` merges overlays over the shipped manifest:

```
shipped  <  ~/.pmcp/manifest.yaml (user)  <  <project>/.pmcp/manifest.yaml (project)  <  $PMCP_MANIFEST_PATH (env, wins)
```

Same-named entries are replaced whole. The merge is centralized inside `load_manifest()`, so all ~19 callers get the merged manifest with **zero call-site changes** — user servers participate first-class in `gateway.request_capability` matching, `gateway.catalog_search` `manifest_candidates`, `gateway.provision`, and `refresh` startup resolution, **policy- and auth-gated identically** to shipped entries.

## Robustness
Fail-soft per-file *and* per-entry: a missing/malformed overlay (bad YAML or one bad entry) logs a warning and is skipped — never crashes the gateway (same bar as #84). Overlays apply only on the default no-arg path; an explicit `manifest_path` loads just that file. Replicates project-root discovery locally to avoid the `config/loader` ↔ `manifest/loader` circular import.

## Tests/verification
6 new tests in `tests/test_manifest_overlay.py` (user-adds-server, project>user>shipped, env wins, malformed-file-skipped, malformed-entry-skipped, explicit-path-no-overlay). Full suite **2100 passed, 11 skipped**; ruff (lint+format) + mypy clean.

Answers the question "can users add their own private manifest items" — now: **yes**. Out of scope (separate): `register_discovered_server` persistence and the `PMCP_REGISTRY_*` remote registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)