### PR TITLE
fix: v10 code-review remediation — reconnect, auth wiring, code-exec/SSRF/DoS hardening (v1.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-07-04
+
+Remediation of the v1.18.0 code review (roadmap `specs/phase-plans-v10.md`).
+
+### Fixed
+- **Downstream servers now actually recover from failure.** A crashed stdio
+  server never came back: `_cleanup_client` cancelled the very connect task
+  driving the reconnect (a `gather()` cancelling itself → `RecursionError`).
+  `_cancel_background_tasks` now excludes the current task and `_cleanup_client`
+  cancels only the client's own read/stderr tasks. Remote (SSE/HTTP) servers now
+  auto-reconnect on an unexpected drop (parity with stdio). Failed connects no
+  longer leave a stale ERROR client or a leaked stderr reader task. Proven by a
+  real-subprocess integration test.
+- Transport DoS bounds: pre-session keepalive SSE streams are capped
+  (`PMCP_MAX_KEEPALIVE_STREAMS`, default 64) with an absolute lifetime
+  (`PMCP_KEEPALIVE_MAX_SECONDS`, default 300); POST bodies are enforced against
+  the size cap **during read** so chunked/unadvertised-length bodies can't bypass
+  it (413), with a request timeout closing slow-trickle connections.
+- Robustness: terminal task records are evicted past a cap (was unbounded);
+  `disconnect_server` re-cancels pending requests under the lifecycle lock
+  (orphaned-future window); malformed `.mcp.json` is surfaced (path + reason)
+  instead of silently disabling its servers; `find_project_root` no longer
+  resolves to `$HOME`; version-check URLs are `quote()`-escaped; the two flaky
+  monitor tests are now deterministic.
+
+### Security
+- **OAuth 2.1 resource-server auth mode and Origin/DNS-rebinding validation are
+  now reachable.** They were fully implemented and tested but never passed to the
+  running server. New CLI flags/env (`--auth-mode`, `--oauth-issuer`,
+  `--oauth-jwks-url`, `--oauth-audience`, `--required-scope`, `--allowed-origin`;
+  `PMCP_AUTH_MODE`/`PMCP_OAUTH_*`/`PMCP_ALLOWED_ORIGINS`) thread them through
+  `GatewayServer`. The Origin check now runs by default: a cross-origin browser
+  `Origin` is rejected (loopback/same-origin/allowlisted pass; no-Origin clients
+  unaffected). Host validation is opt-in when origins are configured.
+- Provisioning input validation: a discovered/registered package name is now
+  validated (rejects leading-dash flag injection, path separators, shell/URL
+  metachars) before it can reach `npx -y <name>`, and the resolved install
+  command is echoed for confirmation. `auth_connect` refuses to persist/export an
+  env var that isn't the target server's declared credential variable (hard
+  denylist for `LD_*`/`DYLD_*`/`NODE_OPTIONS`/`PATH`/`PYTHON*`), closing an
+  `LD_PRELOAD`-into-subprocess code-exec path.
+- Outbound-fetch hardening: JWKS and auth-metadata fetches no longer follow
+  redirects to internal hosts; the registry response is size-capped during a
+  streamed read (no OOM); the private registry endpoint requires `https` and
+  rejects link-local/metadata hosts; the registry cache is written atomically at
+  `0600`.
+- Local credentials: `pmcp secrets set` reads the value via prompt/`--stdin`
+  (never argv/shell history); the secret directory is created `0700`;
+  `submit_feedback` scrubs the title and all fields (not just the description)
+  before posting to a public issue.
+
+### Changed
+- Policy allow/deny matching is now **case-sensitive** (matching server-ID
+  semantics elsewhere in the gateway).
+- `pmcp status` no longer eagerly connects every server as a side effect of a
+  read-only query — it reports the lazy view by default; use `--probe` to connect.
+- Explicit `--max-concurrent-spawns` / `--rate-limit` / `--request-timeout` flags
+  now take precedence over the matching env var (previously a flag equal to the
+  default was silently overridden).
+
 ## [1.18.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,6 +167,34 @@ public auth metadata URLs. PMCP is still not an Authorization Server and does
 not provide dynamic client registration, SSO, RBAC, billing, or a complete
 multi-tenant identity service.
 
+Auth mode and OAuth resource-server parameters are configurable from the CLI or
+environment (CLI flags take precedence; env values are read only when the flag
+is unset):
+
+| Flag | Env var | Purpose |
+| --- | --- | --- |
+| `--auth-mode {none,shared-secret,resource-server}` | `PMCP_AUTH_MODE` | Select the HTTP auth mode. When unset, PMCP infers `shared-secret` if a token is present, otherwise `none`. |
+| `--oauth-issuer` | `PMCP_OAUTH_ISSUER` | Authorization Server issuer (resource-server mode). |
+| `--oauth-jwks-url` | `PMCP_OAUTH_JWKS_URL` | Public `https` JWKS URL (resource-server mode). |
+| `--oauth-audience` | `PMCP_OAUTH_AUDIENCE` | Canonical resource audience, RFC 8707 (resource-server mode). |
+| `--required-scope` (repeatable) | `PMCP_REQUIRED_SCOPES` (comma-separated) | Scopes every token must present. |
+| `--allowed-origin` (repeatable) | `PMCP_ALLOWED_ORIGINS` (comma-separated) | Browser Origins permitted on `/mcp`; also enables Host-header validation. |
+
+**Origin and Host posture (DNS-rebinding defense).** The `Origin` check runs by
+default in every auth mode, even when no `--allowed-origin` is configured: a
+request carrying a browser `Origin` header is rejected with `403` unless the
+origin is loopback, same-origin with the request `Host`, or explicitly
+allow-listed. Requests with no `Origin` header — the normal case for
+non-browser MCP clients — always pass. Configuring `--allowed-origin` (or
+`PMCP_ALLOWED_ORIGINS`) additionally turns on `Host`-header validation: the
+request `Host` must be loopback or one of the hosts derived from the configured
+origins and the gateway's own canonical resource host (`--oauth-audience` /
+protected-resource metadata URL); other Hosts get `403`. Host validation stays
+off by default so that reverse-proxy deployments that forward an arbitrary
+public `Host` keep working; if you enable it behind a proxy, make sure your
+gateway's public hostname is reachable through the configured origins or
+audience so the proxied `Host` is accepted.
+
 **Assumptions and trust model:**
 
 - PMCP binds to `127.0.0.1` by default — not safe to expose publicly without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.18.0"
+version = "1.19.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/specs/phase-plans-v10.md
+++ b/specs/phase-plans-v10.md
@@ -1,0 +1,408 @@
+# PMCP — Phase Plan v10 (Code-Review Remediation)
+
+> How to use this document: save to `specs/phase-plans-v10.md`, then run `/claude-plan-phase <ALIAS>` to produce the lane-level plan for each phase (→ `plans/phase-plan-v10-<alias>.md`), then `/claude-execute-phase <alias>` to build it.
+
+---
+
+## Context
+
+A complete five-subsystem code review of PMCP v1.18.0 (commit `1c907db`) found a well-built, defensively-written codebase (no `shell=True`, timing-safe auth, strict JWT, fail-soft parsing, 81% coverage, ruff+mypy clean) with risk concentrated in two themes: **failure-recovery paths that are thinner than the happy paths**, and **security features that are fully implemented and tested but never wired to the running server**. This roadmap remediates the verified findings without re-architecting the healthy core.
+
+The single highest-impact finding was verified by execution: **stdio auto-reconnect is broken** — killing a downstream stdio server triggers a self-referential task cancellation in `_cleanup_client` (`_cancel_background_tasks` cancels the currently-running connect task) that raises `RecursionError`, so a crashed server never recovers. Every existing reconnect test mocks the connect path, which is why it was missed. Remote (SSE/HTTP) servers never even schedule a reconnect. Recovering these paths (P1) ships first and independently.
+
+The security findings split into: **unwired defenses** (OAuth resource-server mode and Origin/DNS-rebinding validation exist and are tested but `server.py` never passes the params — P2); **agent-reachable code-exec surfaces** (an unvalidated package name reaches `npx -y <name>`; `auth_connect` stores an arbitrary env var like `LD_PRELOAD` — P3); **local credential exposure** (`secrets set` on argv, world-traversable secret dir, case-insensitive policy — P4); and **DoS/SSRF hardening** across the transport and registry HTTP paths (P5A/P5B). P6 sweeps the remaining robustness/quality items.
+
+Each phase is independently shippable as a patch/minor release (v1.18.x → v1.19.0) via the existing flow (bump `pyproject.toml`+`__init__.py`+`uv.lock`, promote CHANGELOG, tag `vX.Y.Z` → `release.yml` → PyPI).
+
+---
+
+## Assumptions (fail-loud if wrong)
+
+1. The five call-site conventions and public gateway tool schemas stay stable; fixes are internal behavior, not protocol changes (no breaking changes to `mcp__pmcp__*` tool inputs/outputs).
+2. The reconnect `RecursionError` reproduces deterministically (it did: kill a real stdio server → `_cleanup_client` → recursion) and is fixed by making task cancellation current-task-safe — not by a deeper redesign of the task registry.
+3. Native Windows remains a supported target (per pyproject classifiers); any new signal/lock/fs code keeps the existing `hasattr`/`sys.platform` guards.
+4. The manifest-overlay and provisioning trust model is "same as `.mcp.json`" (local-machine trust); hardening adds validation/warnings, not a new sandbox.
+5. `release.yml` + PyPI trusted publishing keep working; the validator runtime (`phase-loop`) is installed.
+
+---
+
+## Non-Goals
+
+- No architectural refactor of the 5386-line `handlers.py` or the 2586-line `manager.py` — targeted fixes only.
+- No new transport, no new auth backend beyond wiring the existing resource-server mode.
+- No change to manifest-overlay precedence or the private-registry opt-in model.
+- No attempt to sandbox provisioned subprocesses (out of scope; validation + confirmation only).
+- No coverage-percentage target; add tests for the fixed paths, don't chase a number.
+
+---
+
+## Cross-Cutting Principles
+
+1. **Preserve the verified strengths — never regress them:** no `shell=True`/list-argv exec only; `hmac.compare_digest`; strict JWT (`alg=none` rejected, `iss/exp/nbf/aud` required, algorithms allowlisted); `_sanitize_error` on caller-facing errors; bounded audit/feedback buffers; fail-soft manifest/registry parsing; hardened singleton lock; process-group reaping; shielded idle-timeout.
+2. **Fail-closed on security decisions.** A validation/wiring change defaults to the safe posture (reject unknown Origin, reject non-conforming package name, don't store a non-declared env var) rather than the permissive one.
+3. **Every phase ships green:** full suite passes, `ruff check` + `ruff format --check` + `mypy src/pmcp/` clean, plus a CHANGELOG entry and version bump. Run `ruff format` before pushing (CI checks `--check`).
+4. **Add a real (non-mocked) test for each recovery/security fix** — the reconnect bug proves that mocking the path under test hides the bug.
+5. **Backward compatible:** new CLI flags/env vars are additive with safe defaults; no existing invocation changes behavior except where a finding requires it (documented in CHANGELOG).
+
+---
+
+## Phase Dependency DAG
+
+```
+  P1  Reconnect & failure-path recovery (manager.py)
+   │
+   ▼
+  P6  Robustness & quality sweep            (P6 after P1)
+
+  P2  Auth / Origin wiring (server+cli+http)
+   │
+   ├──────────────► P4  Local credential hardening   (P4 after P2)
+   │
+   └──────────────► P5A DoS hardening (http.py)       (P5A after P2)
+
+  P3  Agent-reachable code-exec validation   parallel root (types+handlers)
+  P5B SSRF / registry hardening (auth+registry)  parallel root
+
+  Parallel roots (start immediately): P1, P2, P3, P5B
+  After P1: P6.   After P2: P4, P5A.
+  Critical path length = 2 phases (P2 → P4 | P5A, or P1 → P6).
+```
+
+---
+
+## Top Interface-Freeze Gates
+
+These are the narrowest contracts that unblock downstream phases. `/claude-plan-phase` concretizes each exact signature when it plans the owning phase.
+
+1. **IF-0-P1-1** — `manager.py` task-cancellation + client-lifecycle contract is finalized: `_cancel_background_tasks(...)` never cancels `asyncio.current_task()` (new default-safe behavior), and connect error-paths remove the client from `_clients` and cancel its stderr task. Consumed by **P6** (which adds `_tasks` pruning / `disconnect_server` locking on the same file).
+2. **IF-0-P2-1** — `GatewayServer.__init__` gains `auth_mode`, `resource_server_issuer`, `resource_server_jwks_url`, `resource_server_audience`, `required_scopes: list[str] | None`, `allowed_origins: list[str] | None` (all optional, safe defaults), plus the CLI flag/env names (`--auth-mode`, `--oauth-issuer`, `--oauth-jwks-url`, `--oauth-audience`, `--required-scope`, `--allowed-origin` / `PMCP_ALLOWED_ORIGINS`). Consumed by **P4** (also edits `cli.py`) and **P5A** (also edits `http.py`).
+3. **IF-0-P3-1** — a shared validation surface: `is_valid_package_name(name) -> bool` (strict npm/pypi name regex, rejects leading `-`) and `env_var_allowed_for_server(env_var, server_config) -> bool`. Consumed within **P3**; published day-1 so the handlers lane and the types/schema lane start against it.
+
+---
+
+## Phases
+
+### Phase 1 — Reconnect & failure-path recovery (P1)
+
+**Objective**
+Make downstream servers actually recover from transient failure: fix the stdio reconnect `RecursionError` self-cancel, add remote (SSE/HTTP) auto-reconnect parity, and clean up failed connects so no stale ERROR client or leaked stderr task remains.
+
+**Exit criteria**
+- [ ] A real (non-mocked) integration test kills a live stdio server subprocess and asserts the manager returns it to `ONLINE` within the reconnect backoff — the test fails on today's code (`RecursionError`) and passes after the fix.
+- [ ] `_cancel_background_tasks` never cancels `asyncio.current_task()` (unit test asserts calling it from within a tracked task does not cancel that task).
+- [ ] A dropped remote (SSE/HTTP) server schedules a reconnect (parity with stdio); test drives `_read_sse`'s finally path.
+- [ ] A connect that fails at `initialize` leaves no entry in `_clients` and no live stderr reader task (test asserts both).
+- [ ] Full suite + ruff + mypy green; CHANGELOG "Fixed" entry.
+
+**Scope notes**
+- Single-writer file: `src/pmcp/client/manager.py` — all three fixes edit it; keep them in one lane to avoid conflicts. Second lane owns `tests/` (new `test_client_manager_reconnect.py` integration + unit tests) and can start against the fix's intended behavior.
+- Lane A (`manager.py`): (1) exclude `current_task()` in `_cancel_background_tasks` and/or scope `_cleanup_client` to the old client's read/stderr tasks; (2) mirror `_read_stdout`'s `_schedule_reconnect` into `_read_sse`'s finally; (3) pop `_clients`/`_cleanup_client` + cancel the stderr task on both connect error paths.
+- Lane B (`tests/`): reuse the real stdio server at `diagnostics/issue-79-1b/slow_server.py` as the crash target.
+- Preserve process-group reaping and the shielded idle-timeout (do not touch those code paths).
+
+**Non-goals**
+- `_tasks` unbounded growth and the `disconnect_server` lock window (deferred to P6 — same file, after this lands).
+
+**Key files**
+- src/pmcp/client/manager.py
+- tests/test_client_manager*.py (new integration test)
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-P1-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/client/manager.py`, `tests/`
+- evidence paths: `plans/phase-plan-v10-p1.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 2 — Auth / Origin wiring (P2)
+
+**Objective**
+Connect the already-implemented, already-tested OAuth resource-server auth mode and Origin/Host validation to the running server so operators can actually enable them; default posture rejects cross-origin browser requests (DNS-rebinding defense).
+
+**Exit criteria**
+- [ ] `GatewayServer` + CLI accept and pass `auth_mode`, `resource_server_*`, `required_scopes`, and `allowed_origins` to `create_http_app` (test asserts a resource-server-configured server actually validates a JWT and rejects an unsigned/aud-mismatched token end-to-end).
+- [ ] With no explicit config, a cross-origin browser `Origin` header is rejected 403 on `/mcp` (test), while same-origin / no-Origin (non-browser) requests pass; `Host` is validated.
+- [ ] `pmcp --help` documents the new flags; `PMCP_ALLOWED_ORIGINS` env honored.
+- [ ] No regression to `none` / `shared-secret` modes (existing auth tests pass unchanged).
+- [ ] Full suite + ruff + mypy green; CHANGELOG "Added/Fixed" + README auth section.
+
+**Scope notes**
+- Publish IF-0-P2-1 (the `GatewayServer.__init__` signature + flag names) on day 1 so the three lanes start against the contract.
+- Lane A (`server.py` + wiring): thread params through `GatewayServer.__init__`, `run_http`, and the `create_http_app(...)` call (currently only `auth_token/rate_limit_rpm/request_timeout`).
+- Lane B (`cli.py`): add the `--auth-mode`/`--oauth-*`/`--required-scope`/`--allowed-origin` flags + env; single-writer on `cli.py` for this phase (P4 edits `cli.py` after this freeze).
+- Lane C (`http.py`): choose a safe default for `allowed_origins` (reject cross-origin browser Origins) and add `Host` validation; `http.py` single-writer for this phase (P5A edits it after).
+- Decide default-origin policy explicitly (loopback binds still need DNS-rebinding defense).
+
+**Non-goals**
+- The keepalive-stream DoS and body-size cap in `http.py` (P5A, after this).
+
+**Key files**
+- src/pmcp/server.py
+- src/pmcp/cli.py
+- src/pmcp/transport/http.py
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-P2-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/server.py`, `src/pmcp/cli.py`, `src/pmcp/transport/http.py`, `README.md`
+- evidence paths: `plans/phase-plan-v10-p2.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 3 — Agent-reachable code-exec validation (P3)
+
+**Objective**
+Close the two paths where agent/registry-supplied data reaches code execution: validate the package identifier before it becomes `npx -y <name>`, and stop `auth_connect` from storing an arbitrary process-affecting env var (`LD_PRELOAD`/`NODE_OPTIONS`/`PATH`). Also scrub all feedback fields and lock the provision handoff (same file, same security theme).
+
+**Exit criteria**
+- [ ] `register_discovered_server`/`provision` reject a package name that isn't a valid npm/pypi identifier or that starts with `-` (test: `-g`, `../evil`, `a b` rejected; `@scope/name`, `name` accepted); the exact install command is surfaced for confirmation before execution.
+- [ ] `auth_connect` refuses to write an `env_var` not declared by the target server (or not on an allowlist) — test asserts `LD_PRELOAD` is rejected, the server's declared `env_var` is accepted.
+- [ ] `submit_feedback` runs `_scrub_sensitive_text` over `title`, `failed_tool_call`, and `subordinate_server` (test asserts a secret in each is redacted before the payload is built).
+- [ ] `provision_status` guards the `server_ready → adopt_process` handoff with a per-job lock/CAS and does not re-run a full `refresh` on repeat polls of a finished job (test: two concurrent polls adopt once).
+- [ ] Full suite + ruff + mypy green; CHANGELOG "Security/Fixed".
+
+**Scope notes**
+- Publish IF-0-P3-1 (`is_valid_package_name`, `env_var_allowed_for_server`) day 1.
+- Single-writer file: `src/pmcp/tools/handlers.py` (all four items touch it) — one handlers lane; a second lane owns `src/pmcp/types.py` (add the `pattern=` to `RegisterDiscoveredServerInput.package`) + the shared validator module + `tests/`.
+- Disjoint from P1/P2/P5 files → this is a parallel root.
+
+**Non-goals**
+- Sandboxing the provisioned subprocess; the fix is validate + confirm, not isolate.
+
+**Key files**
+- src/pmcp/tools/handlers.py
+- src/pmcp/types.py
+- src/pmcp/manifest/ (validator helper, if placed there)
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-P3-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/tools/handlers.py`, `src/pmcp/types.py`
+- evidence paths: `plans/phase-plan-v10-p3.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 4 — Local credential hardening (P4)
+
+**Objective**
+Stop leaking local credentials: take `secrets set` off the argv, create the secret directory `0700`, and resolve the case-insensitive policy match. Fold in the remaining `cli.py` UX findings (status eager-connect, doctor 401 disambiguation, env-override sentinels).
+
+**Exit criteria**
+- [ ] `pmcp secrets set <key>` reads the value via `getpass`/`--stdin` (positional value optional); test asserts no value on argv.
+- [ ] The secret directory (`~/.config/pmcp` / project) is created mode `0700` (test asserts dir bits, not just the `0600` file).
+- [ ] Policy allow/deny matching is case-sensitive (or the case-insensitivity is confirmed intentional and documented) — test pins the decision.
+- [ ] `pmcp status` with no gateway does NOT eagerly connect every server (defaults to the lazy/no-connect view); a flag opts into active probing.
+- [ ] `doctor` distinguishes 401/403 ("gateway up, needs auth") from unreachable; explicit `--flag` overrides the env-override magic-number sentinels (`==8`/`==60`).
+- [ ] Full suite + ruff + mypy green; CHANGELOG.
+
+**Scope notes**
+- Lanes are file-disjoint → 3 parallel lanes: (a) `cli.py` (secrets stdin + status/doctor/sentinels), (b) `env_store.py` (0700 dir), (c) `policy.py` (case decision).
+- `cli.py` is single-writer here; depends on P2 having frozen the CLI auth-flag surface so the two `cli.py` edits don't collide.
+
+**Non-goals**
+- `secrets sync --dry-run` and other UX niceties (fold into P6 if time permits, else defer).
+
+**Key files**
+- src/pmcp/cli.py
+- src/pmcp/env_store.py
+- src/pmcp/policy/policy.py
+
+**Depends on**
+- P2
+
+**Produces**
+- (none)
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/cli.py`, `src/pmcp/env_store.py`, `src/pmcp/policy/policy.py`
+- evidence paths: `plans/phase-plan-v10-p4.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 5A — Transport DoS hardening (P5A)
+
+**Objective**
+Bound the HTTP transport's resource usage: cap and time-limit the unauthenticated pre-session keepalive SSE streams, and enforce the body-size limit against chunked/unadvertised-length POSTs.
+
+**Exit criteria**
+- [ ] Concurrent pre-session keepalive streams are capped and have an idle deadline (test: N+1th stream is rejected or the stream closes after the deadline).
+- [ ] A chunked POST exceeding the 10 MB body cap is rejected while reading (test with no/false `content-length`), not just on the header.
+- [ ] `/health` + `/metrics` exposure decision documented (optionally bindable/gated on non-loopback).
+- [ ] Full suite + ruff + mypy green; CHANGELOG.
+
+**Scope notes**
+- Decompose into 2 lanes: (a) `src/pmcp/transport/http.py` implementation (keepalive-stream cap + idle deadline + streaming body-size enforcement) as the single writer of that file, and (b) `tests/` covering both limits (disjoint file, starts against the intended behavior).
+- Depends on P2 (which also edits `http.py` for Origin/Host); take the file after that freeze.
+
+**Non-goals**
+- Rate-limiter proxy/`X-Forwarded-For` handling (LOW; fold into P6 or defer).
+
+**Key files**
+- src/pmcp/transport/http.py
+
+**Depends on**
+- P2
+
+**Produces**
+- (none)
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/transport/http.py`
+- evidence paths: `plans/phase-plan-v10-p5a.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 5B — SSRF & registry hardening (P5B)
+
+**Objective**
+Harden the outbound HTTP paths: disable redirects on JWKS/metadata fetches (SSRF), guard the registry response size during read (OOM), require https + a host allowlist for the private registry endpoint, and make the registry cache write atomic with tight perms.
+
+**Exit criteria**
+- [ ] JWKS fetch (`auth.py` aiohttp) and `fetch_json_metadata` (`auth.py` urlopen) use `allow_redirects=False` / a no-redirect opener and re-validate any target (test: a 302 to an internal host is not followed).
+- [ ] The registry client enforces the 2 MB cap during read (streamed / `Content-Length` pre-check), not after `resp.read()` (test: oversized response aborts early).
+- [ ] With `PMCP_REGISTRY_ALLOW_PRIVATE` on, a non-https or non-allowlisted `PMCP_REGISTRY_PRIVATE_ENDPOINT` is rejected (test).
+- [ ] Registry cache is written via temp + `os.replace` (atomic) with restrictive perms (test).
+- [ ] Full suite + ruff + mypy green; CHANGELOG.
+
+**Scope notes**
+- File-disjoint from all other phases → parallel root (depends on none).
+- 2 lanes: (a) `src/pmcp/auth.py` (redirect hardening), (b) `src/pmcp/manifest/registry.py` (size guard + endpoint allowlist + atomic cache).
+
+**Non-goals**
+- Version-checker URL escaping (`version_checker.py`) — grouped into P6.
+
+**Key files**
+- src/pmcp/auth.py
+- src/pmcp/manifest/registry.py
+
+**Depends on**
+- (none)
+
+**Produces**
+- (none)
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/auth.py`, `src/pmcp/manifest/registry.py`
+- evidence paths: `plans/phase-plan-v10-p5b.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 6 — Robustness & quality sweep (P6)
+
+**Objective**
+Clear the remaining MED/LOW robustness and quality findings across the manager, manifest overlay, config loader, and version checker, and de-flake the sleep-based subprocess tests.
+
+**Exit criteria**
+- [ ] `_tasks` registry evicts terminal (completed/failed/cancelled) records (TTL/LRU); `disconnect_server` inspects/cancels pending state under `_lifecycle_lock`; dead `managed.request_id` removed; `background_task` done-callback uses `pop(t, None)` (tests where practical).
+- [ ] Manifest overlay logs a prominent warning when an overlay entry shadows a shipped server by name, and `_find_project_manifest` keeps discovery within the resolved project root (no out-of-tree symlink follow).
+- [ ] Malformed `.mcp.json` parse errors are surfaced in `pmcp status` (not silently swallowed in `load_configs`); `find_project_root` does not resolve to `$HOME`.
+- [ ] Version-check URLs are `urllib.parse.quote`-escaped for pypi/cargo/docker.
+- [ ] `test_monitor_reads_stderr` and `test_monitor_keeps_last_20_lines` poll job state instead of `asyncio.sleep(0.3)` (no wall-clock race).
+- [ ] Full suite + ruff + mypy green; CHANGELOG.
+
+**Scope notes**
+- File-disjoint lanes → up to 5 parallel: (a) `manager.py` (after P1's IF-0-P1-1 — task/lifecycle stable), (b) `manifest/loader.py`, (c) `config/loader.py`, (d) `manifest/version_checker.py` + misc, (e) `tests/` de-flake.
+- Only lane (a) shares a file (`manager.py`) with a prior phase (P1) → the P1 dependency; the other lanes have no cross-phase file conflict and could technically start earlier, but are grouped here as the cleanup release.
+
+**Non-goals**
+- Any behavior change to the manifest-overlay precedence or the gateway tool schemas.
+
+**Key files**
+- src/pmcp/client/manager.py
+- src/pmcp/manifest/loader.py
+- src/pmcp/config/loader.py
+- src/pmcp/manifest/version_checker.py
+- tests/test_manifest.py
+
+**Depends on**
+- P1
+
+**Produces**
+- (none)
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/client/manager.py`, `src/pmcp/manifest/loader.py`, `src/pmcp/config/loader.py`, `src/pmcp/manifest/version_checker.py`, `tests/`
+- evidence paths: `plans/phase-plan-v10-p6.md`
+- redaction posture: `metadata_only`
+
+---
+
+## Execution Notes
+
+- **Planning**: `/claude-plan-phase <ALIAS>` per phase. Parallel roots with no shared DAG ancestor can be planned concurrently: **P1, P2, P3, P5B** all start immediately.
+- **Execution**: `/claude-execute-phase <alias>` after each plan is approved. **P4** and **P5A** unblock once **P2** merges (they take `cli.py` / `http.py` after P2's interface freeze). **P6** unblocks once **P1** merges (shared `manager.py`).
+- **Critical path**: 2 phases deep — `P2 → P4` (or `P2 → P5A`), and `P1 → P6`. With enough executors, wall-clock ≈ two phase cycles.
+- **Single-writer files across phases**: `cli.py` = P2 then P4; `http.py` = P2 then P5A; `manager.py` = P1 then P6; `handlers.py` = P3 only. Respect these owners to prevent cross-phase serialization/merge conflicts.
+- **Release cadence**: ship each phase (or a small batch) as its own tagged release. Suggested: P1 → v1.18.1 (critical fix); P2 → v1.19.0 (new auth flags); P3/P4/P5A/P5B → v1.19.x security patches; P6 → v1.19.x. Adjust to taste; the DAG, not the versioning, governs order.
+
+---
+
+## Acceptance Criteria
+
+- [ ] A killed downstream stdio server auto-recovers to ONLINE (the `RecursionError` is gone), and a dropped remote server reconnects — both proven by non-mocked integration tests.
+- [ ] An operator can enable OAuth resource-server auth and Origin validation via CLI/env and see them enforced end-to-end; the default posture rejects cross-origin browser requests.
+- [ ] An invalid/hostile package name is rejected before any `npx` execution, and `auth_connect` cannot store a non-declared process-affecting env var.
+- [ ] `secrets set` never places a credential on argv; the secret directory is `0700`.
+- [ ] Outbound JWKS/metadata/registry fetches don't follow redirects to internal hosts and can't OOM the gateway; the transport bounds keepalive streams and chunked bodies.
+- [ ] Full suite green (≥ current 2100 passing), ruff (lint+format) + mypy clean, at every phase's merge; the two known-flaky monitor tests are deterministic.
+
+## Verification
+
+```bash
+# Per phase (and at the end): the standing green bar
+cd /home/viperjuice/code/pmcp
+.venv/bin/python -m pytest -q
+.venv/bin/python -m ruff check src/ tests/ && .venv/bin/python -m ruff format --check src/ tests/
+.venv/bin/python -m mypy src/pmcp/
+
+# P1 — reconnect actually recovers (this command FAILS on today's code, PASSES after P1)
+.venv/bin/python -m pytest tests/ -k "reconnect and stdio" -v
+
+# P2 — auth/Origin are reachable and enforced
+.venv/bin/python -m pytest tests/ -k "resource_server or origin or dns_rebind" -v
+
+# P3 — code-exec surfaces validated
+.venv/bin/python -m pytest tests/ -k "package_name or auth_connect_env or feedback_scrub" -v
+
+# P4 — no secret on argv, 0700 dir
+.venv/bin/python -m pytest tests/ -k "secrets and (stdin or mode or dir)" -v
+
+# P5A/P5B — DoS + SSRF bounds
+.venv/bin/python -m pytest tests/ -k "keepalive_cap or chunked_body or redirect or registry_size" -v
+
+# End-to-end smoke: gateway still starts, health reports version, tools list
+.venv/bin/python -m pmcp --version
+```

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.18.0"
+__version__ = "1.19.0"

--- a/src/pmcp/auth.py
+++ b/src/pmcp/auth.py
@@ -10,14 +10,35 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from ipaddress import ip_address
 from typing import Any
+from urllib.error import HTTPError
 from urllib.parse import parse_qsl, quote, urlparse, urlunparse
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 import aiohttp
 import jwt
 from jwt import PyJWKSet
 
 from pmcp.types import AuthChallengeInfo, AuthMetadataInfo, UrlElicitationInfo
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Refuse HTTP redirects so a public URL cannot 3xx to an internal host."""
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> Request | None:
+        raise HTTPError(newurl, code, "Redirects are not allowed.", headers, fp)
+
+
+_NO_REDIRECT_OPENER = build_opener(_NoRedirectHandler)
+# Metadata fetches go through a no-redirect opener; tests patch this name.
+urlopen = _NO_REDIRECT_OPENER.open
 
 AUTH_SECRET_QUERY_KEYS = {
     "access_token",
@@ -221,9 +242,18 @@ class AsyncJWKS:
     async def _fetch(self) -> Mapping[str, Any]:
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get(self._raw_url) as response:
+                async with session.get(
+                    self._raw_url, allow_redirects=False
+                ) as response:
+                    if 300 <= response.status < 400:
+                        raise ResourceServerJWKSUnavailable(
+                            f"JWKS endpoint returned a redirect for {self.url}; "
+                            "refusing to follow."
+                        )
                     response.raise_for_status()
                     content = await response.content.read(self._max_bytes + 1)
+        except ResourceServerJWKSUnavailable:
+            raise
         except Exception as exc:
             raise ResourceServerJWKSUnavailable(
                 f"JWKS fetch failed for {self.url}."

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -211,21 +211,21 @@ Environment overrides:
     parser.add_argument(
         "--max-concurrent-spawns",
         type=int,
-        default=8,
+        default=None,
         help="Max simultaneous child MCP server processes to spawn (default: 8). "
         "Also read from PMCP_MAX_SPAWNS.",
     )
     parser.add_argument(
         "--rate-limit",
         type=int,
-        default=0,
+        default=None,
         help="HTTP rate limit in requests per minute per client IP on /mcp "
         "(default: 0 = unlimited). Also read from PMCP_RATE_LIMIT.",
     )
     parser.add_argument(
         "--request-timeout",
         type=int,
-        default=60,
+        default=None,
         help="HTTP request timeout in seconds (default: 60). Also read from PMCP_REQUEST_TIMEOUT.",
     )
     parser.add_argument(
@@ -369,6 +369,12 @@ Environment overrides:
         "--pending",
         action="store_true",
         help="Show pending requests",
+    )
+    status_parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="Actively connect to each configured server (default: lazy, "
+        "report servers without connecting)",
     )
     status_parser.add_argument(
         "-v",
@@ -607,7 +613,19 @@ Environment overrides:
         help="Set a secret value in PMCP env file",
     )
     secrets_set_parser.add_argument("key", type=str, help="Secret key name")
-    secrets_set_parser.add_argument("value", type=str, help="Secret value")
+    secrets_set_parser.add_argument(
+        "value",
+        type=str,
+        nargs="?",
+        default=None,
+        help="Secret value. Omit to read it from --stdin or an interactive "
+        "prompt; passing it here exposes it in 'ps aux' and shell history.",
+    )
+    secrets_set_parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read the secret value from stdin instead of passing it on argv",
+    )
     secrets_set_parser.add_argument(
         "--scope",
         choices=["user", "project"],
@@ -1223,7 +1241,15 @@ async def run_status(args: argparse.Namespace) -> None:
         return
 
     try:
-        if args.verbose:
+        if getattr(args, "probe", False):
+            logger.info(f"Connecting to {len(allowed_configs)} servers...")
+            await client_manager.connect_all(allowed_configs)
+            statuses = client_manager.get_all_server_statuses()
+            tools = client_manager.get_all_tools()
+        else:
+            # Default: lazy view. `status` is a read-only command, so it must not
+            # spawn/connect every configured server as a side effect. Use --probe
+            # to opt into active connection.
             from pmcp.types import ServerStatus
 
             statuses = [
@@ -1235,11 +1261,6 @@ async def run_status(args: argparse.Namespace) -> None:
                 for config in allowed_configs
             ]
             tools = []
-        else:
-            logger.info(f"Connecting to {len(allowed_configs)} servers...")
-            await client_manager.connect_all(allowed_configs)
-            statuses = client_manager.get_all_server_statuses()
-            tools = client_manager.get_all_tools()
         revision_id, last_refresh = client_manager.get_registry_meta()
 
         # Filter by server if specified
@@ -1809,8 +1830,12 @@ async def _probe_sse_endpoint(url: str, timeout_s: float) -> tuple[bool, str]:
         return False, sanitize_auth_diagnostic(exc)
 
 
-async def _probe_http_health(timeout_s: float) -> tuple[bool, str]:
-    """Probe gateway /health and return (ok, details)."""
+async def _probe_http_health(timeout_s: float) -> tuple[bool, str, int | None]:
+    """Probe gateway /health and return (ok, details, status_code).
+
+    status_code is the HTTP status when the gateway responded (even on an error
+    status like 401/403), or None when the gateway was unreachable.
+    """
     import httpx
 
     url = _get_gateway_health_url()
@@ -1847,11 +1872,19 @@ async def _probe_http_health(timeout_s: float) -> tuple[bool, str]:
                     parts.append(f"audit_events={len(audit_events)}")
                 if parts:
                     detail = f"{detail} ({', '.join(parts)})"
-            return True, detail
-        return False, f"{safe_url} returned HTTP {response.status_code}"
+            return True, detail, 200
+        return (
+            False,
+            f"{safe_url} returned HTTP {response.status_code}",
+            response.status_code,
+        )
     except Exception as exc:
-        return False, sanitize_auth_diagnostic(
-            f"{safe_url} unreachable ({exc.__class__.__name__}: {exc})"
+        return (
+            False,
+            sanitize_auth_diagnostic(
+                f"{safe_url} unreachable ({exc.__class__.__name__}: {exc})"
+            ),
+            None,
         )
 
 
@@ -1899,10 +1932,23 @@ async def run_doctor(args: argparse.Namespace) -> None:
     else:
         checks.append(("mode", "ok", "No active PMCP system service detected."))
 
-    http_ok, http_detail = await _probe_http_health(args.timeout)
+    probe_result = await _probe_http_health(args.timeout)
+    http_ok, http_detail = probe_result[0], probe_result[1]
+    http_status = probe_result[2] if len(probe_result) > 2 else None
     if http_ok:
         checks.append(
             ("http", "ok", f"Gateway /health reachability OK: {http_detail}.")
+        )
+    elif http_status in (401, 403):
+        checks.append(
+            (
+                "http",
+                "warn",
+                "Gateway is up but /health requires authentication "
+                f"(HTTP {http_status}): {http_detail}. The gateway is reachable; "
+                "supply credentials (PMCP_AUTH_TOKEN or the configured auth mode) "
+                "rather than restarting it.",
+            )
         )
     else:
         checks.append(
@@ -2075,19 +2121,20 @@ async def run_server(args: argparse.Namespace) -> None:
         args.auth_token = os.environ["PMCP_AUTH_TOKEN"]
         auth_token_from_cli = False
 
-    # Env overrides for new flags
-    if (
-        not getattr(args, "max_concurrent_spawns", None)
-        or args.max_concurrent_spawns == 8
-    ):
-        if os.environ.get("PMCP_MAX_SPAWNS"):
-            args.max_concurrent_spawns = int(os.environ["PMCP_MAX_SPAWNS"])
-    if not getattr(args, "rate_limit", None):
-        if os.environ.get("PMCP_RATE_LIMIT"):
-            args.rate_limit = int(os.environ["PMCP_RATE_LIMIT"])
-    if getattr(args, "request_timeout", 60) == 60:
-        if os.environ.get("PMCP_REQUEST_TIMEOUT"):
-            args.request_timeout = int(os.environ["PMCP_REQUEST_TIMEOUT"])
+    # Resolve tunables with a clear precedence: an explicitly-passed CLI flag
+    # (default=None sentinel) wins, then the environment variable, then the
+    # built-in default. Using a None sentinel instead of comparing against the
+    # default value means an explicit flag equal to the default (e.g.
+    # --request-timeout 60) still wins over the environment.
+    if getattr(args, "max_concurrent_spawns", None) is None:
+        env_spawns = os.environ.get("PMCP_MAX_SPAWNS")
+        args.max_concurrent_spawns = int(env_spawns) if env_spawns else 8
+    if getattr(args, "rate_limit", None) is None:
+        env_rate = os.environ.get("PMCP_RATE_LIMIT")
+        args.rate_limit = int(env_rate) if env_rate else 0
+    if getattr(args, "request_timeout", None) is None:
+        env_timeout = os.environ.get("PMCP_REQUEST_TIMEOUT")
+        args.request_timeout = int(env_timeout) if env_timeout else 60
 
     # Auth / Origin env fallbacks (CLI flags take precedence).
     if not getattr(args, "auth_mode", None) and os.environ.get("PMCP_AUTH_MODE"):
@@ -2290,6 +2337,32 @@ async def _call_gateway_tool(
     return payload or {}
 
 
+def _resolve_secret_set_value(args: argparse.Namespace) -> str:
+    """Resolve the value for `secrets set` without exposing it on argv.
+
+    Precedence: an explicit positional value (with a warning, since it is
+    visible in ``ps aux`` and shell history) > ``--stdin`` > interactive
+    getpass prompt. Mirrors how `auth connect` reads credentials.
+    """
+    import getpass
+
+    value = getattr(args, "value", None)
+    if value is not None:
+        print(
+            "warning: secret value passed on the command line is visible in "
+            "'ps aux' and shell history; pipe it via --stdin or omit it to be "
+            "prompted.",
+            file=sys.stderr,
+        )
+        return value
+
+    if getattr(args, "stdin", False):
+        line = sys.stdin.readline()
+        return line.rstrip("\r\n")
+
+    return getpass.getpass(f"Enter value for {args.key}: ")
+
+
 async def run_auth_connect(args: argparse.Namespace) -> None:
     """Connect auth for a server and optionally provision it."""
     import getpass
@@ -2485,6 +2558,14 @@ def main() -> None:
     load_dotenv(Path.cwd() / ".env.pmcp", override=False)
 
     args = parse_args()
+
+    # Resolve the `secrets set` value here (not in async_main) so it is never
+    # required on argv, while async_main stays a pure dispatcher over args.
+    if (
+        getattr(args, "command", None) == "secrets"
+        and getattr(args, "secrets_command", None) == "set"
+    ):
+        args.value = _resolve_secret_set_value(args)
 
     try:
         asyncio.run(async_main(args))

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -229,6 +229,52 @@ Environment overrides:
         help="HTTP request timeout in seconds (default: 60). Also read from PMCP_REQUEST_TIMEOUT.",
     )
     parser.add_argument(
+        "--auth-mode",
+        choices=["none", "shared-secret", "resource-server"],
+        default=None,
+        help="HTTP auth mode (default: inferred — shared-secret if a token is set, "
+        "else none). Also read from PMCP_AUTH_MODE.",
+    )
+    parser.add_argument(
+        "--oauth-issuer",
+        type=str,
+        default=None,
+        help="OAuth Authorization Server issuer for resource-server mode. "
+        "Also read from PMCP_OAUTH_ISSUER.",
+    )
+    parser.add_argument(
+        "--oauth-jwks-url",
+        type=str,
+        default=None,
+        help="Public https JWKS URL for resource-server mode. "
+        "Also read from PMCP_OAUTH_JWKS_URL.",
+    )
+    parser.add_argument(
+        "--oauth-audience",
+        type=str,
+        default=None,
+        help="Canonical resource audience (RFC 8707) for resource-server mode. "
+        "Also read from PMCP_OAUTH_AUDIENCE.",
+    )
+    parser.add_argument(
+        "--required-scope",
+        action="append",
+        default=None,
+        dest="required_scopes",
+        metavar="SCOPE",
+        help="Required OAuth scope for resource-server mode (repeatable). "
+        "Also read from PMCP_REQUIRED_SCOPES (comma-separated).",
+    )
+    parser.add_argument(
+        "--allowed-origin",
+        action="append",
+        default=None,
+        dest="allowed_origins",
+        metavar="ORIGIN",
+        help="Allowed browser Origin for /mcp (repeatable). Also enables Host "
+        "header validation. Also read from PMCP_ALLOWED_ORIGINS (comma-separated).",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"pmcp {importlib.metadata.version('pmcp')}",
@@ -2043,6 +2089,36 @@ async def run_server(args: argparse.Namespace) -> None:
         if os.environ.get("PMCP_REQUEST_TIMEOUT"):
             args.request_timeout = int(os.environ["PMCP_REQUEST_TIMEOUT"])
 
+    # Auth / Origin env fallbacks (CLI flags take precedence).
+    if not getattr(args, "auth_mode", None) and os.environ.get("PMCP_AUTH_MODE"):
+        args.auth_mode = os.environ["PMCP_AUTH_MODE"]
+    if not getattr(args, "oauth_issuer", None) and os.environ.get("PMCP_OAUTH_ISSUER"):
+        args.oauth_issuer = os.environ["PMCP_OAUTH_ISSUER"]
+    if not getattr(args, "oauth_jwks_url", None) and os.environ.get(
+        "PMCP_OAUTH_JWKS_URL"
+    ):
+        args.oauth_jwks_url = os.environ["PMCP_OAUTH_JWKS_URL"]
+    if not getattr(args, "oauth_audience", None) and os.environ.get(
+        "PMCP_OAUTH_AUDIENCE"
+    ):
+        args.oauth_audience = os.environ["PMCP_OAUTH_AUDIENCE"]
+    if not getattr(args, "required_scopes", None) and os.environ.get(
+        "PMCP_REQUIRED_SCOPES"
+    ):
+        args.required_scopes = [
+            s.strip()
+            for s in os.environ["PMCP_REQUIRED_SCOPES"].split(",")
+            if s.strip()
+        ]
+    if not getattr(args, "allowed_origins", None) and os.environ.get(
+        "PMCP_ALLOWED_ORIGINS"
+    ):
+        args.allowed_origins = [
+            o.strip()
+            for o in os.environ["PMCP_ALLOWED_ORIGINS"].split(",")
+            if o.strip()
+        ]
+
     # Lock directory - CLI flag takes precedence over env var
     lock_dir = getattr(args, "lock_dir", None)
     if not lock_dir and os.environ.get("PMCP_LOCK_DIR"):
@@ -2078,6 +2154,12 @@ async def run_server(args: argparse.Namespace) -> None:
         max_concurrent_spawns=getattr(args, "max_concurrent_spawns", 8),
         rate_limit_rpm=getattr(args, "rate_limit", 0),
         request_timeout=getattr(args, "request_timeout", 60),
+        auth_mode=getattr(args, "auth_mode", None),
+        resource_server_issuer=getattr(args, "oauth_issuer", None),
+        resource_server_jwks_url=getattr(args, "oauth_jwks_url", None),
+        resource_server_audience=getattr(args, "oauth_audience", None),
+        required_scopes=getattr(args, "required_scopes", None),
+        allowed_origins=getattr(args, "allowed_origins", None),
     )
 
     # Handle graceful shutdown

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -462,7 +462,6 @@ class ManagedClient:
             tool_count=0,
         )
     )
-    request_id: int = 0
     pending_requests: dict[int, PendingRequest] = field(default_factory=dict)
     read_task: asyncio.Task[None] | None = None
     # stderr reader task for stdio servers; tracked so a failed/replaced connect
@@ -505,6 +504,11 @@ class ClientManager:
         self._reconnect_tasks: dict[str, asyncio.Task[None]] = {}
         self._request_counters: dict[str, int] = {}
         self._tasks: dict[tuple[str, str], McpTaskRecord] = {}
+        # Cap on retained terminal (completed/failed/cancelled) task records.
+        # Active records are never evicted; only terminal ones are pruned oldest
+        # first once this many accumulate, so the registry can't grow unbounded
+        # between full teardowns.
+        self._max_terminal_tasks = 100
 
     async def connect_all(
         self, configs: list[ResolvedServerConfig], retry: bool = True
@@ -589,7 +593,7 @@ class ClientManager:
         self._background_tasks.add(task)
         self._background_task_servers[task] = server_name
         task.add_done_callback(self._background_tasks.discard)
-        task.add_done_callback(self._background_task_servers.pop)
+        task.add_done_callback(lambda t: self._background_task_servers.pop(t, None))
         return task
 
     async def _cancel_background_tasks(
@@ -788,6 +792,11 @@ class ClientManager:
 
         async with self._lifecycle_lock:
             managed = self._clients.get(name)
+            # Re-cancel inside the lock: requests may have been queued in the
+            # window between the pre-lock inspection above and acquiring the
+            # lock, which would otherwise leave orphaned pending futures.
+            if managed is not None and managed.pending_requests:
+                cancelled += self.cancel_pending_requests(name)
             if not managed:
                 status = self._servers.get(name)
                 if status is not None:
@@ -1026,7 +1035,27 @@ class ClientManager:
             or (existing.requestor_context if existing else None),
         )
         self._tasks[(server_name, task_info.task_id)] = record
+        self._evict_terminal_tasks()
         return record
+
+    def _evict_terminal_tasks(self) -> None:
+        """Prune oldest terminal task records past the retention cap.
+
+        Only completed/failed/cancelled records are candidates; active tasks are
+        left untouched. Eviction targets the oldest records by ``updated_at`` so
+        recently-finished tasks remain queryable.
+        """
+        terminal = [
+            (key, record)
+            for key, record in self._tasks.items()
+            if self._terminal_task(record)
+        ]
+        excess = len(terminal) - self._max_terminal_tasks
+        if excess <= 0:
+            return
+        terminal.sort(key=lambda item: (item[1].updated_at or 0.0, item[0]))
+        for key, _record in terminal[:excess]:
+            self._tasks.pop(key, None)
 
     def _terminal_task(self, task: McpTaskRecord) -> bool:
         return task.status in {"completed", "failed", "cancelled"}
@@ -1724,7 +1753,6 @@ class ClientManager:
     ) -> dict[str, Any]:
         """Send a JSON-RPC request and wait for response."""
         request_id = self._next_request_id(managed.config.name)
-        managed.request_id = request_id
         now = time.time()
 
         request = {

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -465,6 +465,9 @@ class ManagedClient:
     request_id: int = 0
     pending_requests: dict[int, PendingRequest] = field(default_factory=dict)
     read_task: asyncio.Task[None] | None = None
+    # stderr reader task for stdio servers; tracked so a failed/replaced connect
+    # can cancel it directly instead of relying on server-name-scoped cancellation.
+    stderr_task: asyncio.Task[None] | None = None
     # Remote auth headers as RESOLVED at connect time (placeholders expanded).
     # gateway.refresh compares these against freshly-resolved headers to detect
     # token rotation in the env store, which leaves the raw config unchanged.
@@ -595,7 +598,14 @@ class ClientManager:
         server_name: str | None = None,
         exclude: set[asyncio.Task[Any]] | None = None,
     ) -> None:
-        exclude = exclude or set()
+        # Copy so we never mutate a caller's set, and always exclude the running
+        # task: a connect/reconnect task scoped to this server name must never
+        # cancel a gather() containing itself (that self-cancel recurses until
+        # RecursionError and leaves the server stuck in ERROR).
+        exclude = set(exclude) if exclude else set()
+        current = asyncio.current_task()
+        if current is not None:
+            exclude.add(current)
         tasks = [
             task
             for task in self._background_tasks
@@ -1264,7 +1274,7 @@ class ClientManager:
 
         # Start reading stderr in background
         if process.stderr:
-            self._track_background_task(
+            managed.stderr_task = self._track_background_task(
                 asyncio.create_task(self._read_stderr(name, process.stderr)),
                 name,
             )
@@ -1298,13 +1308,18 @@ class ClientManager:
         except Exception as e:
             status.status = ServerStatusEnum.ERROR
             status.last_error = str(e)
-            if managed.read_task and not managed.read_task.done():
-                managed.read_task.cancel()
-                try:
-                    await asyncio.shield(managed.read_task)
-                except (asyncio.CancelledError, Exception):
-                    pass
+            for task in (managed.read_task, managed.stderr_task):
+                if task and not task.done():
+                    task.cancel()
+                    try:
+                        await asyncio.shield(task)
+                    except (asyncio.CancelledError, Exception):
+                        pass
             await _terminate_process_tree(process, name)
+            # Drop the stale ERROR client so it can't be found as a live
+            # connection on the next connect attempt (issue: stale entry + leak).
+            if self._clients.get(name) is managed:
+                self._clients.pop(name, None)
             raise
 
     async def _connect_sse(self, config: ResolvedServerConfig) -> None:
@@ -1409,7 +1424,17 @@ class ClientManager:
         except Exception as e:
             status.status = ServerStatusEnum.ERROR
             status.last_error = str(e)
+            if managed.read_task and not managed.read_task.done():
+                managed.read_task.cancel()
+                try:
+                    await asyncio.shield(managed.read_task)
+                except (asyncio.CancelledError, Exception):
+                    pass
             await remote_stack.aclose()
+            # Drop the stale ERROR client so it can't be found as a live
+            # connection on the next connect attempt.
+            if self._clients.get(name) is managed:
+                self._clients.pop(name, None)
             raise
 
     async def _read_stderr(self, name: str, stderr: asyncio.StreamReader) -> None:
@@ -1674,6 +1699,10 @@ class ClientManager:
                 logger.warning(f"Server {name} disconnected unexpectedly")
                 managed.status.status = ServerStatusEnum.ERROR
                 managed.status.last_error = "SSE connection closed"
+                # Schedule auto-reconnect if we have the config (storm guard: only one task)
+                if managed.config is not None and not managed.reconnecting:
+                    managed.reconnecting = True
+                    self._schedule_reconnect(name, managed.config)
             else:
                 logger.debug(f"Server {name} disconnected (graceful shutdown)")
 
@@ -1931,14 +1960,20 @@ class ClientManager:
 
         Safe to call on any managed client regardless of state. All exceptions are
         suppressed so callers always complete successfully.
+
+        Cancels only *this* client's own read/stderr tasks — not every background
+        task scoped to the server name. A reconnect runs its connect inside a task
+        that is itself scoped to the name; a server-name-wide cancel here would
+        cancel the in-flight reconnect (cascading into the running connect task)
+        and abort the very recovery that called us.
         """
-        if managed.read_task and not managed.read_task.done():
-            managed.read_task.cancel()
-            try:
-                await asyncio.shield(managed.read_task)
-            except (asyncio.CancelledError, Exception):
-                pass
-        await self._cancel_background_tasks(server_name=name)
+        for task in (managed.read_task, managed.stderr_task):
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await asyncio.shield(task)
+                except (asyncio.CancelledError, Exception):
+                    pass
         await _terminate_process_tree(managed.process, name)
         self._clients.pop(name, None)
         self._servers.pop(name, None)
@@ -1997,7 +2032,7 @@ class ClientManager:
 
         # Start reading stderr in background (if available)
         if process.stderr:
-            self._track_background_task(
+            managed.stderr_task = self._track_background_task(
                 asyncio.create_task(self._read_stderr(name, process.stderr)),
                 name,
             )

--- a/src/pmcp/config/loader.py
+++ b/src/pmcp/config/loader.py
@@ -203,9 +203,14 @@ def find_project_root(start_dir: Path) -> Path | None:
     """Find project root by looking for .mcp.json or common project markers."""
     current = start_dir.resolve()
     temp_root = Path(tempfile.gettempdir()).resolve()
+    home_root = Path.home().resolve()
 
     while current != current.parent:
         if current == temp_root:
+            return None
+        # $HOME is already covered by the user config source; treating it as a
+        # project root would double-attribute ~/.mcp.json (project + user).
+        if current == home_root:
             return None
         # Check for .mcp.json
         if (current / ".mcp.json").exists():
@@ -291,6 +296,27 @@ def _read_config_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     if not isinstance(data, dict):
         return None, "config_root_not_object"
     return data, None
+
+
+def _parse_config_or_warn(path: Path) -> McpConfigFile | None:
+    """Parse a config file, surfacing a WARNING when it exists but is malformed.
+
+    ``parse_json_file`` returns ``None`` both for a missing file and for a
+    malformed one, so on the hot ``load_configs`` path a broken ``.mcp.json``
+    would silently disable all of its servers. This wrapper keeps startup
+    fail-soft while logging the path and reason at WARNING so ``pmcp status``
+    and operators can see that the file's servers were dropped.
+    """
+    if not path.exists():
+        return None
+    config = parse_json_file(path)
+    if config is None:
+        _raw, error = _read_config_object(path)
+        logger.warning(
+            f"Ignoring malformed config {path} "
+            f"({error or 'invalid_mcp_config'}); its servers are disabled"
+        )
+    return config
 
 
 def load_config_sources(
@@ -638,7 +664,7 @@ def load_configs(
     resolved_project_root = project_root or find_project_root(Path.cwd())
     if resolved_project_root:
         project_config_path = resolved_project_root / ".mcp.json"
-        project_config = parse_json_file(project_config_path)
+        project_config = _parse_config_or_warn(project_config_path)
 
         if project_config and project_config.mcpServers:
             logger.info(f"Loaded project config from {project_config_path}")
@@ -661,7 +687,7 @@ def load_configs(
         else DEFAULT_USER_CONFIG_PATHS
     )
     for user_path in user_paths:
-        user_config = parse_json_file(user_path)
+        user_config = _parse_config_or_warn(user_path)
 
         if user_config and user_config.mcpServers:
             logger.info(f"Loaded user config from {user_path}")
@@ -689,7 +715,7 @@ def load_configs(
             resolved_custom_path = Path(env_path)
 
     if resolved_custom_path:
-        custom_config = parse_json_file(resolved_custom_path)
+        custom_config = _parse_config_or_warn(resolved_custom_path)
 
         if custom_config and custom_config.mcpServers:
             logger.info(f"Loaded custom config from {resolved_custom_path}")

--- a/src/pmcp/env_store.py
+++ b/src/pmcp/env_store.py
@@ -86,7 +86,17 @@ def write_env_file(path: Path, values: dict[str, str]) -> None:
     if content:
         content += "\n"
 
-    path.parent.mkdir(parents=True, exist_ok=True)
+    # Tighten only directories PMCP itself creates (e.g. ~/.config/pmcp for
+    # user-scope secrets) to 0700. Never chmod a pre-existing directory such as
+    # a project root, which for project-scope secrets is path.parent.
+    parent = path.parent
+    parent_created = not parent.exists()
+    parent.mkdir(parents=True, exist_ok=True)
+    if parent_created:
+        try:
+            os.chmod(parent, 0o700)
+        except OSError:
+            pass
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     os.fchmod(fd, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as env_file:

--- a/src/pmcp/manifest/loader.py
+++ b/src/pmcp/manifest/loader.py
@@ -382,7 +382,15 @@ def _find_project_manifest() -> Path | None:
             return None
         candidate = current / ".pmcp" / "manifest.yaml"
         if candidate.exists():
-            return candidate
+            # Don't follow an overlay that a symlink points outside this tree:
+            # resolve the candidate and require it to stay within the ancestor
+            # directory that contains it.
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                resolved = None
+            if resolved is not None and resolved.is_relative_to(current):
+                return candidate
         current = current.parent
 
     return None
@@ -510,6 +518,12 @@ def load_manifest(manifest_path: Path | None = None) -> Manifest:
                     f"{len(overlay_servers)} servers, "
                     f"{len(overlay_clis)} CLI alternatives"
                 )
+            for name in overlay_servers:
+                if name in servers:
+                    logger.warning(
+                        f"Manifest overlay ({label}) from {overlay_path} overrides "
+                        f"existing server '{name}'"
+                    )
             servers.update(overlay_servers)
             cli_alternatives.update(overlay_clis)
 

--- a/src/pmcp/manifest/registry.py
+++ b/src/pmcp/manifest/registry.py
@@ -6,11 +6,14 @@ import asyncio
 import json
 import logging
 import os
+import tempfile
 import time
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -125,16 +128,60 @@ def registry_private_enabled() -> bool:
     }
 
 
+def _is_loopback_endpoint_host(hostname: str) -> bool:
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _private_endpoint_allowed(endpoint: str) -> bool:
+    """Validate a private registry endpoint before trusting it.
+
+    Requires ``https://`` (``http://`` only for loopback dev hosts) and rejects
+    link-local / metadata hosts such as 169.254.169.254 even over TLS.
+    """
+    try:
+        parsed = urlparse(endpoint)
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    if not parsed.scheme or not parsed.netloc or not hostname:
+        return False
+    try:
+        address = ip_address(hostname)
+    except ValueError:
+        address = None
+    if address is not None and (
+        address.is_link_local or address.is_multicast or address.is_unspecified
+    ):
+        return False
+    if parsed.scheme == "https":
+        return True
+    return parsed.scheme == "http" and _is_loopback_endpoint_host(hostname)
+
+
 def effective_registry_endpoint(default: str = DEFAULT_REGISTRY_ENDPOINT) -> str:
     """Return the configured private registry endpoint only when opt-in is on.
 
     Flag off (default): the configured private endpoint is ignored and the
-    public registry endpoint is used.
+    public registry endpoint is used. When on, the endpoint must be a valid
+    https:// (or loopback http://) URL that does not target a link-local or
+    metadata host; otherwise it is rejected and the public endpoint is used.
     """
     if registry_private_enabled():
         private = os.environ.get(REGISTRY_PRIVATE_ENDPOINT_ENV, "").strip()
         if private:
-            return private
+            if _private_endpoint_allowed(private):
+                return private
+            logger.warning(
+                "Ignoring %s: private registry endpoint must be https:// "
+                "(or http://localhost) and must not target a link-local or "
+                "metadata host.",
+                REGISTRY_PRIVATE_ENDPOINT_ENV,
+            )
     return default
 
 
@@ -367,6 +414,27 @@ def _dedupe_latest(servers: list[RegistryServerEntry]) -> list[RegistryServerEnt
     return list(deduped.values())
 
 
+async def _read_body_capped(
+    resp: aiohttp.ClientResponse, max_bytes: int
+) -> bytes | None:
+    """Read a response body while enforcing ``max_bytes`` during the read.
+
+    Returns None (without ever buffering the whole body) when the advertised
+    or streamed size exceeds the cap, so a multi-GB response cannot OOM us.
+    """
+    content_length = resp.content_length
+    if content_length is not None and content_length > max_bytes:
+        return None
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in resp.content.iter_chunked(65536):
+        total += len(chunk)
+        if total > max_bytes:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def _with_query(endpoint: str, params: dict[str, str]) -> str:
     from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -402,8 +470,8 @@ async def _fetch_registry_servers_uncached(
                     else current_endpoint
                 )
                 async with session.get(url) as resp:
-                    body = await resp.read()
-                if len(body) > max_response_bytes:
+                    body = await _read_body_capped(resp, max_response_bytes)
+                if body is None:
                     diagnostics.append("registry_response_size_cap")
                     break
                 payload = json.loads(body.decode("utf-8"))
@@ -589,7 +657,25 @@ def load_registry_cache(cache_path: Path | None = None) -> RegistryCache | None:
 
 
 def save_registry_cache(cache: RegistryCache, cache_path: Path | None = None) -> None:
-    """Save registry cache JSON with stable ordering."""
+    """Save registry cache JSON atomically with owner-only (0600) permissions.
+
+    The payload is written to a temp file in the same directory then atomically
+    ``os.replace``d into place, so a crash mid-write cannot corrupt the cache.
+    """
     path = _cache_path(cache_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(asdict(cache), indent=2, sort_keys=True) + "\n")
+    payload = json.dumps(asdict(cache), indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        os.chmod(tmp_name, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import re
 from typing import Literal
+from urllib.parse import quote
 
 import aiohttp
 
@@ -46,11 +47,9 @@ async def get_npm_version(package_name: str, timeout: float = 10.0) -> str | Non
     if cache_key in _version_cache:
         return _version_cache[cache_key]
 
-    # Handle scoped packages (@org/pkg)
-    if package_name.startswith("@"):
-        url = f"https://registry.npmjs.org/{package_name.replace('@', '%40').replace('/', '%2F')}"
-    else:
-        url = f"https://registry.npmjs.org/{package_name}"
+    # Handle scoped packages (@org/pkg): escape the whole name segment
+    # (@ -> %40, / -> %2F) so it is a single path component.
+    url = f"https://registry.npmjs.org/{quote(package_name, safe='')}"
 
     try:
         async with aiohttp.ClientSession() as session:
@@ -92,7 +91,7 @@ async def get_pypi_version(package_name: str, timeout: float = 10.0) -> str | No
     if cache_key in _version_cache:
         return _version_cache[cache_key]
 
-    url = f"https://pypi.org/pypi/{package_name}/json"
+    url = f"https://pypi.org/pypi/{quote(package_name, safe='')}/json"
 
     try:
         async with aiohttp.ClientSession() as session:
@@ -134,7 +133,7 @@ async def get_cargo_version(crate_name: str, timeout: float = 10.0) -> str | Non
     if cache_key in _version_cache:
         return _version_cache[cache_key]
 
-    url = f"https://crates.io/api/v1/crates/{crate_name}"
+    url = f"https://crates.io/api/v1/crates/{quote(crate_name, safe='')}"
 
     try:
         async with aiohttp.ClientSession(
@@ -184,7 +183,8 @@ async def get_docker_version(image_name: str, timeout: float = 10.0) -> str | No
     else:
         repo_path = f"library/{image_name}"
 
-    url = f"https://hub.docker.com/v2/repositories/{repo_path}/tags/latest"
+    # Keep "/" unescaped: org/name is a two-segment path on Docker Hub.
+    url = f"https://hub.docker.com/v2/repositories/{quote(repo_path, safe='/')}/tags/latest"
 
     try:
         async with aiohttp.ClientSession() as session:

--- a/src/pmcp/policy/policy.py
+++ b/src/pmcp/policy/policy.py
@@ -83,8 +83,15 @@ class PolicyManager:
                 logger.warning(f"Invalid redaction pattern '{pattern}': {e}")
 
     def _matches_any(self, value: str, patterns: list[str]) -> bool:
-        """Check if value matches any glob pattern."""
-        return any(fnmatch.fnmatch(value.lower(), p.lower()) for p in patterns)
+        """Check if value matches any glob pattern.
+
+        Matching is case-SENSITIVE: server/tool/resource/prompt IDs are treated
+        as case-sensitive everywhere else in the gateway, so an allow/deny glob
+        must match the exact case (e.g. a deny of ``Secret*`` does not match
+        ``secretserver``). ``fnmatchcase`` is used instead of ``fnmatch`` so the
+        behavior is stable across case-insensitive host filesystems.
+        """
+        return any(fnmatch.fnmatchcase(value, p) for p in patterns)
 
     def is_server_allowed(self, server_name: str) -> bool:
         """Check if server is allowed by policy."""

--- a/src/pmcp/server.py
+++ b/src/pmcp/server.py
@@ -9,7 +9,7 @@ import os
 import signal
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server import Server
 from mcp.types import (
@@ -72,6 +72,12 @@ class GatewayServer:
         max_concurrent_spawns: int = 8,
         rate_limit_rpm: int = 0,
         request_timeout: int = 60,
+        auth_mode: Literal["none", "shared-secret", "resource-server"] | None = None,
+        resource_server_issuer: str | None = None,
+        resource_server_jwks_url: str | None = None,
+        resource_server_audience: str | None = None,
+        required_scopes: list[str] | None = None,
+        allowed_origins: list[str] | None = None,
     ) -> None:
         self._project_root = project_root
         self._custom_config_path = custom_config_path
@@ -82,6 +88,12 @@ class GatewayServer:
         self._max_concurrent_spawns = max_concurrent_spawns
         self._rate_limit_rpm = rate_limit_rpm
         self._request_timeout = request_timeout
+        self._auth_mode = auth_mode
+        self._resource_server_issuer = resource_server_issuer
+        self._resource_server_jwks_url = resource_server_jwks_url
+        self._resource_server_audience = resource_server_audience
+        self._required_scopes = required_scopes
+        self._allowed_origins = allowed_origins
         # Lock directory - None means use global default (~/.pmcp)
         self._lock_dir: Path | None = Path(lock_dir) if lock_dir else None
 
@@ -610,8 +622,14 @@ class GatewayServer:
             app = create_http_app(
                 self._server,
                 auth_token=self._auth_token,
+                auth_mode=self._auth_mode,
                 rate_limit_rpm=self._rate_limit_rpm,
                 request_timeout=self._request_timeout,
+                resource_server_issuer=self._resource_server_issuer,
+                resource_server_jwks_url=self._resource_server_jwks_url,
+                resource_server_audience=self._resource_server_audience,
+                required_scopes=self._required_scopes,
+                allowed_origins=self._allowed_origins,
             )
             logger.info(
                 f"MCP Gateway server started (http://{self._host}:{self._port})"

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -47,6 +47,7 @@ from pmcp.config.loader import (
 )
 from pmcp.errors import ErrorCode, GatewayException, make_error
 from pmcp.env_store import set_env_value
+from pmcp.validation import env_var_allowed, is_valid_package_name
 from pmcp.identity import filter_self_references
 from pmcp.manifest.code_patterns_loader import get_code_hint
 from pmcp.manifest.environment import CLIInfo, detect_platform, probe_clis
@@ -898,6 +899,11 @@ class GatewayTools:
         self._detected_cli_infos: dict[str, CLIInfo] = {}
         self._platform: str | None = None
         self._discovered_server_configs: dict[str, ServerConfig] = {}
+        # provision_status finalization is one-shot per job: the per-job lock
+        # serializes the server_ready→adopt handoff (and the complete→refresh)
+        # so concurrent polls cannot double-adopt or re-refresh a finished job.
+        self._provision_finalize_locks: dict[str, asyncio.Lock] = {}
+        self._provision_finalized: set[str] = set()
         self._stale_check_cache: dict[str, tuple[float, str | None, str | None]] = {}
         self._stale_check_ttl_seconds = 6 * 60 * 60
         self._stale_index_interval_seconds = 60 * 60  # Re-index every hour
@@ -3386,13 +3392,25 @@ class GatewayTools:
             },
             indent=2,
         )
-        subordinate = parsed.subordinate_server or "unknown"
-        failed_call = parsed.failed_tool_call or "unknown"
+        # All caller-supplied fields land in a potentially public GitHub issue,
+        # so scrub each the same way as the description — not just description.
+        subordinate = (
+            self._scrub_sensitive_text(parsed.subordinate_server)
+            if parsed.subordinate_server
+            else "unknown"
+        )
+        failed_call = (
+            self._scrub_sensitive_text(parsed.failed_tool_call)
+            if parsed.failed_tool_call
+            else "unknown"
+        )
 
         title_prefix = (
             "[Feedback][Bug]" if parsed.issue_type == "bug" else "[Feedback][Feature]"
         )
-        issue_title = f"{title_prefix} {parsed.title.strip()}"
+        issue_title = (
+            f"{title_prefix} {self._scrub_sensitive_text(parsed.title.strip())}"
+        )
         issue_title = issue_title[:160]
 
         body = (
@@ -4300,7 +4318,17 @@ class GatewayTools:
 
         manifest = load_manifest()
         server_config = manifest.get_server(server_name)
-        env_var = parsed.env_var or (server_config.env_var if server_config else None)
+        # Resolve the server's declared credential variable from both the
+        # manifest and the discovered-server registry: discovered servers
+        # (register_discovered_server) never land in the manifest, so relying on
+        # manifest.get_server alone would break their register→auth→provision
+        # flow.
+        declared_env_var = server_config.env_var if server_config else None
+        if declared_env_var is None:
+            discovered = self._discovered_server_configs.get(server_name)
+            if discovered is not None:
+                declared_env_var = discovered.env_var
+        env_var = parsed.env_var or declared_env_var
 
         if not env_var:
             self._audit(
@@ -4321,6 +4349,34 @@ class GatewayTools:
                     "Pass env_var explicitly or add auth metadata to manifest."
                 ),
                 auth_state="missing_auth",
+            )
+
+        # A caller-chosen env var is written into process env and the persistent
+        # .env, then inherited by the next provisioned subprocess. Only the
+        # server's declared credential variable (or a credential-shaped name when
+        # none is declared) is permitted; loader-influencing variables such as
+        # LD_PRELOAD / NODE_OPTIONS / PATH / PYTHON* are refused outright.
+        if not env_var_allowed(env_var, declared_env_var):
+            self._audit(
+                method="gateway.auth_connect",
+                action="auth_connect",
+                outcome="refused",
+                started_at=audit_started_at,
+                server_name=server_name,
+                auth_state="missing_auth",
+                auth_event="policy_denied",
+                error=f"Env var '{env_var}' is not permitted for this server.",
+            )
+            expected = f" Expected '{declared_env_var}'." if declared_env_var else ""
+            return AuthConnectOutput(
+                ok=False,
+                server=server_name,
+                message=(
+                    f"Env var '{env_var}' is not permitted for server "
+                    f"'{server_name}'.{expected} Refusing to store it."
+                ),
+                auth_state="missing_auth",
+                env_var=env_var,
             )
 
         try:
@@ -4725,6 +4781,22 @@ class GatewayTools:
         server_name = parsed.server_name
         package = parsed.package
 
+        # Defense in depth: the pydantic field validator already rejects unsafe
+        # identifiers, but re-check here before the package is baked into an
+        # install command that gateway.provision will exec as list-argv.
+        if not is_valid_package_name(package):
+            return RegisterDiscoveredServerOutput(
+                ok=False,
+                server_name=server_name,
+                registered=False,
+                message=(
+                    f"Refused to register '{server_name}': "
+                    f"unsafe package identifier {package!r}."
+                ),
+            )
+
+        install_command = ["npx", "-y", package]
+
         requires_api_key = len(parsed.env_vars) > 0
         # Primary env var used for availability checks and auth_connect prompt
         env_var = parsed.env_vars[0] if parsed.env_vars else None
@@ -4743,10 +4815,10 @@ class GatewayTools:
             description=parsed.description or f"Discovered MCP package: {package}",
             keywords=["mcp", "discovered", server_name, package],
             install={
-                "mac": ["npx", "-y", package],
-                "linux": ["npx", "-y", package],
-                "wsl": ["npx", "-y", package],
-                "windows": ["npx", "-y", package],
+                "mac": list(install_command),
+                "linux": list(install_command),
+                "wsl": list(install_command),
+                "windows": list(install_command),
             },
             command="npx",
             args=["-y", package],
@@ -4771,8 +4843,10 @@ class GatewayTools:
             registered=True,
             message=(
                 f"Registered '{server_name}' (package: {package}). "
+                f"gateway.provision will run: {' '.join(install_command)}. "
                 "Call gateway.provision to install and start it."
             ),
+            install_command=install_command,
             next_step=f"gateway.provision(server_name='{server_name}')",
         )
 
@@ -4808,153 +4882,27 @@ class GatewayTools:
                 f"provision_status: job={job_id} status={job_status} progress={job_progress}"
             )
 
-            # If server_ready, perform handoff to ClientManager
-            if job_status == "server_ready":
-                process = job.process
-                if not process or process.returncode is not None:
-                    # Process died before handoff
-                    job.status = "failed"
-                    job.error = "Server process exited before handoff"
-                    return ProvisionJobStatus(
-                        job_id=job_id,
-                        server=job_server_name,
-                        status="failed",
-                        progress=job_progress,
-                        message=f"Server process for '{job_server_name}' exited unexpectedly",
-                        output_tail=job_output_lines[-5:],
-                        elapsed_seconds=elapsed,
-                        error="Process exited before handoff",
-                    )
-
-                try:
-                    # Build config from manifest
-                    manifest = load_manifest()
-                    server_config = manifest.get_server(job_server_name)
-                    if not server_config:
-                        raise ValueError(
-                            f"Server '{job_server_name}' not found in manifest"
-                        )
-
-                    resolved_config = manifest_server_to_config(server_config)
-
-                    # Adopt the process into ClientManager
-                    await self._client_manager.adopt_process(
-                        job_server_name, process, resolved_config
-                    )
-
-                    # Mark job complete and clear process reference
-                    job.status = "complete"
-                    job.process = None
-
-                    # Persist to provisioned registry so refresh() can reconnect it
-                    env_var = server_config.env_var if server_config else None
-                    self._register_provisioned_server(job_server_name, env_var)
-
-                    # Get the new tools
-                    tools = [
-                        t
-                        for t in self._client_manager.get_all_tools()
-                        if t.server_name == job_server_name
-                    ]
-
-                    return ProvisionJobStatus(
-                        job_id=job_id,
-                        server=job_server_name,
-                        status="complete",
-                        progress=100,
-                        message=f"Server '{job_server_name}' installed and connected with {len(tools)} tools.",
-                        output_tail=job_output_lines[-5:],
-                        elapsed_seconds=elapsed,
-                        new_tools=[
-                            CapabilityCard(
-                                tool_id=t.tool_id,
-                                server=t.server_name,
-                                tool_name=t.tool_name,
-                                short_description=t.short_description,
-                                tags=t.tags,
-                                availability="online",
-                                risk_hint=t.risk_hint.value,
-                            )
-                            for t in tools[:10]
-                        ]
-                        if tools
-                        else None,
-                    )
-
-                except Exception as e:
-                    logger.error(
-                        f"Handoff failed for {job_server_name}: {e}", exc_info=True
-                    )
-                    job.status = "failed"
-                    job.error = f"Handoff failed: {e}"
-                    # Kill the orphaned process
-                    if process and process.returncode is None:
-                        try:
-                            process.kill()
-                        except Exception:
-                            pass
-                    job.process = None
-
-                    return ProvisionJobStatus(
-                        job_id=job_id,
-                        server=job_server_name,
-                        status="failed",
-                        progress=job_progress,
-                        message=f"Failed to connect to '{job_server_name}': {self._sanitize_error(e)}",
-                        output_tail=job_output_lines[-5:],
-                        elapsed_seconds=elapsed,
-                        error=self._sanitize_error(e),
-                    )
-
-            # If complete (from non-npx install), trigger refresh to connect the server
-            if job_status == "complete":
-                tools = []
-                refresh_error = None
-
-                try:
-                    await self.refresh({"reason": f"Provisioned {job_server_name}"})
-                    # Get the new tools
-                    tools = [
-                        t
-                        for t in self._client_manager.get_all_tools()
-                        if t.server_name == job_server_name
-                    ]
-                except Exception as e:
-                    logger.error(f"Failed to refresh after install: {e}")
-                    refresh_error = self._sanitize_error(e)
-
-                message = f"Server '{job_server_name}' installed"
-                if tools:
-                    message += f" and connected with {len(tools)} tools."
-                elif refresh_error:
-                    message += f" but refresh failed: {refresh_error}"
-                else:
-                    message += " but no tools found. Try gateway.refresh manually."
-
-                return ProvisionJobStatus(
-                    job_id=job_id,
-                    server=job_server_name,
-                    status="complete",
-                    progress=100,
-                    message=message,
-                    output_tail=job_output_lines[-5:],
-                    elapsed_seconds=elapsed,
-                    new_tools=[
-                        CapabilityCard(
-                            tool_id=t.tool_id,
-                            server=t.server_name,
-                            tool_name=t.tool_name,
-                            short_description=t.short_description,
-                            tags=t.tags,
-                            availability="online",
-                            risk_hint=t.risk_hint.value,
-                        )
-                        for t in tools[:10]
-                    ]
-                    if tools
-                    else None,
-                    error=refresh_error,
+            # server_ready → adopt the process; complete (non-npx) → refresh.
+            # Both are one-shot per job: serialize on a per-job lock and re-read
+            # the live status inside it so two concurrent polls cannot
+            # double-adopt or re-refresh a job another poll already finalized.
+            if job_status in ("server_ready", "complete"):
+                finalize_lock = self._provision_finalize_locks.setdefault(
+                    job_id, asyncio.Lock()
                 )
+                async with finalize_lock:
+                    if job_id in self._provision_finalized:
+                        return self._build_finalized_status(job, job_id, elapsed)
+                    live_status = job.status
+                    if live_status == "server_ready":
+                        return await self._finalize_server_ready(job, job_id, elapsed)
+                    if live_status == "complete":
+                        return await self._finalize_complete(job, job_id, elapsed)
+                    # Live status changed under us (e.g. failed); fall through
+                    # and report it below using refreshed snapshots.
+                    job_status = live_status
+                    job_progress = job.progress
+                    job_error = job.error
 
             # For other statuses, return current state
             status_messages = {
@@ -4987,6 +4935,209 @@ class GatewayTools:
                 message=f"Error checking status: {self._sanitize_error(e)}",
                 error=self._sanitize_error(e),
             )
+
+    async def _finalize_server_ready(
+        self, job: Any, job_id: str, elapsed: float
+    ) -> ProvisionJobStatus:
+        """Adopt a server_ready job's process into ClientManager exactly once.
+
+        The caller must hold the job's finalize lock and have confirmed the job
+        is not already finalized.
+        """
+        job_server_name = job.server_name
+        job_progress = job.progress
+        job_output_lines = list(job.output_lines)
+
+        process = job.process
+        if not process or process.returncode is not None:
+            # Process died before handoff
+            job.status = "failed"
+            job.error = "Server process exited before handoff"
+            return ProvisionJobStatus(
+                job_id=job_id,
+                server=job_server_name,
+                status="failed",
+                progress=job_progress,
+                message=f"Server process for '{job_server_name}' exited unexpectedly",
+                output_tail=job_output_lines[-5:],
+                elapsed_seconds=elapsed,
+                error="Process exited before handoff",
+            )
+
+        try:
+            # Build config from manifest
+            manifest = load_manifest()
+            server_config = manifest.get_server(job_server_name)
+            if not server_config:
+                raise ValueError(f"Server '{job_server_name}' not found in manifest")
+
+            resolved_config = manifest_server_to_config(server_config)
+
+            # Adopt the process into ClientManager
+            await self._client_manager.adopt_process(
+                job_server_name, process, resolved_config
+            )
+
+            # Mark job complete and clear process reference
+            job.status = "complete"
+            job.process = None
+            self._provision_finalized.add(job_id)
+
+            # Persist to provisioned registry so refresh() can reconnect it
+            env_var = server_config.env_var if server_config else None
+            self._register_provisioned_server(job_server_name, env_var)
+
+            # Get the new tools
+            tools = [
+                t
+                for t in self._client_manager.get_all_tools()
+                if t.server_name == job_server_name
+            ]
+
+            return ProvisionJobStatus(
+                job_id=job_id,
+                server=job_server_name,
+                status="complete",
+                progress=100,
+                message=f"Server '{job_server_name}' installed and connected with {len(tools)} tools.",
+                output_tail=job_output_lines[-5:],
+                elapsed_seconds=elapsed,
+                new_tools=[
+                    CapabilityCard(
+                        tool_id=t.tool_id,
+                        server=t.server_name,
+                        tool_name=t.tool_name,
+                        short_description=t.short_description,
+                        tags=t.tags,
+                        availability="online",
+                        risk_hint=t.risk_hint.value,
+                    )
+                    for t in tools[:10]
+                ]
+                if tools
+                else None,
+            )
+
+        except Exception as e:
+            logger.error(f"Handoff failed for {job_server_name}: {e}", exc_info=True)
+            job.status = "failed"
+            job.error = f"Handoff failed: {e}"
+            # Kill the orphaned process
+            if process and process.returncode is None:
+                try:
+                    process.kill()
+                except Exception:
+                    pass
+            job.process = None
+
+            return ProvisionJobStatus(
+                job_id=job_id,
+                server=job_server_name,
+                status="failed",
+                progress=job_progress,
+                message=f"Failed to connect to '{job_server_name}': {self._sanitize_error(e)}",
+                output_tail=job_output_lines[-5:],
+                elapsed_seconds=elapsed,
+                error=self._sanitize_error(e),
+            )
+
+    async def _finalize_complete(
+        self, job: Any, job_id: str, elapsed: float
+    ) -> ProvisionJobStatus:
+        """Refresh once for a completed (non-npx) install job.
+
+        The caller must hold the job's finalize lock and have confirmed the job
+        is not already finalized. Marks the job finalized before refreshing so a
+        racing poll cannot trigger a second full refresh.
+        """
+        job_server_name = job.server_name
+        job_output_lines = list(job.output_lines)
+        self._provision_finalized.add(job_id)
+
+        tools = []
+        refresh_error = None
+        try:
+            await self.refresh({"reason": f"Provisioned {job_server_name}"})
+            # Get the new tools
+            tools = [
+                t
+                for t in self._client_manager.get_all_tools()
+                if t.server_name == job_server_name
+            ]
+        except Exception as e:
+            logger.error(f"Failed to refresh after install: {e}")
+            refresh_error = self._sanitize_error(e)
+
+        message = f"Server '{job_server_name}' installed"
+        if tools:
+            message += f" and connected with {len(tools)} tools."
+        elif refresh_error:
+            message += f" but refresh failed: {refresh_error}"
+        else:
+            message += " but no tools found. Try gateway.refresh manually."
+
+        return ProvisionJobStatus(
+            job_id=job_id,
+            server=job_server_name,
+            status="complete",
+            progress=100,
+            message=message,
+            output_tail=job_output_lines[-5:],
+            elapsed_seconds=elapsed,
+            new_tools=[
+                CapabilityCard(
+                    tool_id=t.tool_id,
+                    server=t.server_name,
+                    tool_name=t.tool_name,
+                    short_description=t.short_description,
+                    tags=t.tags,
+                    availability="online",
+                    risk_hint=t.risk_hint.value,
+                )
+                for t in tools[:10]
+            ]
+            if tools
+            else None,
+            error=refresh_error,
+        )
+
+    def _build_finalized_status(
+        self, job: Any, job_id: str, elapsed: float
+    ) -> ProvisionJobStatus:
+        """Read-only terminal status for a job already finalized by another poll.
+
+        Reports the connected tools without re-adopting or re-refreshing.
+        """
+        job_server_name = job.server_name
+        job_output_lines = list(job.output_lines)
+        tools = [
+            t
+            for t in self._client_manager.get_all_tools()
+            if t.server_name == job_server_name
+        ]
+        return ProvisionJobStatus(
+            job_id=job_id,
+            server=job_server_name,
+            status="complete",
+            progress=100,
+            message=f"Server '{job_server_name}' installed and connected with {len(tools)} tools.",
+            output_tail=job_output_lines[-5:],
+            elapsed_seconds=elapsed,
+            new_tools=[
+                CapabilityCard(
+                    tool_id=t.tool_id,
+                    server=t.server_name,
+                    tool_name=t.tool_name,
+                    short_description=t.short_description,
+                    tags=t.tags,
+                    availability="online",
+                    risk_hint=t.risk_hint.value,
+                )
+                for t in tools[:10]
+            ]
+            if tools
+            else None,
+        )
 
     async def sync_environment(
         self, input_data: dict[str, Any]

--- a/src/pmcp/transport/http.py
+++ b/src/pmcp/transport/http.py
@@ -16,6 +16,7 @@ import asyncio
 import collections
 import contextlib
 import hmac
+import ipaddress
 import json
 import logging
 import uuid
@@ -147,6 +148,46 @@ async def _check_rate_limit(client_ip: str, max_rpm: int) -> bool:
         return True
 
 
+def _is_loopback_host(hostname: str) -> bool:
+    """Return True for loopback host names (localhost, 127.0.0.0/8, ::1)."""
+    if not hostname:
+        return False
+    hostname = hostname.strip("[]")
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _split_host_port(value: str, default_port: str) -> tuple[str, str]:
+    """Split a ``host[:port]`` authority into (hostname, port).
+
+    Handles bracketed IPv6 literals (``[::1]:3344``). ``default_port`` is
+    returned when no explicit port is present.
+    """
+    value = value.strip()
+    if value.startswith("["):
+        host, sep, rest = value[1:].partition("]")
+        port = rest[1:] if rest.startswith(":") else default_port
+        return host, (port or default_port)
+    if value.count(":") == 1:
+        host, _, port = value.partition(":")
+        return host, (port or default_port)
+    return value, default_port
+
+
+def _origin_host_port(origin: str) -> tuple[str, str] | None:
+    """Return (hostname, port) for an Origin header value, or None if unparseable."""
+    parsed = urlparse(origin)
+    if not parsed.scheme or not parsed.hostname:
+        return None
+    default_port = "443" if parsed.scheme == "https" else "80"
+    port = str(parsed.port) if parsed.port is not None else default_port
+    return parsed.hostname, port
+
+
 def create_http_app(
     mcp_server: Server,
     auth_token: str | None = None,
@@ -223,6 +264,65 @@ def create_http_app(
         rate_limit_enabled=rate_limit_rpm > 0,
         rate_limit_rpm=rate_limit_rpm if rate_limit_rpm > 0 else None,
     )
+
+    # Host allowlist for DNS-rebinding defense. Enforced only when the operator
+    # opts in by configuring allowed_origins; the set is derived from the origins
+    # plus the gateway's own canonical resource host (audience / metadata URL) so
+    # a reverse proxy forwarding the public Host is not rejected.
+    _allowed_host_names: set[str] = set()
+    if allowed_origins is not None:
+        for _origin in allowed_origins:
+            parsed = _origin_host_port(_origin)
+            if parsed is not None:
+                _allowed_host_names.add(parsed[0])
+        for _url in (resource_server_audience, protected_resource_metadata_url):
+            if _url:
+                parsed_url = urlparse(_url)
+                if parsed_url.hostname:
+                    _allowed_host_names.add(parsed_url.hostname)
+
+    def _origin_rejected(request: Request) -> bool:
+        """Return True if a browser Origin header should be rejected (403).
+
+        Runs by default (even without a configured allowlist) as DNS-rebinding
+        defense: a non-loopback, non-same-origin Origin that is not explicitly
+        allow-listed is rejected. Requests with no Origin (normal MCP clients)
+        always pass.
+        """
+        origin = request.headers.get("origin")
+        if origin is None:
+            return False
+        parsed = _origin_host_port(origin)
+        if parsed is None:
+            return True
+        origin_host, origin_port = parsed
+        if _is_loopback_host(origin_host):
+            return False
+        if allowed_origins is not None and origin in allowed_origins:
+            return False
+        # Same-origin: Origin host:port matches the request Host header.
+        default_port = "443" if request.url.scheme == "https" else "80"
+        host_header = request.headers.get("host", "")
+        host_name, host_port = _split_host_port(host_header, default_port)
+        if origin_host == host_name and origin_port == host_port:
+            return False
+        return True
+
+    def _host_rejected(request: Request) -> bool:
+        """Return True if the request Host header is not allow-listed (403).
+
+        Enforced only when allowed_origins is configured; loopback Hosts are
+        always accepted so local clients keep working.
+        """
+        if allowed_origins is None:
+            return False
+        host_header = request.headers.get("host", "")
+        if not host_header:
+            return False
+        host_name, _ = _split_host_port(host_header, "")
+        if _is_loopback_host(host_name):
+            return False
+        return host_name not in _allowed_host_names
 
     def _resource_audience() -> str:
         return resource_server_audience or ""
@@ -333,11 +433,13 @@ def create_http_app(
             if request.headers.get(key)
         }
 
-        if allowed_origins is not None:
-            origin = request.headers.get("origin")
-            if origin is not None and origin not in allowed_origins:
-                logger.debug("handle_mcp [%s]: 403 invalid origin", request_id)
-                return _reject(403, "Forbidden")
+        if _origin_rejected(request):
+            logger.debug("handle_mcp [%s]: 403 invalid origin", request_id)
+            return _reject(403, "Forbidden")
+
+        if _host_rejected(request):
+            logger.debug("handle_mcp [%s]: 403 invalid host", request_id)
+            return _reject(403, "Forbidden")
 
         if effective_auth_mode == "shared-secret":
             incoming = request.headers.get("authorization", "")

--- a/src/pmcp/transport/http.py
+++ b/src/pmcp/transport/http.py
@@ -19,6 +19,7 @@ import hmac
 import ipaddress
 import json
 import logging
+import os
 import uuid
 from collections.abc import AsyncIterator, MutableMapping
 from typing import TYPE_CHECKING, Any, Callable, Literal
@@ -65,6 +66,74 @@ _rl_store: dict[str, collections.deque] = {}
 _rl_lock: asyncio.Lock | None = None
 
 _MAX_BODY_BYTES: int = 10 * 1024 * 1024  # 10 MB
+
+# ---------------------------------------------------------------------------
+# Transport DoS guards for unauthenticated pre-session traffic
+# ---------------------------------------------------------------------------
+# The pre-session keepalive SSE stream (rmcp compatibility, see handle_mcp) is
+# infinite by design. Without bounds an unauthenticated client can open an
+# unlimited number of long-lived connections and exhaust the server
+# (connection-exhaustion DoS). We cap both the number of concurrent streams and
+# each stream's absolute lifetime. Both are env-tunable for operators.
+_DEFAULT_MAX_KEEPALIVE_STREAMS: int = 64
+_DEFAULT_KEEPALIVE_MAX_SECONDS: float = 300.0
+_KEEPALIVE_HEARTBEAT_SECONDS: float = 30.0
+
+# Live count of open pre-session keepalive streams. Mutated only from the event
+# loop thread; check-then-increment in handle_mcp has no await in between and is
+# therefore atomic. Held in a dict so nested closures can mutate without a
+# module-level ``global`` declaration (mirrors the _rl_store pattern).
+_keepalive_active: dict[str, int] = {"count": 0}
+
+
+def _env_int(name: str, default: int, *, minimum: int) -> int:
+    """Read a positive int from the environment, clamped to ``minimum``."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float, *, minimum: float) -> float:
+    """Read a positive float from the environment, clamped to ``minimum``."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except ValueError:
+        return default
+
+
+async def _read_body_capped(
+    receive: Callable[[], Any], max_bytes: int
+) -> tuple[bytes, bool]:
+    """Read the full ASGI request body, enforcing ``max_bytes`` as chunks arrive.
+
+    Returns ``(body, exceeded)``. Counting bytes during the read (rather than
+    trusting the advertised Content-Length) means a chunked or mislabeled
+    request cannot bypass the size cap. Once the cap is exceeded the read stops
+    immediately and any buffered data is dropped.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    more_body = True
+    while more_body:
+        message = await receive()
+        if message["type"] == "http.disconnect":
+            break
+        chunk = message.get("body", b"")
+        if chunk:
+            total += len(chunk)
+            if total > max_bytes:
+                return b"", True
+            chunks.append(chunk)
+        more_body = message.get("more_body", False)
+    return b"".join(chunks), False
+
 
 # ---------------------------------------------------------------------------
 # Prometheus counter registration (optional — falls back to _metrics dict)
@@ -504,11 +573,22 @@ def create_http_app(
                 )
                 return Response("Too Many Requests", status_code=429)
 
-        # Input size guard — reject oversized POST bodies before reading them
+        # Input size guard — fast-path reject when the advertised Content-Length
+        # already exceeds the cap. This is only a hint: a chunked or mislabeled
+        # request has no (or a false) Content-Length, so the body is additionally
+        # counted while reading below (see _read_body_capped).
         if request.method == "POST":
             cl = request.headers.get("content-length")
-            if cl and int(cl) > _MAX_BODY_BYTES:
-                return Response("Payload Too Large", status_code=413)
+            if cl:
+                try:
+                    declared = int(cl)
+                except ValueError:
+                    declared = 0
+                if declared > _MAX_BODY_BYTES:
+                    logger.debug(
+                        "handle_mcp [%s]: 413 Content-Length over cap", request_id
+                    )
+                    return Response("Payload Too Large", status_code=413)
 
         # Workaround for rmcp clients (e.g., Codex) that open the GET common
         # stream before completing the initialize handshake (and therefore have
@@ -518,18 +598,53 @@ def create_http_app(
         # channel are lost. Return a minimal keep-alive SSE stream instead; rmcp
         # will re-open the GET with a real session ID once it has one.
         if request.method == "GET" and not request.headers.get("mcp-session-id"):
+            # DoS guard: cap concurrent pre-session streams and give each an
+            # absolute lifetime so an unauthenticated client cannot open an
+            # unbounded number of infinite connections.
+            max_streams = _env_int(
+                "PMCP_MAX_KEEPALIVE_STREAMS",
+                _DEFAULT_MAX_KEEPALIVE_STREAMS,
+                minimum=1,
+            )
+            if _keepalive_active["count"] >= max_streams:
+                logger.debug(
+                    "handle_mcp [%s]: 503 keepalive stream cap reached (%d)",
+                    request_id,
+                    max_streams,
+                )
+                return _reject(503, "Service Unavailable")
+            # No await between the check above and this increment: atomic on the
+            # event loop. The finally in the generator releases the slot.
+            _keepalive_active["count"] += 1
+            max_seconds = _env_float(
+                "PMCP_KEEPALIVE_MAX_SECONDS",
+                _DEFAULT_KEEPALIVE_MAX_SECONDS,
+                minimum=0.1,
+            )
 
             async def _keepalive_sse() -> AsyncIterator[bytes]:
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + max_seconds
                 try:
-                    while True:
+                    while loop.time() < deadline:
                         yield b": keep-alive\n\n"
-                        await asyncio.sleep(30)
+                        remaining = deadline - loop.time()
+                        if remaining <= 0:
+                            break
+                        await asyncio.sleep(
+                            min(_KEEPALIVE_HEARTBEAT_SECONDS, remaining)
+                        )
                 except asyncio.CancelledError:
                     pass
+                finally:
+                    _keepalive_active["count"] -= 1
 
             logger.debug(
-                "handle_mcp [%s]: rmcp-compat serving pre-session GET as keep-alive SSE",
+                "handle_mcp [%s]: rmcp-compat serving pre-session GET as keep-alive"
+                " SSE (deadline=%ss, active=%d)",
                 request_id,
+                max_seconds,
+                _keepalive_active["count"],
             )
             return StreamingResponse(
                 _keepalive_sse(),
@@ -537,31 +652,55 @@ def create_http_app(
                 headers={"Cache-Control": "no-cache"},
             )
 
-        # Workaround for rmcp clients (e.g., Codex) that send the
-        # notifications/initialized message without the mcp-session-id header.
-        # The MCP initialize response includes the session ID, but rmcp does not
-        # propagate it to the immediately-following initialized notification.
-        # PMCP normally returns 400 for session-less POSTs that aren't initialize,
-        # which causes the rmcp worker to abort. Accept this specific notification
-        # as a no-op when no session ID is present.
-        if request.method == "POST" and not request.headers.get("mcp-session-id"):
-            body_bytes = await request.body()
-            try:
-                body = json.loads(body_bytes)
-                if body.get("method") == "notifications/initialized":
-                    logger.debug(
-                        "handle_mcp [%s]: rmcp-compat accepted notifications/initialized"
-                        " without session ID",
-                        request_id,
-                    )
-                    return Response(status_code=202)
-            except Exception:
-                pass
-
-            # For other session-less POSTs (e.g., the initialize request itself),
-            # replay the already-consumed body through the receive callable so
-            # the session manager can still read it.
+        # Read the POST body up front, counting bytes against _MAX_BODY_BYTES so
+        # a chunked / mislabeled request cannot bypass the header-only cap above.
+        # Bound the read by request_timeout so a slow-trickle client cannot pin a
+        # connection open (slow-read DoS) — the session manager would otherwise
+        # read the body inside the wait_for wrapper further down, but we now read
+        # it here for every POST, so we reproduce that bound.
+        if request.method == "POST":
             original_receive = request._receive
+            try:
+                body_bytes, body_too_large = await asyncio.wait_for(
+                    _read_body_capped(original_receive, _MAX_BODY_BYTES),
+                    timeout=request_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "handle_mcp [%s]: body read timed out after %ss",
+                    request_id,
+                    request_timeout,
+                )
+                return Response("Gateway Timeout", status_code=504)
+            if body_too_large:
+                logger.debug(
+                    "handle_mcp [%s]: 413 body exceeded cap during read", request_id
+                )
+                return Response("Payload Too Large", status_code=413)
+
+            # Workaround for rmcp clients (e.g., Codex) that send the
+            # notifications/initialized message without the mcp-session-id header.
+            # The MCP initialize response includes the session ID, but rmcp does
+            # not propagate it to the immediately-following initialized
+            # notification. PMCP normally returns 400 for session-less POSTs that
+            # aren't initialize, which causes the rmcp worker to abort. Accept
+            # this specific notification as a no-op when no session ID is present.
+            if not request.headers.get("mcp-session-id"):
+                try:
+                    body = json.loads(body_bytes)
+                    if body.get("method") == "notifications/initialized":
+                        logger.debug(
+                            "handle_mcp [%s]: rmcp-compat accepted"
+                            " notifications/initialized without session ID",
+                            request_id,
+                        )
+                        return Response(status_code=202)
+                except Exception:
+                    pass
+
+            # Replay the already-consumed body through the receive callable so the
+            # session manager can still read it (for both session-bearing POSTs
+            # and session-less ones such as the initialize request itself).
             body_replayed = False
 
             async def replay_receive() -> Any:

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -8,6 +8,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from pmcp.validation import is_valid_package_name
+
 # === Transport Types ===
 
 GatewayTransport = Literal["stdio", "http"]
@@ -1090,6 +1092,17 @@ class RegisterDiscoveredServerInput(BaseModel):
         default="", description="Short description of the server's purpose"
     )
 
+    @field_validator("package")
+    @classmethod
+    def _validate_package(cls, value: str) -> str:
+        if not is_valid_package_name(value):
+            raise ValueError(
+                "package must be a valid npm/pypi identifier "
+                "(no leading dash, whitespace, path separators, or shell "
+                "metacharacters)"
+            )
+        return value
+
 
 class RegisterDiscoveredServerOutput(BaseModel):
     """Output for gateway.register_discovered_server."""
@@ -1098,6 +1111,9 @@ class RegisterDiscoveredServerOutput(BaseModel):
     server_name: str
     registered: bool
     message: str
+    # Exact list-argv install command that gateway.provision will execute, so
+    # the caller can confirm it before provisioning runs.
+    install_command: list[str] | None = None
     next_step: str | None = None
 
 

--- a/src/pmcp/validation.py
+++ b/src/pmcp/validation.py
@@ -1,0 +1,96 @@
+"""Pure input validators for agent-reachable provisioning surfaces.
+
+Kept dependency-free (stdlib only) so it can be imported from
+``pmcp.types`` without creating an import cycle through the manifest package.
+"""
+
+from __future__ import annotations
+
+import re
+
+# npm allows an optional ``@scope/`` prefix. Both the scope and the name must
+# start with a URL-safe character and contain only letters, digits, and
+# ``. _ -``. pypi identifiers are a subset of this. A leading ``-`` (which npx
+# would treat as a flag → argument injection), whitespace, path separators
+# (``../``, ``/``), and shell/URL metacharacters are all rejected.
+_PACKAGE_SEGMENT = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+_PACKAGE_NAME_RE = re.compile(rf"^(?:@{_PACKAGE_SEGMENT}/)?{_PACKAGE_SEGMENT}$")
+
+
+def is_valid_package_name(name: str) -> bool:
+    """Return True if *name* is a safe npm/pypi package identifier.
+
+    Rejects leading dashes (which ``npx`` would treat as flags → argument
+    injection), whitespace, path separators, and shell/URL metacharacters, so
+    that the value can be safely placed into a list-argv install command such
+    as ``["npx", "-y", name]``.
+    """
+    if not name or len(name) > 214:
+        return False
+    return bool(_PACKAGE_NAME_RE.fullmatch(name))
+
+
+# Environment variables that change how a subsequently spawned subprocess loads
+# or executes code. Storing any of these would let a caller achieve code
+# execution in the next provisioned server process, so they are rejected
+# unconditionally — even if a (malicious or misconfigured) manifest declares
+# one as a server's credential variable.
+_DANGEROUS_ENV_VARS = frozenset(
+    {
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "LD_AUDIT",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FRAMEWORK_PATH",
+        "NODE_OPTIONS",
+        "PATH",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONSTARTUP",
+        "PYTHONBREAKPOINT",
+        "PYTHONINSPECT",
+        "BASH_ENV",
+        "ENV",
+        "IFS",
+        "GIT_SSH_COMMAND",
+        "GIT_EXTERNAL_DIFF",
+        "PERL5LIB",
+        "RUBYOPT",
+    }
+)
+
+# Prefixes covering entire families of code-loading variables (LD_*, DYLD_*,
+# PYTHON*), so newly added members are rejected without an explicit listing.
+_DANGEROUS_ENV_PREFIXES = ("LD_", "DYLD_", "PYTHON")
+
+# A credential-shaped variable name ends in one of these tokens. Used only as a
+# fallback to preserve the explicit ``env_var`` override for servers that have
+# no declared credential variable of their own.
+_CREDENTIAL_NAME_RE = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*_"
+    r"(TOKEN|KEY|SECRET|SECRETS|PASSWORD|CREDENTIAL|CREDENTIALS|PAT|DSN|AUTH)$"
+)
+
+
+def is_dangerous_env_var(name: str) -> bool:
+    """Return True if storing *name* could influence subprocess code loading."""
+    upper = name.upper()
+    if upper in _DANGEROUS_ENV_VARS:
+        return True
+    return any(upper.startswith(prefix) for prefix in _DANGEROUS_ENV_PREFIXES)
+
+
+def env_var_allowed(env_var: str, declared_env_var: str | None) -> bool:
+    """Return True if *env_var* is safe to store as auth for a server.
+
+    Allows only the server's declared credential variable, or — when the server
+    declares none — a credential-shaped name. Anything that could influence code
+    loading in a provisioned subprocess is rejected unconditionally, taking
+    precedence over the declared variable.
+    """
+    if not env_var or is_dangerous_env_var(env_var):
+        return False
+    if declared_env_var is not None:
+        return env_var == declared_env_var
+    return bool(_CREDENTIAL_NAME_RE.fullmatch(env_var))

--- a/tests/test_auth_origin_wiring.py
+++ b/tests/test_auth_origin_wiring.py
@@ -1,0 +1,281 @@
+"""Wiring tests for P2: connect auth-mode / OAuth / Origin params end-to-end.
+
+These prove the previously-dead resource-server and Origin paths are now reachable
+through ``GatewayServer`` and the CLI, not just via a direct ``create_http_app`` call.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from starlette.testclient import TestClient
+
+ISSUER = "https://issuer.example"
+AUDIENCE = "https://pmcp.example/mcp"
+JWKS_URL = "https://issuer.example/.well-known/jwks.json"
+
+
+def _signed_token(
+    *,
+    issuer: str = ISSUER,
+    audience: str | list[str] = AUDIENCE,
+    scope: str = "read write",
+) -> tuple[str, dict[str, object]]:
+    """Return a signed RS256 JWT plus the matching JWKS document."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    jwk = jwt.algorithms.RSAAlgorithm.to_jwk(key.public_key(), as_dict=True)
+    jwk["kid"] = "test-key"
+    jwks = {"keys": [jwk]}
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "iss": issuer,
+            "sub": "subject-1",
+            "aud": audience,
+            "scope": scope,
+            "exp": now + 300,
+            "nbf": now - 10,
+        },
+        key,
+        algorithm="RS256",
+        headers={"kid": "test-key"},
+    )
+    return token, jwks
+
+
+def _resource_server_client(**overrides: Any) -> TestClient:
+    """Build a create_http_app TestClient in resource-server mode with a mocked
+    session manager. The JWKS fetch is patched per-request (see _jwks_patch); the
+    token validator is the REAL one so acceptance/rejection is proven end-to-end."""
+    from pmcp.transport.http import create_http_app
+
+    mock_server = MagicMock()
+    mock_server.create_initialization_options = MagicMock(return_value={})
+
+    with patch(
+        "pmcp.transport.http.StreamableHTTPSessionManager",
+        autospec=True,
+    ) as mock_manager:
+        instance = mock_manager.return_value
+        instance.run.return_value.__aenter__ = AsyncMock(return_value=None)
+        instance.run.return_value.__aexit__ = AsyncMock(return_value=False)
+        instance.handle_request = AsyncMock(return_value=None)
+
+        kwargs: dict[str, Any] = {
+            "auth_mode": "resource-server",
+            "resource_server_issuer": ISSUER,
+            "resource_server_jwks_url": JWKS_URL,
+            "resource_server_audience": AUDIENCE,
+        }
+        kwargs.update(overrides)
+        app = create_http_app(mock_server, **kwargs)
+        return TestClient(
+            app, base_url="http://127.0.0.1", raise_server_exceptions=False
+        )
+
+
+def _jwks_patch(jwks: dict[str, object]) -> Any:
+    """Patch the JWKS fetch to return a fixed document (no network)."""
+    return patch(
+        "pmcp.transport.http.AsyncJWKS.get_for_token",
+        new=AsyncMock(return_value=jwks),
+    )
+
+
+class TestResourceServerModeEnforcedEndToEnd:
+    """Prove the resource-server validation path is reachable through the app."""
+
+    def test_valid_jwt_is_accepted(self) -> None:
+        token, jwks = _signed_token()
+        client = _resource_server_client()
+
+        with _jwks_patch(jwks):
+            response = client.post(
+                "/mcp",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            )
+
+        assert response.status_code == 202
+
+    def test_wrong_audience_jwt_is_401(self) -> None:
+        token, jwks = _signed_token(audience="https://other.example/mcp")
+        client = _resource_server_client()
+
+        with _jwks_patch(jwks):
+            response = client.post(
+                "/mcp",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            )
+
+        assert response.status_code == 401
+        assert "www-authenticate" in response.headers
+
+    def test_unsigned_token_is_401(self) -> None:
+        _token, jwks = _signed_token()
+        unsigned = jwt.encode(
+            {"iss": ISSUER, "aud": AUDIENCE}, key="", algorithm="none"
+        )
+        client = _resource_server_client()
+
+        with _jwks_patch(jwks):
+            response = client.post(
+                "/mcp",
+                headers={"Authorization": f"Bearer {unsigned}"},
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            )
+
+        assert response.status_code == 401
+
+
+class TestGatewayServerWiring:
+    """GatewayServer must pass the auth/Origin params through to create_http_app."""
+
+    def test_init_stores_auth_and_origin_params(self) -> None:
+        from pmcp.server import GatewayServer
+
+        server = GatewayServer(
+            auth_mode="resource-server",
+            resource_server_issuer=ISSUER,
+            resource_server_jwks_url=JWKS_URL,
+            resource_server_audience=AUDIENCE,
+            required_scopes=["pmcp.invoke"],
+            allowed_origins=["https://app.example"],
+        )
+
+        assert server._auth_mode == "resource-server"
+        assert server._resource_server_issuer == ISSUER
+        assert server._resource_server_jwks_url == JWKS_URL
+        assert server._resource_server_audience == AUDIENCE
+        assert server._required_scopes == ["pmcp.invoke"]
+        assert server._allowed_origins == ["https://app.example"]
+
+    @pytest.mark.asyncio
+    async def test_run_http_forwards_params_to_create_http_app(self) -> None:
+        import uvicorn
+
+        from pmcp.server import GatewayServer
+
+        server = GatewayServer(
+            auth_mode="resource-server",
+            resource_server_issuer=ISSUER,
+            resource_server_jwks_url=JWKS_URL,
+            resource_server_audience=AUDIENCE,
+            required_scopes=["pmcp.invoke"],
+            allowed_origins=["https://app.example"],
+        )
+        server._server = MagicMock()
+
+        with (
+            patch("pmcp.server.acquire_singleton_lock", return_value=True),
+            patch(
+                "pmcp.transport.http.create_http_app", return_value=MagicMock()
+            ) as create_app,
+            patch.object(server, "initialize", new=AsyncMock()),
+            patch.object(server, "shutdown", new=AsyncMock()),
+            patch.object(uvicorn, "Config", MagicMock()),
+            patch.object(uvicorn, "Server") as uvicorn_server,
+        ):
+            uvicorn_server.return_value.serve = AsyncMock()
+            await server._run_http()
+
+        kwargs = create_app.call_args.kwargs
+        assert kwargs["auth_mode"] == "resource-server"
+        assert kwargs["resource_server_issuer"] == ISSUER
+        assert kwargs["resource_server_jwks_url"] == JWKS_URL
+        assert kwargs["resource_server_audience"] == AUDIENCE
+        assert kwargs["required_scopes"] == ["pmcp.invoke"]
+        assert kwargs["allowed_origins"] == ["https://app.example"]
+
+
+class TestCliWiresAuthParams:
+    """CLI flags and env vars must reach the GatewayServer constructor."""
+
+    @pytest.mark.asyncio
+    async def test_cli_flags_populate_gateway_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pmcp.cli import parse_args, run_server
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "pmcp",
+                "--transport",
+                "stdio",
+                "--auth-mode",
+                "resource-server",
+                "--oauth-issuer",
+                ISSUER,
+                "--oauth-jwks-url",
+                JWKS_URL,
+                "--oauth-audience",
+                AUDIENCE,
+                "--required-scope",
+                "pmcp.invoke",
+                "--required-scope",
+                "pmcp.read",
+                "--allowed-origin",
+                "https://app.example",
+                "--allowed-origin",
+                "https://admin.example",
+            ],
+        )
+        args = parse_args()
+
+        assert args.auth_mode == "resource-server"
+        assert args.required_scopes == ["pmcp.invoke", "pmcp.read"]
+        assert args.allowed_origins == ["https://app.example", "https://admin.example"]
+
+        with patch("pmcp.server.GatewayServer") as gs:
+            gs.return_value.run = AsyncMock()
+            await run_server(args)
+
+        kwargs = gs.call_args.kwargs
+        assert kwargs["auth_mode"] == "resource-server"
+        assert kwargs["resource_server_issuer"] == ISSUER
+        assert kwargs["resource_server_jwks_url"] == JWKS_URL
+        assert kwargs["resource_server_audience"] == AUDIENCE
+        assert kwargs["required_scopes"] == ["pmcp.invoke", "pmcp.read"]
+        assert kwargs["allowed_origins"] == [
+            "https://app.example",
+            "https://admin.example",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_env_vars_populate_gateway_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pmcp.cli import parse_args, run_server
+
+        monkeypatch.setattr("sys.argv", ["pmcp", "--transport", "stdio"])
+        monkeypatch.setenv("PMCP_AUTH_MODE", "resource-server")
+        monkeypatch.setenv("PMCP_OAUTH_ISSUER", ISSUER)
+        monkeypatch.setenv("PMCP_OAUTH_JWKS_URL", JWKS_URL)
+        monkeypatch.setenv("PMCP_OAUTH_AUDIENCE", AUDIENCE)
+        monkeypatch.setenv("PMCP_REQUIRED_SCOPES", "pmcp.invoke, pmcp.read")
+        monkeypatch.setenv(
+            "PMCP_ALLOWED_ORIGINS", "https://app.example, https://admin.example"
+        )
+        args = parse_args()
+
+        with patch("pmcp.server.GatewayServer") as gs:
+            gs.return_value.run = AsyncMock()
+            await run_server(args)
+
+        kwargs = gs.call_args.kwargs
+        assert kwargs["auth_mode"] == "resource-server"
+        assert kwargs["resource_server_issuer"] == ISSUER
+        assert kwargs["resource_server_jwks_url"] == JWKS_URL
+        assert kwargs["resource_server_audience"] == AUDIENCE
+        assert kwargs["required_scopes"] == ["pmcp.invoke", "pmcp.read"]
+        assert kwargs["allowed_origins"] == [
+            "https://app.example",
+            "https://admin.example",
+        ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -929,6 +929,9 @@ class TestRunStatus:
         from pmcp.types import ServerStatusEnum
 
         status_args.json = True
+        # P4: status is lazy by default; --probe opts into active connection,
+        # which is what surfaces live protocol fields from server statuses.
+        status_args.probe = True
         config = ResolvedServerConfig(
             name="configured",
             source="project",

--- a/tests/test_cli_p4.py
+++ b/tests/test_cli_p4.py
@@ -1,0 +1,167 @@
+"""P4 credential-hardening tests: lazy status and auth-aware doctor.
+
+These live in a dedicated module (rather than test_cli.py) so the P4 changes to
+`run_status` (lazy-by-default) and `run_doctor` (401/403 vs unreachable) are
+pinned without disturbing the existing test_cli.py contracts.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _status_args(**overrides: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "json": False,
+        "server": None,
+        "pending": False,
+        "verbose": False,
+        "probe": False,
+        "project": None,
+        "config": None,
+        "policy": None,
+        "log_level": "warn",
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestStatusLazyByDefault:
+    """`pmcp status` with no live gateway must not connect servers by default."""
+
+    @pytest.mark.asyncio
+    async def test_status_without_probe_does_not_connect(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Default status reports a LAZY view without calling connect_all."""
+        from pmcp.cli import run_status
+        from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig
+
+        downstream = ResolvedServerConfig(
+            name="github",
+            source="user",
+            config=LocalMcpServerConfig(command="npx", args=["-y", "server-github"]),
+        )
+
+        with patch(
+            "pmcp.cli._query_running_gateway_status", new=AsyncMock(return_value=None)
+        ):
+            with patch("pmcp.config.loader.load_configs", return_value=[downstream]):
+                with patch(
+                    "pmcp.client.manager.ClientManager.connect_all", new=AsyncMock()
+                ) as mock_connect_all:
+                    await run_status(_status_args())
+
+        mock_connect_all.assert_not_awaited()
+        captured = capsys.readouterr()
+        assert "lazy" in captured.out.lower()
+        assert "github" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_status_with_probe_connects(self) -> None:
+        """--probe opts into active connection via connect_all."""
+        from pmcp.cli import run_status
+        from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig
+
+        downstream = ResolvedServerConfig(
+            name="github",
+            source="user",
+            config=LocalMcpServerConfig(command="npx", args=["-y", "server-github"]),
+        )
+
+        with patch(
+            "pmcp.cli._query_running_gateway_status", new=AsyncMock(return_value=None)
+        ):
+            with patch("pmcp.config.loader.load_configs", return_value=[downstream]):
+                with patch(
+                    "pmcp.client.manager.ClientManager.connect_all", new=AsyncMock()
+                ) as mock_connect_all:
+                    with patch(
+                        "pmcp.client.manager.ClientManager.disconnect_all",
+                        new=AsyncMock(),
+                    ):
+                        await run_status(_status_args(probe=True))
+
+        mock_connect_all.assert_awaited_once()
+
+
+class TestDoctorAuthAware:
+    """doctor distinguishes an authenticating gateway from an unreachable one."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [401, 403])
+    async def test_doctor_reports_auth_required(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+        status_code: int,
+    ) -> None:
+        """A 401/403 /health response reports 'gateway up but requires auth'."""
+        from pmcp.cli import run_doctor
+
+        args = argparse.Namespace(
+            command="doctor", project=None, timeout=2.0, log_level="warn"
+        )
+
+        with patch("pmcp.cli.Path.home", return_value=tmp_path):
+            with patch("pmcp.cli._is_pmcp_system_service_active", return_value=False):
+                with patch(
+                    "pmcp.cli._load_local_mcp_json",
+                    return_value=(tmp_path / ".mcp.json", {"mcpServers": {}}),
+                ):
+                    with patch(
+                        "pmcp.cli._probe_http_health",
+                        new=AsyncMock(
+                            return_value=(
+                                False,
+                                f"http://127.0.0.1:3344/health returned HTTP {status_code}",
+                                status_code,
+                            )
+                        ),
+                    ):
+                        await run_doctor(args)
+
+        captured = capsys.readouterr()
+        assert "[WARN] http:" in captured.out
+        assert "requires authentication" in captured.out
+        assert str(status_code) in captured.out
+        # Must NOT emit the generic unreachable guidance.
+        assert "Start pmcp --transport http" not in captured.out
+
+    @pytest.mark.asyncio
+    async def test_doctor_unreachable_uses_generic_guidance(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        """A truly unreachable gateway keeps the generic warning."""
+        from pmcp.cli import run_doctor
+
+        args = argparse.Namespace(
+            command="doctor", project=None, timeout=2.0, log_level="warn"
+        )
+
+        with patch("pmcp.cli.Path.home", return_value=tmp_path):
+            with patch("pmcp.cli._is_pmcp_system_service_active", return_value=False):
+                with patch(
+                    "pmcp.cli._load_local_mcp_json",
+                    return_value=(tmp_path / ".mcp.json", {"mcpServers": {}}),
+                ):
+                    with patch(
+                        "pmcp.cli._probe_http_health",
+                        new=AsyncMock(
+                            return_value=(
+                                False,
+                                "http://127.0.0.1:3344/health unreachable (ConnectError)",
+                                None,
+                            )
+                        ),
+                    ):
+                        await run_doctor(args)
+
+        captured = capsys.readouterr()
+        assert "[WARN] http:" in captured.out
+        assert "requires authentication" not in captured.out
+        assert "Start pmcp --transport http" in captured.out

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -1585,6 +1585,36 @@ class TestCallTool:
         assert returned == task
         assert "already terminal" in message
 
+    def test_terminal_task_records_are_evicted_past_cap(self) -> None:
+        """Terminal task records are pruned past the cap; active ones survive."""
+        manager = ClientManager()
+        manager._max_terminal_tasks = 5
+
+        # An active (non-terminal) record must never be evicted.
+        manager._record_task(
+            "srv",
+            McpTaskInfo(task_id="active", status="working", updated_at=0.0),
+        )
+
+        # Record many terminal tasks with increasing updated_at timestamps.
+        for i in range(20):
+            manager._record_task(
+                "srv",
+                McpTaskInfo(
+                    task_id=f"done-{i}", status="completed", updated_at=float(i + 1)
+                ),
+            )
+
+        terminal = [
+            t for t in manager.get_tracked_tasks("srv") if manager._terminal_task(t)
+        ]
+        assert len(terminal) == 5
+        # Oldest terminal records were dropped; newest survive.
+        surviving = {t.task_id for t in terminal}
+        assert surviving == {f"done-{i}" for i in range(15, 20)}
+        # The active task is untouched.
+        assert manager.get_task_record("srv", "active") is not None
+
 
 class TestServerHealthTracking:
     """Tests for server health tracking."""

--- a/tests/test_client_manager_reconnect.py
+++ b/tests/test_client_manager_reconnect.py
@@ -1,0 +1,207 @@
+"""Reconnect and failure-path recovery tests for ClientManager.
+
+These exercise the *real* stdio connect path (spawning an actual subprocess)
+rather than mocking the connect internals, because the auto-reconnect
+self-cancel bug (RecursionError) only reproduces when a live connect task runs
+through ``_cleanup_client`` -> ``_cancel_background_tasks`` while cancelling
+tasks scoped to its own server name.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import signal
+
+import pytest
+
+from pmcp.client.manager import ClientManager, ManagedClient
+from pmcp.types import (
+    LocalMcpServerConfig,
+    RemoteMcpServerConfig,
+    ResolvedServerConfig,
+    ServerStatus,
+    ServerStatusEnum,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_SLOW_SERVER = (
+    Path(__file__).resolve().parent.parent
+    / "diagnostics"
+    / "issue-79-1b"
+    / "slow_server.py"
+)
+
+
+def _stdio_config(name: str) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="project",
+        config=LocalMcpServerConfig(command="python3", args=[str(_SLOW_SERVER)]),
+    )
+
+
+async def _await_status(
+    mgr: ClientManager,
+    name: str,
+    status: ServerStatusEnum,
+    *,
+    timeout: float,
+    predicate=None,
+) -> ServerStatus:
+    """Poll until ``name`` reaches ``status`` (and optional predicate), or fail."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        current = mgr._servers.get(name)
+        if (
+            current is not None
+            and current.status == status
+            and (predicate is None or predicate())
+        ):
+            return current
+        await asyncio.sleep(0.1)
+    current = mgr._servers.get(name)
+    raise AssertionError(
+        f"{name} did not reach {status} within {timeout}s "
+        f"(last status={current.status if current else None})"
+    )
+
+
+@pytest.fixture
+async def manager() -> ClientManager:
+    mgr = ClientManager()
+    try:
+        yield mgr
+    finally:
+        await mgr.disconnect_all()
+
+
+@pytest.mark.skipif(not _SLOW_SERVER.exists(), reason="slow_server.py fixture missing")
+async def test_stdio_server_reconnects_after_crash(manager: ClientManager) -> None:
+    """A SIGKILLed stdio server auto-reconnects with a fresh process.
+
+    On the pre-fix code this hangs in ERROR forever because the reconnect's
+    connect task cancels a ``gather()`` containing itself (RecursionError).
+    """
+    name = "slow"
+    cfg = _stdio_config(name)
+
+    errors = await manager.connect_all([cfg])
+    assert errors == [], errors
+
+    online = await _await_status(manager, name, ServerStatusEnum.ONLINE, timeout=15.0)
+    assert online.status == ServerStatusEnum.ONLINE
+
+    managed = manager._clients[name]
+    assert managed.process is not None
+    old_pid = managed.process.pid
+
+    os.kill(old_pid, signal.SIGKILL)
+
+    # First reconnect attempt fires after the initial 5s back-off; allow for the
+    # kill to be observed, the reconnect to run, and the new process to init.
+    recovered = await _await_status(
+        manager,
+        name,
+        ServerStatusEnum.ONLINE,
+        timeout=25.0,
+        predicate=lambda: (
+            (m := manager._clients.get(name)) is not None
+            and m.process is not None
+            and m.process.pid != old_pid
+        ),
+    )
+    assert recovered.status == ServerStatusEnum.ONLINE
+    new_pid = manager._clients[name].process.pid
+    assert new_pid != old_pid, "expected a brand-new process after reconnect"
+
+
+async def test_cancel_background_tasks_excludes_current_task(
+    manager: ClientManager,
+) -> None:
+    """A task cancelling its own server's background tasks survives.
+
+    Reproduces the self-cancel path directly: the running task is registered as
+    both a background task and the server's connect task, so it matches
+    ``_cancel_background_tasks``'s scope. It must NOT be cancelled.
+    """
+    name = "self-cancel"
+    reached_end = False
+
+    async def worker() -> None:
+        nonlocal reached_end
+        current = asyncio.current_task()
+        assert current is not None
+        manager._track_background_task(current, name)
+        # Match the exact bug branch: task is self._connect_tasks.get(name).
+        manager._connect_tasks[name] = current
+        await manager._cancel_background_tasks(server_name=name)
+        reached_end = True
+
+    task = asyncio.create_task(worker())
+    await task
+
+    assert reached_end, "current task was cancelled by its own cleanup"
+    assert not task.cancelled()
+
+
+async def test_remote_drop_schedules_reconnect(manager: ClientManager) -> None:
+    """An unexpected remote (SSE) stream drop schedules an auto-reconnect."""
+    name = "remote"
+    cfg = ResolvedServerConfig(
+        name=name,
+        source="project",
+        config=RemoteMcpServerConfig(type="sse", url="https://example.invalid/mcp"),
+    )
+    status = ServerStatus(name=name, status=ServerStatusEnum.ONLINE, tool_count=0)
+    managed = ManagedClient(config=cfg, is_remote=True, status=status)
+    manager._clients[name] = managed
+
+    scheduled: list[str] = []
+    manager._schedule_reconnect = (  # type: ignore[method-assign]
+        lambda n, c: scheduled.append(n)
+    )
+
+    async def dropping_stream():
+        raise ConnectionError("stream dropped")
+        yield  # pragma: no cover - makes this an async generator
+
+    await manager._read_sse(name, managed, dropping_stream())
+
+    assert scheduled == [name], "remote drop did not schedule a reconnect"
+    assert managed.reconnecting is True
+    assert managed.status.status == ServerStatusEnum.ERROR
+
+
+@pytest.mark.skipif(not _SLOW_SERVER.exists(), reason="slow_server.py fixture missing")
+async def test_failed_connect_leaves_no_stale_client(
+    manager: ClientManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A connect that fails at initialize leaves no stale client or live tasks."""
+    name = "failinit"
+    cfg = _stdio_config(name)
+
+    async def boom(managed: ManagedClient) -> None:
+        raise RuntimeError("initialize failed")
+
+    monkeypatch.setattr(manager, "_send_initialize", boom)
+
+    with pytest.raises(RuntimeError, match="initialize failed"):
+        await manager._connect_stdio(cfg)
+
+    assert name not in manager._clients, "stale client left after failed connect"
+
+    # No background task scoped to this server (stdout/stderr readers) stays live.
+    alive: list[asyncio.Task] = []
+    for _ in range(20):
+        alive = [
+            t
+            for t in manager._background_tasks
+            if manager._background_task_servers.get(t) == name and not t.done()
+        ]
+        if not alive:
+            break
+        await asyncio.sleep(0.05)
+    assert not alive, "leaked live background task after failed connect"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -156,6 +157,33 @@ class TestLoadConfigs:
             user_config_paths=[],
         )
         assert len(configs) == 0
+
+    def test_malformed_config_is_surfaced_but_startup_proceeds(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Malformed project config: its servers are silently dropped today.
+        (tmp_path / ".mcp.json").write_text("invalid json {{{")
+        # A valid user config that must still load despite the broken project file.
+        user_path = tmp_path / "user.mcp.json"
+        user_path.write_text(
+            json.dumps({"mcpServers": {"good": {"command": "echo", "args": ["hi"]}}})
+        )
+
+        with caplog.at_level(logging.WARNING, logger="pmcp.config.loader"):
+            configs = load_configs(
+                project_root=tmp_path,
+                user_config_paths=[user_path],
+            )
+
+        # Startup still proceeds: the valid user server loads.
+        assert [c.name for c in configs] == ["good"]
+        # The malformed file's failure is surfaced (path + disabled note).
+        assert any(
+            "malformed config" in record.message.lower()
+            and str(tmp_path / ".mcp.json") in record.message
+            for record in caplog.records
+            if record.levelno >= logging.WARNING
+        )
 
     def test_normalizes_relative_paths(self, tmp_path: Path) -> None:
         project_config = {

--- a/tests/test_http_dos.py
+++ b/tests/test_http_dos.py
@@ -1,0 +1,146 @@
+"""Transport DoS hardening tests for the HTTP transport (Phase P5A).
+
+Covers:
+- pre-session keepalive SSE stream concurrency cap (503 when full) and slot
+  release when a stream closes;
+- pre-session keepalive stream absolute lifetime (deadline) so it cannot live
+  forever;
+- request-body size cap enforced *during the read* so a chunked / mislabeled
+  POST cannot bypass the header-only Content-Length check.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+
+def _make_contract_client(
+    auth_token: str | None = None,
+    rate_limit_rpm: int = 0,
+    **kwargs: object,
+) -> TestClient:
+    """Create a minimal HTTP app client with the session manager mocked out.
+
+    Mirrors the helper in test_http_transport.py: base_url is loopback so the
+    Host header is always allow-listed and Origin/Host checks stay deterministic.
+    """
+    from pmcp.transport.http import create_http_app
+
+    mock_server = MagicMock()
+    mock_server.create_initialization_options = MagicMock(return_value={})
+
+    with patch(
+        "pmcp.transport.http.StreamableHTTPSessionManager",
+        autospec=True,
+    ) as mock_manager:
+        instance = mock_manager.return_value
+        instance.run.return_value.__aenter__ = AsyncMock(return_value=None)
+        instance.run.return_value.__aexit__ = AsyncMock(return_value=False)
+        instance.handle_request = AsyncMock(return_value=None)
+
+        app = create_http_app(
+            mock_server,
+            auth_token=auth_token,
+            rate_limit_rpm=rate_limit_rpm,
+            **kwargs,
+        )
+        return TestClient(
+            app, base_url="http://127.0.0.1", raise_server_exceptions=False
+        )
+
+
+class TestKeepaliveStreamCap:
+    """Concurrency cap and slot release for pre-session keepalive SSE streams."""
+
+    def test_pre_session_stream_rejected_when_cap_reached(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pmcp.transport import http as http_mod
+
+        monkeypatch.setenv("PMCP_MAX_KEEPALIVE_STREAMS", "2")
+        http_mod._keepalive_active["count"] = 2  # simulate two open streams
+        try:
+            client = _make_contract_client()
+            response = client.get("/mcp")  # pre-session GET (no mcp-session-id)
+            assert response.status_code == 503
+        finally:
+            http_mod._keepalive_active["count"] = 0
+
+    def test_stream_releases_slot_after_deadline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pmcp.transport import http as http_mod
+
+        # Tiny lifetime so the infinite stream terminates quickly and the
+        # TestClient (which consumes the whole body) does not hang.
+        monkeypatch.setenv("PMCP_KEEPALIVE_MAX_SECONDS", "0.3")
+        http_mod._keepalive_active["count"] = 0
+
+        client = _make_contract_client()
+        response = client.get("/mcp")
+
+        assert response.status_code == 200
+        assert "keep-alive" in response.text
+        # finally-block in the generator ran during body consumption.
+        assert http_mod._keepalive_active["count"] == 0
+
+
+class TestBodySizeCap:
+    """Body-size cap must be enforced during the read, not header-only."""
+
+    def test_chunked_post_over_cap_rejected_during_read(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pmcp.transport import http as http_mod
+
+        monkeypatch.setattr(http_mod, "_MAX_BODY_BYTES", 1024)
+        client = _make_contract_client(auth_token="secret")
+
+        def gen() -> object:
+            # 2048 bytes total, streamed with no Content-Length (chunked).
+            for _ in range(4):
+                yield b"x" * 512
+
+        response = client.post(
+            "/mcp",
+            headers={"Authorization": "Bearer secret"},
+            content=gen(),
+        )
+
+        assert response.status_code == 413
+
+    def test_content_length_over_cap_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pmcp.transport import http as http_mod
+
+        monkeypatch.setattr(http_mod, "_MAX_BODY_BYTES", 1024)
+        client = _make_contract_client(auth_token="secret")
+
+        response = client.post(
+            "/mcp",
+            headers={"Authorization": "Bearer secret"},
+            content=b"x" * 2048,
+        )
+
+        assert response.status_code == 413
+
+    def test_small_chunked_post_still_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The capped read must not break normal chunked request bodies."""
+        client = _make_contract_client(auth_token="secret")
+
+        def gen() -> object:
+            yield b'{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+        response = client.post(
+            "/mcp",
+            headers={"Authorization": "Bearer secret"},
+            content=gen(),
+        )
+
+        assert response.status_code == 202

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -42,7 +42,11 @@ def _make_contract_client(
             rate_limit_rpm=rate_limit_rpm,
             **kwargs,
         )
-        return TestClient(app, raise_server_exceptions=False)
+        # Loopback base URL so the request Host header is always allow-listed;
+        # keeps Origin/Host tests deterministic regardless of TestClient defaults.
+        return TestClient(
+            app, base_url="http://127.0.0.1", raise_server_exceptions=False
+        )
 
 
 class TestGatewayTransportType:
@@ -472,6 +476,71 @@ class TestHttpObservabilityContracts:
         )
 
         assert response.status_code == 403
+
+    def test_cross_origin_rejected_by_default_without_allowlist(self) -> None:
+        """DNS-rebinding defense runs even when allowed_origins is unset."""
+        client = _make_contract_client()
+
+        foreign = client.post(
+            "/mcp",
+            headers={"Origin": "https://evil.example"},
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+
+        assert foreign.status_code == 403
+
+    def test_no_origin_and_loopback_and_same_origin_pass_by_default(self) -> None:
+        """Normal MCP clients (no Origin) and loopback/same-origin browsers pass."""
+        client = _make_contract_client()
+
+        no_origin = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        loopback = client.post(
+            "/mcp",
+            headers={"Origin": "http://localhost:8080"},
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        same_origin = client.post(
+            "/mcp",
+            headers={"Origin": "http://127.0.0.1"},
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+
+        assert no_origin.status_code == 202
+        assert loopback.status_code == 202
+        assert same_origin.status_code == 202
+
+    def test_host_validation_enforced_only_when_origins_configured(self) -> None:
+        """A foreign Host is rejected once allowed_origins opts Host checking in."""
+        client = _make_contract_client(allowed_origins=["https://app.example"])
+
+        foreign_host = client.post(
+            "/mcp",
+            headers={"Host": "evil.example"},
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        allowlisted_host = client.post(
+            "/mcp",
+            headers={"Host": "app.example"},
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+
+        assert foreign_host.status_code == 403
+        assert allowlisted_host.status_code == 202
+
+    def test_host_not_validated_without_allowlist(self) -> None:
+        """Without allowed_origins, an arbitrary Host still works (proxy-friendly)."""
+        client = _make_contract_client()
+
+        response = client.post(
+            "/mcp",
+            headers={"Host": "pmcp.public.example"},
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+
+        assert response.status_code == 202
 
 
 class TestHttpTransportIntegration:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1399,11 +1399,12 @@ class TestMonitorInstall:
         manager = JobManager.get_instance()
         job_id = await manager.start_install(server_config, "linux")
 
-        # Wait for completion
-        await asyncio.sleep(0.3)
-
+        # Wait deterministically for the monitor to drain output and finish,
+        # rather than racing a fixed wall-clock sleep against the subprocess.
         job = manager.get_job(job_id)
         assert job is not None
+        assert job._monitor_task is not None
+        await asyncio.wait_for(job._monitor_task, timeout=5.0)
         # Check stderr was captured
         stderr_found = any("stderr_message" in line for line in job.output_lines)
         assert stderr_found, f"Expected stderr in output: {job.output_lines}"
@@ -1427,11 +1428,12 @@ class TestMonitorInstall:
         manager = JobManager.get_instance()
         job_id = await manager.start_install(server_config, "linux")
 
-        # Wait for completion
-        await asyncio.sleep(0.5)
-
+        # Wait deterministically for the monitor to finish instead of racing a
+        # fixed wall-clock sleep against the subprocess generating 30 lines.
         job = manager.get_job(job_id)
         assert job is not None
+        assert job._monitor_task is not None
+        await asyncio.wait_for(job._monitor_task, timeout=5.0)
         assert len(job.output_lines) <= 20
 
     @pytest.mark.asyncio

--- a/tests/test_manifest_overlay.py
+++ b/tests/test_manifest_overlay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -206,6 +207,61 @@ servers:
     assert "good-entry" in manifest.servers
     assert manifest.servers["good-entry"].command == "good-command"
     assert "bad-entry" not in manifest.servers
+
+
+def test_overlay_override_logs_warning(monkeypatch, tmp_path, caplog):
+    """Overriding an existing (shipped) server name logs a prominent warning."""
+    shipped = load_manifest()
+    shipped_name = next(iter(shipped.servers))
+
+    _write(
+        Path.home() / ".pmcp" / "manifest.yaml",
+        f"""
+servers:
+  {shipped_name}:
+    description: "user override"
+    keywords: [userkw]
+    command: "user-command"
+    args: []
+""",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pmcp.manifest.loader"):
+        load_manifest()
+
+    assert any(
+        "overrides existing server" in record.message and shipped_name in record.message
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    )
+
+
+def test_symlinked_overlay_outside_tree_is_ignored(monkeypatch, tmp_path):
+    """A project .pmcp symlink pointing outside the tree is not followed."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    # Real overlay lives outside the project tree; a symlink inside the project
+    # points at it. _find_project_manifest must refuse to follow it out of tree.
+    outside = tmp_path / "outside"
+    _write(
+        outside / "manifest.yaml",
+        """
+servers:
+  sneaky-server:
+    description: "should not be picked up"
+    keywords: [sneaky]
+    command: "sneaky-command"
+    args: []
+""",
+    )
+    (project_dir / ".pmcp").symlink_to(outside, target_is_directory=True)
+    monkeypatch.chdir(project_dir)
+
+    manifest = load_manifest()
+
+    assert "sneaky-server" not in manifest.servers
+    assert len(manifest.servers) > 0  # shipped servers still load
 
 
 def test_explicit_path_skips_overlays(monkeypatch, tmp_path):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -81,6 +81,29 @@ class TestServerAllowDeny:
         assert denied_policy.is_server_allowed("tenant-code-mode") is False
         assert denied_policy.is_server_allowed("github") is True
 
+    def test_allow_deny_matching_is_case_sensitive(self, tmp_path: Path) -> None:
+        """Policy globs match case-sensitively; server IDs are case-sensitive.
+
+        Pins the decision that a deny of ``Secret*`` does NOT match
+        ``secretserver`` (different case), only the exact-case ID.
+        """
+        policy_path = tmp_path / "policy.json"
+        policy_path.write_text(
+            json.dumps(
+                {
+                    "servers": {
+                        "denylist": ["Secret*"],
+                    }
+                }
+            )
+        )
+
+        policy = PolicyManager(policy_path)
+        # Different-case ID is not denied by an upper-case pattern.
+        assert policy.is_server_allowed("secretserver") is True
+        # Exact-case ID is denied.
+        assert policy.is_server_allowed("SecretServer") is False
+
 
 class TestToolAllowDeny:
     """Tests for tool allow/deny lists."""

--- a/tests/test_provision_validation.py
+++ b/tests/test_provision_validation.py
@@ -1,0 +1,289 @@
+"""P3 remediation — agent-reachable code-execution validation.
+
+Covers four confirmed findings:
+1. Package-name validation before ``npx -y <name>`` (argument injection).
+2. auth_connect env-var allowlist (LD_PRELOAD / NODE_OPTIONS / PATH → code exec).
+3. submit_feedback scrubbing of title / failed_tool_call / subordinate_server.
+4. provision_status server_ready→adopt handoff runs exactly once (TOCTOU).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from pmcp.manifest.loader import ServerConfig
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools import handlers as handlers_module
+from pmcp.tools.handlers import GatewayTools
+from pmcp.types import RegisterDiscoveredServerInput, SubmitFeedbackInput
+from pmcp.validation import (
+    env_var_allowed,
+    is_dangerous_env_var,
+    is_valid_package_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MinimalClientManager:
+    def get_all_tools(self):
+        return []
+
+    def get_tool(self, tool_id):
+        return None
+
+    def is_server_online(self, name):
+        return False
+
+    def is_lazy_server(self, name):
+        return False
+
+    def get_all_server_statuses(self):
+        return []
+
+    def get_registry_meta(self):
+        return ("test-rev", 0.0)
+
+    async def call_tool(self, tool_id, args, timeout_ms):
+        return {"content": [{"type": "text", "text": ""}]}
+
+    async def refresh(self, configs):
+        return []
+
+    async def connect_all(self, configs, retry=True):
+        return []
+
+
+def _make_gateway() -> GatewayTools:
+    return GatewayTools(
+        client_manager=_MinimalClientManager(),  # type: ignore[arg-type]
+        policy_manager=PolicyManager(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — package-name validation
+# ---------------------------------------------------------------------------
+
+
+class TestPackageNameValidation:
+    @pytest.mark.parametrize("name", ["-g", "../evil", "a b", "x;rm", "", "  ", "/etc"])
+    def test_rejects_unsafe(self, name):
+        assert is_valid_package_name(name) is False
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "name",
+            "@scope/name",
+            "name-with-dashes",
+            "@modelcontextprotocol/server-github",
+            "left_pad",
+            "pkg.js",
+        ],
+    )
+    def test_accepts_valid(self, name):
+        assert is_valid_package_name(name) is True
+
+    @pytest.mark.parametrize("name", ["-g", "../evil", "a b", "x;rm", ""])
+    def test_pydantic_field_rejects(self, name):
+        with pytest.raises(ValidationError):
+            RegisterDiscoveredServerInput.model_validate(
+                {"package": name, "server_name": "s"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_register_echoes_install_command(self):
+        gateway = _make_gateway()
+        out = await gateway.register_discovered_server(
+            {"package": "@scope/pkg", "server_name": "demo"}
+        )
+        assert out.ok is True
+        # The resolved list-argv command is surfaced for caller confirmation.
+        assert out.install_command == ["npx", "-y", "@scope/pkg"]
+        assert "npx -y @scope/pkg" in out.message
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — auth_connect env-var allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarAllowlist:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+            "NODE_OPTIONS",
+            "PATH",
+            "PYTHONPATH",
+            "PYTHONBREAKPOINT",
+            "DYLD_INSERT_LIBRARIES",
+        ],
+    )
+    def test_dangerous_vars_flagged(self, name):
+        assert is_dangerous_env_var(name) is True
+        # Never allowed, even if a server were to declare it.
+        assert env_var_allowed(name, name) is False
+
+    def test_declared_var_allowed(self):
+        assert env_var_allowed("GITHUB_TOKEN", "GITHUB_TOKEN") is True
+
+    def test_non_declared_var_rejected(self):
+        assert env_var_allowed("OTHER_TOKEN", "GITHUB_TOKEN") is False
+
+    def test_credential_shaped_fallback(self):
+        assert env_var_allowed("BRAVE_API_KEY", None) is True
+        assert env_var_allowed("RANDOMNAME", None) is False
+
+    @pytest.mark.asyncio
+    async def test_auth_connect_rejects_ld_preload(self):
+        gateway = _make_gateway()
+        write_secret = MagicMock()
+        gateway._write_secret = write_secret  # type: ignore[method-assign]
+
+        assert "LD_PRELOAD" not in os.environ
+        out = await gateway.auth_connect(
+            {
+                "server_name": "whatever",
+                "credential": "malicious",
+                "env_var": "LD_PRELOAD",
+            }
+        )
+
+        assert out.ok is False
+        assert "not permitted" in out.message
+        # Nothing was persisted, and process env was not poisoned.
+        write_secret.assert_not_called()
+        assert "LD_PRELOAD" not in os.environ
+
+    @pytest.mark.asyncio
+    async def test_auth_connect_accepts_declared_env_var(self, monkeypatch):
+        gateway = _make_gateway()
+        # Discovered servers never enter the manifest; the declared credential
+        # variable must still be resolved from the discovered-server registry.
+        declared = "FAKE_SERVER_TOKEN_XYZ"
+        gateway._discovered_server_configs["disc"] = ServerConfig(
+            name="disc",
+            description="d",
+            keywords=["disc"],
+            install={"linux": ["npx", "-y", "disc"]},
+            command="npx",
+            args=["-y", "disc"],
+            requires_api_key=True,
+            env_var=declared,
+        )
+        write_secret = MagicMock(return_value="/tmp/fake.env")
+        gateway._write_secret = write_secret  # type: ignore[method-assign]
+        monkeypatch.delenv(declared, raising=False)
+
+        try:
+            out = await gateway.auth_connect(
+                {"server_name": "disc", "credential": "s3cret"}
+            )
+            assert out.ok is True
+            assert out.env_var == declared
+            write_secret.assert_called_once()
+            assert os.environ.get(declared) == "s3cret"
+        finally:
+            os.environ.pop(declared, None)
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — feedback scrubbing across all caller-supplied fields
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackScrub:
+    def test_secret_redacted_in_all_fields(self):
+        gateway = _make_gateway()
+        secret = "sk-abcdef123456"
+        parsed = SubmitFeedbackInput(
+            title=f"Crash while using {secret} token",
+            description="benign description",
+            subordinate_server=f"srv-{secret}",
+            failed_tool_call=f"call with {secret}",
+        )
+
+        title, body = gateway._build_feedback_issue(parsed, "owner/repo")
+
+        # The raw secret must not survive into the public issue payload.
+        assert secret not in title
+        assert secret not in body
+        # And the telemetry lines that echo those fields are present + scrubbed.
+        assert "subordinate_server:" in body
+        assert "failed_tool_call:" in body
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — provision_status handoff runs exactly once under concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionStatusHandoff:
+    @pytest.mark.asyncio
+    async def test_concurrent_polls_adopt_once(self, monkeypatch):
+        gateway = _make_gateway()
+
+        process = SimpleNamespace(returncode=None)
+        job = SimpleNamespace(
+            id="job-1",
+            server_name="srv",
+            status="server_ready",
+            progress=90,
+            output_lines=["line"],
+            started_at=0.0,
+            process=process,
+            error=None,
+        )
+
+        job_manager = SimpleNamespace(get_job=lambda _id: job)
+        monkeypatch.setattr(handlers_module, "get_job_manager", lambda: job_manager)
+        monkeypatch.setattr(
+            handlers_module,
+            "load_manifest",
+            lambda: SimpleNamespace(
+                get_server=lambda _n: SimpleNamespace(env_var=None)
+            ),
+        )
+        monkeypatch.setattr(
+            handlers_module, "manifest_server_to_config", lambda cfg: cfg
+        )
+        gateway._register_provisioned_server = MagicMock()  # type: ignore[method-assign]
+
+        adopt_count = 0
+
+        async def fake_adopt(name, proc, cfg):
+            nonlocal adopt_count
+            adopt_count += 1
+            # Yield so the racing poll reaches the lock while we hold it.
+            await asyncio.sleep(0.01)
+
+        gateway._client_manager.adopt_process = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=fake_adopt
+        )
+
+        results = await asyncio.gather(
+            gateway.provision_status({"job_id": "job-1"}),
+            gateway.provision_status({"job_id": "job-1"}),
+        )
+
+        # Adopted exactly once despite two concurrent server_ready polls.
+        assert adopt_count == 1
+        assert all(r.status == "complete" for r in results)
+        assert job.status == "complete"
+
+        # A later poll of the finalized job must not adopt again.
+        again = await gateway.provision_status({"job_id": "job-1"})
+        assert again.status == "complete"
+        assert adopt_count == 1

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 from pmcp.manifest.registry import (
@@ -73,9 +74,24 @@ RECORDED_PAYLOAD = {
 }
 
 
+class _Content:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def iter_chunked(self, size: int) -> AsyncIterator[bytes]:
+        for start in range(0, len(self._body), size):
+            yield self._body[start : start + size]
+
+
 class _Response:
     def __init__(self, payload: dict[str, object]) -> None:
         self._payload = payload
+        self._body = json.dumps(payload).encode()
+        self.content = _Content(self._body)
+
+    @property
+    def content_length(self) -> int:
+        return len(self._body)
 
     async def __aenter__(self) -> _Response:
         return self
@@ -84,7 +100,7 @@ class _Response:
         return None
 
     async def read(self) -> bytes:
-        return json.dumps(self._payload).encode()
+        return self._body
 
 
 class _Session:

--- a/tests/test_secrets_command.py
+++ b/tests/test_secrets_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import stat
@@ -341,3 +342,84 @@ class TestSecretsHandlers:
         assert output["available_keys"] == ["LOCAL_API_KEY"]
         assert output["missing_keys"] == ["REMOTE_API_TOKEN"]
         assert "stored-local" not in json.dumps(output)
+
+
+class TestSecretDirectoryPermissions:
+    """write_env_file must create PMCP-owned secret dirs privately (0700)."""
+
+    def test_write_env_file_creates_secret_dir_0700(self, tmp_path: Path) -> None:
+        """A freshly created secret directory is locked to 0700, file to 0600."""
+        secret_dir = tmp_path / ".config" / "pmcp"
+        env_path = secret_dir / "pmcp.env"
+
+        write_env_file(env_path, {"OPENAI_API_KEY": "sk-test"})
+
+        assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+    def test_write_env_file_leaves_existing_parent_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """A pre-existing parent (e.g. a project root) is never chmod-ed."""
+        os.chmod(tmp_path, 0o755)
+        env_path = tmp_path / ".env.pmcp"
+
+        write_env_file(env_path, {"OPENAI_API_KEY": "sk-test"})
+
+        assert stat.S_IMODE(tmp_path.stat().st_mode) == 0o755
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+
+class TestSecretsSetValueResolution:
+    """`secrets set` must not require the value on argv."""
+
+    def test_parse_secrets_set_value_optional(self) -> None:
+        """The positional value is optional (no argv exposure required)."""
+        with patch("sys.argv", ["pmcp", "secrets", "set", "OPENAI_API_KEY"]):
+            with patch("importlib.metadata.version", return_value="0.0.0"):
+                args = parse_args()
+
+        assert args.value is None
+        assert args.stdin is False
+
+    def test_parse_secrets_set_stdin_flag(self) -> None:
+        """--stdin parses and leaves the positional value unset."""
+        with patch("sys.argv", ["pmcp", "secrets", "set", "OPENAI_API_KEY", "--stdin"]):
+            with patch("importlib.metadata.version", return_value="0.0.0"):
+                args = parse_args()
+
+        assert args.stdin is True
+        assert args.value is None
+
+    def test_resolve_value_from_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A value omitted from argv is read from stdin with --stdin."""
+        from pmcp.cli import _resolve_secret_set_value
+
+        monkeypatch.setattr("sys.stdin", io.StringIO("sk-piped\n"))
+        args = argparse.Namespace(key="OPENAI_API_KEY", value=None, stdin=True)
+
+        assert _resolve_secret_set_value(args) == "sk-piped"
+
+    def test_resolve_value_from_getpass(self) -> None:
+        """With no value and no --stdin, the value is read interactively."""
+        from pmcp.cli import _resolve_secret_set_value
+
+        args = argparse.Namespace(key="OPENAI_API_KEY", value=None, stdin=False)
+        with patch("getpass.getpass", return_value="sk-prompted") as mock_getpass:
+            assert _resolve_secret_set_value(args) == "sk-prompted"
+
+        mock_getpass.assert_called_once()
+
+    def test_resolve_positional_value_warns_to_stderr(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Passing the value on argv still works but warns on stderr."""
+        from pmcp.cli import _resolve_secret_set_value
+
+        args = argparse.Namespace(key="OPENAI_API_KEY", value="sk-inline", stdin=False)
+
+        assert _resolve_secret_set_value(args) == "sk-inline"
+
+        captured = capsys.readouterr()
+        assert captured.out == ""  # warning must not corrupt JSON stdout
+        assert "visible in" in captured.err

--- a/tests/test_ssrf_registry.py
+++ b/tests/test_ssrf_registry.py
@@ -1,0 +1,310 @@
+"""SSRF and registry-hardening tests for P5B.
+
+Covers redirect refusal in JWKS/metadata fetches, the registry response-size
+guard enforced during the read, private-endpoint validation, and atomic,
+owner-only registry cache writes.
+"""
+
+from __future__ import annotations
+
+import http.client
+import io
+import stat
+from collections.abc import AsyncIterator
+from urllib.error import HTTPError
+from urllib.request import Request
+
+import pytest
+
+from pmcp.auth import (
+    _NO_REDIRECT_OPENER,
+    AsyncJWKS,
+    ResourceServerJWKSUnavailable,
+    _NoRedirectHandler,
+    fetch_json_metadata,
+)
+from pmcp.manifest.registry import (
+    DEFAULT_REGISTRY_ENDPOINT,
+    RegistryCache,
+    effective_registry_endpoint,
+    fetch_registry_servers,
+    load_registry_cache,
+    save_registry_cache,
+)
+
+INTERNAL_HOST = "169.254.169.254"
+
+
+# --------------------------------------------------------------------------
+# 1. JWKS redirect is not followed (aiohttp path)
+# --------------------------------------------------------------------------
+class _RedirectResponse:
+    def __init__(self, status: int, headers: dict[str, str]) -> None:
+        self.status = status
+        self.headers = headers
+
+    async def __aenter__(self) -> _RedirectResponse:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:  # pragma: no cover - not reached on 3xx
+        raise AssertionError("raise_for_status must not run on a refused redirect")
+
+
+class _RecordingSession:
+    def __init__(self, calls: list[tuple[str, dict[str, object]]]) -> None:
+        self._calls = calls
+
+    async def __aenter__(self) -> _RecordingSession:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    def get(self, url: str, **kwargs: object) -> _RedirectResponse:
+        self._calls.append((url, kwargs))
+        return _RedirectResponse(302, {"Location": f"http://{INTERNAL_HOST}/"})
+
+
+async def test_jwks_fetch_refuses_redirect_to_internal_host(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "pmcp.auth.aiohttp.ClientSession",
+        lambda **_: _RecordingSession(calls),
+    )
+
+    jwks = AsyncJWKS("https://issuer.example/jwks.json")
+    with pytest.raises(ResourceServerJWKSUnavailable):
+        await jwks.get()
+
+    # Exactly one request, to the public host, with redirects disabled.
+    assert len(calls) == 1
+    url, kwargs = calls[0]
+    assert kwargs.get("allow_redirects") is False
+    assert INTERNAL_HOST not in url
+
+
+# --------------------------------------------------------------------------
+# 2. metadata redirect is not followed (urllib path)
+# --------------------------------------------------------------------------
+def test_no_redirect_handler_raises_on_redirect() -> None:
+    handler = _NoRedirectHandler()
+    req = Request("https://public.example/meta")
+    with pytest.raises(HTTPError):
+        handler.redirect_request(
+            req,
+            io.BytesIO(b""),
+            302,
+            "Found",
+            http.client.HTTPMessage(),
+            f"http://{INTERNAL_HOST}/latest/meta-data/",
+        )
+
+
+def test_metadata_opener_replaces_default_redirect_handler() -> None:
+    redirect_handlers = [
+        handler
+        for handler in _NO_REDIRECT_OPENER.handlers
+        if isinstance(handler, _NoRedirectHandler)
+    ]
+    # Our no-redirect handler is wired, and no permissive default remains.
+    assert redirect_handlers
+    from urllib.request import HTTPRedirectHandler
+
+    assert all(
+        isinstance(handler, _NoRedirectHandler)
+        for handler in _NO_REDIRECT_OPENER.handlers
+        if isinstance(handler, HTTPRedirectHandler)
+    )
+
+
+def test_fetch_json_metadata_does_not_follow_redirect(monkeypatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_urlopen(request: object, timeout: float) -> object:
+        seen["url"] = getattr(request, "full_url")
+        raise HTTPError(
+            seen["url"],
+            302,
+            "Redirects are not allowed.",
+            http.client.HTTPMessage(),
+            None,
+        )
+
+    monkeypatch.setattr("pmcp.auth.urlopen", fake_urlopen)
+
+    data, error = fetch_json_metadata("https://auth.example/meta?token=secret")
+
+    assert data is None
+    assert error is not None
+    assert "secret" not in error
+    # Only the initial public host is ever contacted.
+    assert INTERNAL_HOST not in seen["url"]
+
+
+# --------------------------------------------------------------------------
+# 3. Registry response-size guard is enforced during the read
+# --------------------------------------------------------------------------
+class _SizedContent:
+    def __init__(self, chunks: list[bytes], consumed: list[bytes]) -> None:
+        self._chunks = chunks
+        self._consumed = consumed
+
+    async def iter_chunked(self, size: int) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            self._consumed.append(chunk)
+            yield chunk
+
+
+class _SizedResponse:
+    def __init__(
+        self,
+        *,
+        content_length: int | None,
+        chunks: list[bytes],
+        consumed: list[bytes],
+    ) -> None:
+        self.content_length = content_length
+        self.content = _SizedContent(chunks, consumed)
+
+    async def __aenter__(self) -> _SizedResponse:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def read(self) -> bytes:  # pragma: no cover - must not be called
+        raise AssertionError("must not buffer the whole oversized body")
+
+
+class _SizedSession:
+    def __init__(self, response: _SizedResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _SizedSession:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    def get(self, url: str) -> _SizedResponse:
+        return self._response
+
+
+async def test_registry_rejects_oversized_content_length(monkeypatch) -> None:
+    consumed: list[bytes] = []
+    response = _SizedResponse(
+        content_length=5_000_000, chunks=[b"x" * 1000], consumed=consumed
+    )
+    monkeypatch.setattr(
+        "pmcp.manifest.registry.aiohttp.ClientSession",
+        lambda **_: _SizedSession(response),
+    )
+
+    cache = await fetch_registry_servers(
+        "https://registry.example/v0/servers",
+        max_response_bytes=2_000_000,
+        use_in_process_cache=False,
+    )
+
+    assert "registry_response_size_cap" in cache.diagnostics
+    assert cache.servers == []
+    # An advertised over-cap length short-circuits before any body is streamed.
+    assert consumed == []
+
+
+async def test_registry_aborts_streamed_body_over_cap(monkeypatch) -> None:
+    consumed: list[bytes] = []
+    chunks = [b"aa", b"bb", b"cc", b"dd"]
+    response = _SizedResponse(content_length=None, chunks=chunks, consumed=consumed)
+    monkeypatch.setattr(
+        "pmcp.manifest.registry.aiohttp.ClientSession",
+        lambda **_: _SizedSession(response),
+    )
+
+    cache = await fetch_registry_servers(
+        "https://registry.example/v0/servers",
+        max_response_bytes=3,
+        use_in_process_cache=False,
+    )
+
+    assert "registry_response_size_cap" in cache.diagnostics
+    assert cache.servers == []
+    # Aborted mid-stream: not every chunk was consumed.
+    assert len(consumed) < len(chunks)
+
+
+# --------------------------------------------------------------------------
+# 4. Private registry endpoint validation
+# --------------------------------------------------------------------------
+def _enable_private(monkeypatch, endpoint: str) -> None:
+    monkeypatch.setenv("PMCP_REGISTRY_ALLOW_PRIVATE", "1")
+    monkeypatch.setenv("PMCP_REGISTRY_PRIVATE_ENDPOINT", endpoint)
+
+
+def test_private_endpoint_allows_https(monkeypatch) -> None:
+    _enable_private(monkeypatch, "https://private.example/v0/servers")
+    assert effective_registry_endpoint() == "https://private.example/v0/servers"
+
+
+def test_private_endpoint_allows_loopback_http(monkeypatch) -> None:
+    _enable_private(monkeypatch, "http://localhost:8080/v0/servers")
+    assert effective_registry_endpoint() == "http://localhost:8080/v0/servers"
+
+
+def test_private_endpoint_allows_loopback_ip_http(monkeypatch) -> None:
+    _enable_private(monkeypatch, "http://127.0.0.1:8080/v0/servers")
+    assert effective_registry_endpoint() == "http://127.0.0.1:8080/v0/servers"
+
+
+def test_private_endpoint_rejects_non_https_public(monkeypatch) -> None:
+    _enable_private(monkeypatch, "http://private.example/v0/servers")
+    assert effective_registry_endpoint() == DEFAULT_REGISTRY_ENDPOINT
+
+
+def test_private_endpoint_rejects_link_local_metadata(monkeypatch) -> None:
+    _enable_private(monkeypatch, f"https://{INTERNAL_HOST}/v0/servers")
+    assert effective_registry_endpoint() == DEFAULT_REGISTRY_ENDPOINT
+
+
+def test_private_endpoint_rejects_missing_scheme(monkeypatch) -> None:
+    _enable_private(monkeypatch, "private.example/v0/servers")
+    assert effective_registry_endpoint() == DEFAULT_REGISTRY_ENDPOINT
+
+
+# --------------------------------------------------------------------------
+# 5. Registry cache is written atomically with 0600 permissions
+# --------------------------------------------------------------------------
+def _sample_cache() -> RegistryCache:
+    return RegistryCache(
+        schema_version="registry-cache.v1",
+        source_endpoint="https://registry.example/v0/servers",
+        fetched_at="2026-01-01T00:00:00Z",
+    )
+
+
+def test_save_registry_cache_is_atomic_and_owner_only(tmp_path) -> None:
+    path = tmp_path / "sub" / "registry-cache.json"
+    save_registry_cache(_sample_cache(), path)
+
+    assert path.exists()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    # No temp file is left behind after the atomic replace.
+    leftovers = [p.name for p in path.parent.iterdir() if p.name != path.name]
+    assert leftovers == []
+    # Content is complete and round-trips.
+    loaded = load_registry_cache(path)
+    assert loaded is not None
+    assert loaded.source_endpoint == "https://registry.example/v0/servers"
+
+
+def test_save_registry_cache_tightens_existing_perms(tmp_path) -> None:
+    path = tmp_path / "registry-cache.json"
+    path.write_text("{}")
+    path.chmod(0o644)
+
+    save_registry_cache(_sample_cache(), path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -733,3 +733,53 @@ class TestClearVersionCache:
 
         clear_version_cache()
         assert len(_version_cache) == 0
+
+
+class TestVersionCheckUrlEscaping:
+    """Version-check URLs escape the package-name segment for all registries."""
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self) -> None:
+        clear_version_cache()
+
+    @staticmethod
+    async def _capture_url(getter, name: str, payload: dict) -> str:
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=payload)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            await getter(name)
+        return mock_session.get.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_pypi_name_is_quoted(self) -> None:
+        url = await self._capture_url(
+            get_pypi_version, "pkg name", {"info": {"version": "1.0.0"}}
+        )
+        assert "pkg%20name" in url
+        assert "pkg name" not in url
+
+    @pytest.mark.asyncio
+    async def test_cargo_name_is_quoted(self) -> None:
+        url = await self._capture_url(
+            get_cargo_version, "crate name", {"crate": {"newest_version": "1.0.0"}}
+        )
+        assert "crate%20name" in url
+        assert "crate name" not in url
+
+    @pytest.mark.asyncio
+    async def test_docker_name_is_quoted_but_slash_preserved(self) -> None:
+        # org/name stays a two-segment path; the space in the name is escaped.
+        url = await self._capture_url(
+            get_docker_version, "org/img name", {"digest": "sha256:abcdef012345"}
+        )
+        assert "org/img%20name" in url
+        assert "img name" not in url

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.18.0"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Executes the full v10 code-review remediation roadmap (`specs/phase-plans-v10.md`) — all 7 phases — and cuts **v1.19.0**.

## Phases (each verified against source + tests)
- **P1 — Reconnect & failure-path recovery** *(the critical one)*. Fixed the `RecursionError` self-cancel that meant a crashed stdio server **never recovered**; added remote (SSE/HTTP) auto-reconnect parity; cleaned up stale ERROR clients + leaked stderr tasks. Proven by a real-subprocess integration test (pre-fix RecursionError → post-fix reconnect with a new PID).
- **P2 — Auth / Origin wiring**. The OAuth resource-server mode and Origin/DNS-rebinding check were implemented+tested but never passed to the running server. Now wired via `GatewayServer` + CLI flags/env; Origin check enforced by default.
- **P3 — Code-exec validation**. Package names validated before `npx -y <name>` (rejects flag-injection/metachars); `auth_connect` refuses non-declared env vars (kills the `LD_PRELOAD` path); feedback fully scrubbed; provision handoff locked.
- **P4 — Local credential hardening**. `secrets set` off argv (prompt/`--stdin`); secret dir `0700`; case-sensitive policy; `status` lazy-by-default; doctor 401 vs down; explicit flags beat env.
- **P5A — Transport DoS**. Keepalive-stream cap + lifetime; body cap enforced during read (chunked bypass closed); slow-read timeout.
- **P5B — SSRF & registry**. No-redirect JWKS/metadata; streaming size cap; private-endpoint https+host allowlist; atomic `0600` cache.
- **P6 — Robustness sweep**. Task-record eviction; `disconnect_server` lock; overlay shadow-warning + symlink containment; malformed-config surfacing; URL escaping; de-flaked the monitor tests.

## Verification
- Full suite **2187 passed, 11 skipped** (+87 tests); `ruff check` + `ruff format --check` + `mypy src/pmcp/` all clean across 40 modules.
- Executed as two parallel waves of disjoint-file agents (P1/P2/P3/P5B, then P4/P5A/P6), each phase committed separately for reviewable history.

Preserves the verified strengths (no `shell=True`, `compare_digest`, strict JWT, fail-soft parsing). Backward compatible; new flags/env are additive with safe defaults. No open review findings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
