### PR TITLE
fix: describe nested schema (#87) + index-it-mcp stdio transport (#89) — v1.19.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ code_index.db
 # Local screenshot artifacts
 /*.png
 /.dev-skills/
+
+# index-it-mcp local index cache
+.mcp-index/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.1] - 2026-07-06
+
+### Fixed
+- **`gateway.describe` now exposes nested array/object item schemas.** Array and
+  object arguments were collapsed to a bare `"array"`/`"object"` type, hiding
+  item shape and required item fields, so agents wasted calls guessing at the
+  payload (e.g. `brightdata::search_engine_batch` needs
+  `{"queries": [{"query": "..."}]}`). `ArgInfo` gains an optional `item_schema`
+  with a compact one-level summary, and the `invoke_template` placeholder now
+  shows the nested shape (e.g. `[{"query": "<string>"}]`). Scalar-arg output is
+  unchanged. (issue #87)
+- **`index-it-mcp` manifest entry now launches the `stdio` transport.** The
+  shipped entry ran `serve` (the HTTP/admin surface) where PMCP's local process
+  path needs a stdio MCP child; `command`/`args` and all four install platforms
+  now end in `stdio`. (issue #89)
+
+### Docs
+- README pilot config for provisioning `index-it-mcp` via `.mcp.json` with a
+  pinned version and the operational env block, noting that per-entry `env` is
+  honored only from `.mcp.json` (the manifest/overlay schema has no `env:`).
+
 ## [1.19.0] - 2026-07-04
 
 Remediation of the v1.18.0 code review (roadmap `specs/phase-plans-v10.md`).

--- a/README.md
+++ b/README.md
@@ -965,6 +965,46 @@ For MCP servers not in the manifest, add them to `~/.mcp.json`:
 
 PMCP supports both local command-based and remote URL-based downstream entries from discovered config files. Entries in `mcpServers` make downstream servers available lazily/on demand; they do not by themselves mean the server should be eagerly started.
 
+#### `index-it-mcp` code-index pilot
+
+For a fleet pilot of the local-first code indexer, add `index-it-mcp` to your
+`.mcp.json` with a **pinned** version and its operational env. PMCP spawns it
+over stdio and passes the `env` block **verbatim** into the child process
+(`_connect_stdio` does `env = os.environ.copy(); env.update(config.env)`), so
+this is the supported channel for the server's configuration:
+
+```json
+{
+  "mcpServers": {
+    "index-it-mcp": {
+      "command": "uvx",
+      "args": ["--from", "index-it-mcp==<approved-version>", "index-it-mcp", "stdio"],
+      "env": {
+        "MCP_ALLOWED_ROOTS": "/path/to/repo",
+        "SEMANTIC_SEARCH_ENABLED": "true",
+        "SEMANTIC_DEFAULT_PROFILE": "code",
+        "SEMANTIC_EMBEDDING_BASE_URL": "http://localhost:8000/v1",
+        "QDRANT_URL": "http://localhost:6333",
+        "OPENAI_API_KEY": "local-vllm-placeholder"
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- **Pin the version** (`index-it-mcp==<approved-version>`) so a PyPI release-line
+  change can't silently swap the indexer under a running fleet. Replace
+  `<approved-version>` with the operator-approved pin.
+- **`OPENAI_API_KEY`** is only the token the server presents to a local
+  OpenAI-compatible endpoint (e.g. a vLLM embedding server at
+  `SEMANTIC_EMBEDDING_BASE_URL`); it is not an api.openai.com secret.
+- **Env must go via `.mcp.json`.** The shipped-manifest and private-overlay
+  entry schema has **no `env:` block** — putting `env:` in a manifest overlay
+  will be ignored. Per-entry environment is only honored from `.mcp.json`
+  `mcpServers` entries.
+
 The top-level `autoStart` list controls explicit eager startup. Names can refer to
 servers defined in `mcpServers` or packaged manifest entries such as `playwright`
 and `context7`. Omit a server from `autoStart` to keep it lazy.

--- a/plans/detailed-describe-nested-schema-and-indexit-stdio-20260706-0920.md
+++ b/plans/detailed-describe-nested-schema-and-indexit-stdio-20260706-0920.md
@@ -1,0 +1,86 @@
+# Detailed plan: fix gateway.describe nested-schema fidelity (#87) + index-it-mcp stdio transport & pilot docs (#89), ship v1.19.1
+
+> **Plan Mode was NOT active** when this was produced — planning artifact only, no implementation begun.
+
+## Task
+Fix two confirmed, PMCP-owned bugs and ship as a **v1.19.1** patch:
+- **#87** — `gateway.describe` collapses nested array/object argument schemas to bare `"array"`/`"object"`, so agents can't see item shape/required item fields and waste calls guessing (e.g. `brightdata::search_engine_batch` needs `{"queries":[{"query":"..."}]}`).
+- **#89 (PMCP-owned slice only)** — the shipped `index-it-mcp` manifest entry launches `serve` (HTTP/admin) where PMCP's local path needs a **stdio** child; plus document how to pass non-secret operational env + pin the version for a fleet pilot. The readiness contract, repo-registration/bootstrap UX, and Code-Index-MCP-repo work are **out of scope** (deferred cross-repo effort).
+
+## Research summary
+Verified via two Explore passes:
+- `describe` (`handlers.py:1567-1579`) builds each `ArgInfo` from only `prop.get("type"/"description"/"examples")` — it never reads `prop["items"]` or nested `properties`/`required`. The raw downstream JSON Schema (with `items`/`properties`) is already present on `ToolInfo.input_schema` (`client/manager.py:1120`), just unread. `ArgInfo` (`types.py:645-652`) is consumed **only** by `describe()`; no `__all__`, no test asserts an exhaustive field set (`test_tools.py:2104-2111` checks `len(args)` only), and `get_code_snippet` doesn't read `ArgInfo` fields — so **adding an optional field is backward-compatible**.
+- The `index-it-mcp` manifest entry (`manifest.yaml:1081-1091`) uses `serve` in `command`/`args` and all four `install` platforms; it's the only manifest entry ending in a subcommand. `index-it-mcp stdio` is a real CLI command (Code-Index-MCP `mcp_server.cli` click group registers both `serve` and `stdio`).
+- **The manifest schema has no `env:` block** — `_parse_server_config` (`loader.py:313-362`) parses only `env_var`/`env_instructions`; overlay entries share this parser. Per-entry `env` is available only through `.mcp.json` `mcpServers` (`LocalMcpServerConfig.env`), applied at `client/manager.py:1276-1290` (`env = os.environ.copy(); env.update(local_config.env)` → `create_subprocess_exec(env=env)`). **No test** currently asserts config `env` reaches the subprocess.
+- README overlay/Configuration docs: "Private manifest overlay" heading at `README.md:900` (example `920-937`, precedence `909-915`); `.mcp.json` `env` example under "Adding Custom Servers" `958-964`.
+
+## Changes
+
+### `src/pmcp/types.py` (modify)
+- `ArgInfo` — modify — add one optional field `item_schema: dict[str, Any] | None = None` (default None → backward-compatible). Holds a **compact** nested summary: for an array property, `{"type": "<item type>", "required": [...], "properties": {name: type, ...}}` from `prop["items"]`; for an object property, `{"required": [...], "properties": {name: type, ...}}`. Not full JSON Schema — one level deep, field name→type only.
+
+### `src/pmcp/tools/handlers.py` (modify)
+- `_summarize_arg_schema(prop: dict) -> tuple[str, dict | None, str]` — add (module-level or private method) — returns `(type_str, item_schema, placeholder)`. For `type == "array"` with an object `items`: `type_str="array"`, `item_schema` = compact item summary, `placeholder` = a nested example string, e.g. `[{"query": "<string>"}]` (built from the item's required fields, falling back to all item props if none required). For `type == "object"` with nested `properties`: summarize its props/required; placeholder = `{"<field>": "<type>", ...}`. For scalars: unchanged behavior (`item_schema=None`, placeholder = existing `<required|optional: {type}>`).
+- `describe` arg-extraction loop (`handlers.py:1567-1579`) — modify — call `_summarize_arg_schema(prop)`, pass `item_schema` into `ArgInfo(...)`, and use the returned nested `placeholder` when building `arg_placeholders` (the `invoke_template`) for array/object args (keep the existing `<required|optional: type>` form for scalars). Reason: surface item shape + required item field names so agents invoke correctly first try.
+
+### `src/pmcp/manifest/manifest.yaml` (modify)
+- `index-it-mcp` entry (`~1085-1090`) — modify — replace `serve` with `stdio` in `command`/`args` (`["--from","index-it-mcp","index-it-mcp","stdio"]`) and in all four `install` platforms (mac/linux/wsl/windows). Reason: PMCP's local process path needs a stdio MCP child, not the HTTP/admin `serve` surface.
+
+### `tests/test_tools.py` (modify)
+- Add `test_describe_exposes_nested_array_item_schema` — add — build a tool whose `input_schema` mirrors `search_engine_batch` (`queries: {type: array, items: {type: object, properties: {query: {type: string}}, required: [query]}}`); assert the returned `ArgInfo` for `queries` has `item_schema` exposing item type `object` + required field `query` (name+type), and that the `invoke_template.arguments["queries"]` placeholder shows the nested `{"query": ...}` shape (not bare `<required: array>`).
+
+### `tests/test_manifest.py` (modify)
+- Add `test_index_it_mcp_uses_stdio_transport` — add — `load_manifest().get_server("index-it-mcp")`; assert `args[-1] == "stdio"` and `"serve" not in args`, and each `install[platform][-1] == "stdio"`. Mirrors `test_manifest_server_config_structure` (`~128`). Regression guard for the transport mode.
+
+### `tests/test_client_manager.py` (modify)
+- Add `test_local_config_env_reaches_subprocess` — add — connect a local server whose config carries an `env` dict (via a mocked `create_subprocess_exec`), assert the `env=` kwarg passed to the subprocess includes those keys merged over `os.environ`. Fills the recon-found gap and satisfies #89 AC3 "tested way to pass env". (Reuse the mock-process patterns already in this file.)
+
+### `CHANGELOG.md` (modify)
+- Add `## [1.19.1] - 2026-07-06` under `[Unreleased]` — **Fixed:** `gateway.describe` now exposes nested array/object item schemas + required item fields (issue #87); the shipped `index-it-mcp` manifest entry launches the `stdio` transport instead of `serve` (issue #89). **Docs:** README pilot config for provisioning `index-it-mcp` with pinned version + operational env via `.mcp.json`.
+
+### `README.md` (modify)
+- Add an `index-it-mcp` pilot subsection (insert after the overlay example, `~937`, or co-located with the `.mcp.json` env example, `~964`) — a copyable **`.mcp.json` `mcpServers`** entry pinning `index-it-mcp==<approved-version>` with the operational env block (`MCP_ALLOWED_ROOTS`, `SEMANTIC_SEARCH_ENABLED`, `SEMANTIC_DEFAULT_PROFILE`, `SEMANTIC_EMBEDDING_BASE_URL`, `QDRANT_URL`, etc. from the issue's Suggested Starting Config). State that PMCP passes `.mcp.json`/overlay-spawned local `env` **verbatim** into the child process (`_connect_stdio`), that pinning `==<version>` avoids PyPI release-line drift, and that env must go via `.mcp.json` (the manifest/overlay schema carries no `env:` block — call this out so operators don't put `env:` in an overlay expecting it to apply).
+
+### `pyproject.toml`, `src/pmcp/__init__.py`, `uv.lock` (modify)
+- version — modify — bump `1.19.0` → `1.19.1` (`uv lock` to update `uv.lock`).
+
+## Documentation impact
+- `README.md` — modify — index-it-mcp pilot config (above); the answer to #89 AC3/AC5-docs.
+- `CHANGELOG.md` — modify — `[1.19.1]` entry (above).
+- No other cross-cutting docs. **Frozen-vocabulary note:** `ArgInfo` gains only an *optional* field — no existing field renamed/removed; the describe output contract is additive.
+
+## Deferred follow-ups (explicitly NOT in this plan)
+- Per-entry `env:` support in the manifest/overlay schema (would let a single overlay carry the pilot env instead of `.mcp.json`) — a schema change; note as a possible v1.20 enhancement.
+- #89 readiness contract (`ready`/`index_unavailable`/`safe_fallback`), repo-registration/bootstrap UX, and Code-Index-MCP-repo CLI/docs — a separate cross-repo effort.
+
+## Dependencies & order
+1. `types.py` ArgInfo field before `handlers.py` uses it.
+2. `manifest.yaml` edit before its regression test.
+3. Concerns A (#87: types/handlers/test) and B (#89: manifest/env-test/docs) are independent — either order.
+4. Version bump + CHANGELOG last (release step). No external/migration deps.
+
+## Execution Policy
+- execute: effort=low, reason=bounded bug-fixes + docs; the only non-mechanical bit is the one-level schema-summary in `_summarize_arg_schema`.
+
+## Verification
+```bash
+cd /home/viperjuice/code/pmcp
+# Targeted
+.venv/bin/python -m pytest tests/test_tools.py -k "describe" -v
+.venv/bin/python -m pytest tests/test_manifest.py -k "index_it_mcp or stdio" tests/test_client_manager.py -k "env_reaches" -v
+# Full gate (baseline 2187 passed) — must stay green
+.venv/bin/python -m pytest -q
+.venv/bin/python -m ruff check src/ tests/ && .venv/bin/python -m ruff format --check src/ tests/
+.venv/bin/python -m mypy src/pmcp/
+# Release sanity
+grep -m1 '^version' pyproject.toml; grep __version__ src/pmcp/__init__.py   # both 1.19.1
+awk -v v="1.19.1" '$0 ~ "^## \\["v"\\]"{f=1;next} f&&/^## \[/{exit} f' CHANGELOG.md | head   # notes extractable
+```
+Edge cases to cover in tests: array whose `items` is a scalar (`{type: array, items: {type: string}}`) → placeholder `["<string>"]`, `item_schema` records item type only; array-of-objects with NO required item fields → placeholder uses all item props; a plain scalar arg → behavior unchanged (regression).
+
+## Acceptance criteria
+- [ ] `gateway.describe` on a tool with `queries: array<object{query:string, required}>` returns an `ArgInfo` whose `item_schema` shows item type `object` + required field `query`, and whose `invoke_template` placeholder shows the nested `{"query": ...}` shape (not bare `<required: array>`). Scalar-arg describe output is unchanged.
+- [ ] `load_manifest().get_server("index-it-mcp")` has `args[-1] == "stdio"` (and no `"serve"`), for `command`/`args` and all four install platforms.
+- [ ] A local server config `env` dict is passed to the spawned subprocess (`create_subprocess_exec(env=...)` includes the keys) — proven by test.
+- [ ] README contains a copyable `.mcp.json` `index-it-mcp` pilot entry with pinned version + the operational env keys, and states env goes via `.mcp.json` (not the manifest/overlay schema).
+- [ ] Full suite passes (≥2187), ruff (lint+format) + mypy clean; `pyproject.toml`/`__init__.py`/`uv.lock` all report `1.19.1`; `## [1.19.1]` CHANGELOG section is extractable by the release-notes awk.

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -755,6 +755,28 @@
       "task_summary": "Private/custom MCP manifest overlay merged in load_manifest (user/project/PMCP_MANIFEST_PATH); ship v1.18.0",
       "type": "detailed",
       "updated_at": "2026-06-29T08:41:00Z"
+    },
+    {
+      "acceptance_criteria_count": 5,
+      "created_at": "2026-07-06T09:20:00Z",
+      "file": "plans/detailed-describe-nested-schema-and-indexit-stdio-20260706-0920.md",
+      "handoff_ref": ".dev-skills/handoffs/claude-plan-detailed/20260706T0920Z-describe-nested-schema-indexit-stdio.md",
+      "lifecycle": [
+        {
+          "at": "2026-07-06T09:20:00Z",
+          "by": "claude-plan-detailed",
+          "metadata": {
+            "artifact_state": "staged"
+          },
+          "transition": "planned"
+        }
+      ],
+      "owner_skill": "claude-plan-detailed",
+      "slug": "detailed-describe-nested-schema-indexit-stdio",
+      "status": "staged",
+      "task_summary": "gateway.describe nested-schema fidelity (#87) + index-it-mcp stdio transport & pilot docs (#89); ship v1.19.1",
+      "type": "detailed",
+      "updated_at": "2026-07-06T09:20:00Z"
     }
   ],
   "schema_version": 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.19.0"
+version = "1.19.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.19.0"
+__version__ = "1.19.1"

--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -1082,12 +1082,12 @@ servers:
     description: "Local-first code indexer - symbol lookup, full-text and semantic search across 48 languages, real-time file watching"
     keywords: [code-search, indexing, symbols, tree-sitter, semantic-search, code-intelligence, repositories, local-first, ctags, code-index, full-text-search, multi-language]
     install:
-      mac: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "serve"]
-      linux: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "serve"]
-      wsl: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "serve"]
-      windows: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "serve"]
+      mac: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "stdio"]
+      linux: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "stdio"]
+      wsl: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "stdio"]
+      windows: ["uvx", "--from", "index-it-mcp", "index-it-mcp", "stdio"]
     command: "uvx"
-    args: ["--from", "index-it-mcp", "index-it-mcp", "serve"]
+    args: ["--from", "index-it-mcp", "index-it-mcp", "stdio"]
     requires_api_key: false
 
   # === Project Management ===

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -877,6 +877,68 @@ def get_gateway_tool_definitions() -> list[Tool]:
     ]
 
 
+def _summarize_arg_schema(
+    prop: dict[str, Any],
+) -> tuple[str, dict[str, Any] | None, str]:
+    """Summarize one argument's JSON Schema, one level deep.
+
+    Returns ``(type_str, item_schema, placeholder)`` where ``item_schema`` is a
+    compact nested summary (or None for scalars) and ``placeholder`` is a JSON
+    example string. For array-of-objects the placeholder shows the nested item
+    shape (e.g. ``[{"query": "<string>"}]``) so agents can invoke correctly on
+    the first try instead of guessing at the bare ``array`` type.
+    """
+    prop_type = str(prop.get("type", "unknown"))
+
+    def _prop_type(p: dict[str, Any]) -> str:
+        return str(p.get("type", "unknown"))
+
+    if prop_type == "array":
+        items = prop.get("items")
+        if isinstance(items, dict):
+            item_type = _prop_type(items)
+            if item_type == "object":
+                item_props = items.get("properties", {})
+                item_required = items.get("required", [])
+                properties = {
+                    key: _prop_type(value) if isinstance(value, dict) else "unknown"
+                    for key, value in item_props.items()
+                }
+                item_schema: dict[str, Any] = {
+                    "type": "object",
+                    "required": list(item_required),
+                    "properties": properties,
+                }
+                # Prefer required item fields for the example; fall back to all.
+                example_keys = list(item_required) or list(properties)
+                example = {
+                    key: f"<{properties.get(key, 'unknown')}>" for key in example_keys
+                }
+                return prop_type, item_schema, json.dumps([example])
+            # Array of scalars: record item type only.
+            return prop_type, {"type": item_type}, json.dumps([f"<{item_type}>"])
+        return prop_type, None, "<required: array>"
+
+    if prop_type == "object":
+        obj_props = prop.get("properties")
+        if isinstance(obj_props, dict):
+            obj_required = prop.get("required", [])
+            properties = {
+                key: _prop_type(value) if isinstance(value, dict) else "unknown"
+                for key, value in obj_props.items()
+            }
+            item_schema = {
+                "required": list(obj_required),
+                "properties": properties,
+            }
+            example = {key: f"<{value}>" for key, value in properties.items()}
+            return prop_type, item_schema, json.dumps(example)
+        return prop_type, None, "<required: object>"
+
+    # Scalar: no nested schema, caller keeps the existing placeholder form.
+    return prop_type, None, ""
+
+
 class GatewayTools:
     """Gateway tool handler implementations."""
 
@@ -1564,17 +1626,21 @@ class GatewayTools:
         properties = schema.get("properties", {})
         required = schema.get("required", [])
 
+        nested_placeholders: dict[str, str] = {}
         for name, prop in properties.items():
-            prop_type = prop.get("type", "unknown")
             description = prop.get("description", "")
+            type_str, item_schema, placeholder = _summarize_arg_schema(prop)
+            if item_schema is not None:
+                nested_placeholders[name] = placeholder
 
             args.append(
                 ArgInfo(
                     name=name,
-                    type=str(prop_type),
+                    type=type_str,
                     required=name in required,
                     short_description=description[:200] if description else "",
                     examples=prop.get("examples"),
+                    item_schema=item_schema,
                 )
             )
 
@@ -1586,7 +1652,9 @@ class GatewayTools:
         # Build invoke template for direct invocation
         arg_placeholders: dict[str, str] = {}
         for arg in args:
-            if arg.required:
+            if arg.item_schema is not None:
+                arg_placeholders[arg.name] = nested_placeholders[arg.name]
+            elif arg.required:
                 arg_placeholders[arg.name] = f"<required: {arg.type}>"
             else:
                 arg_placeholders[arg.name] = f"<optional: {arg.type}>"

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -650,6 +650,12 @@ class ArgInfo(BaseModel):
     required: bool
     short_description: str
     examples: list[Any] | None = None
+    # Compact one-level summary of a nested array item / object shape, when the
+    # arg is an array or object (None for scalars). For an array-of-objects:
+    # {"type": "object", "required": [...], "properties": {name: type, ...}};
+    # for an object: {"required": [...], "properties": {name: type, ...}};
+    # for an array-of-scalars: {"type": "<item type>"}. Not full JSON Schema.
+    item_schema: dict[str, Any] | None = None
 
 
 class InvokeTemplate(BaseModel):

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -2667,6 +2667,37 @@ class TestConnectStdioGuard:
 
         cleanup_mock.assert_awaited_once_with("test", existing_managed)
 
+    @pytest.mark.asyncio
+    async def test_local_config_env_reaches_subprocess(self) -> None:
+        """A local server config's env dict is merged over os.environ and passed
+        to the spawned subprocess (#89 AC3)."""
+        manager = ClientManager()
+
+        config = ResolvedServerConfig(
+            name="index-it-mcp",
+            source="project",
+            config=LocalMcpServerConfig(
+                command="fake",
+                args=["stdio"],
+                env={"MCP_ALLOWED_ROOTS": "/repo", "QDRANT_URL": "http://q"},
+            ),
+        )
+
+        # Fail fast after the spawn call so we don't need full MCP wiring; the
+        # env kwarg is captured from call_args.
+        spawn = AsyncMock(side_effect=RuntimeError("abort"))
+        with patch("asyncio.create_subprocess_exec", spawn):
+            with pytest.raises(RuntimeError, match="abort"):
+                await manager._connect_stdio(config)
+
+        _, kwargs = spawn.call_args
+        passed_env = kwargs["env"]
+        # Custom keys present with their values...
+        assert passed_env["MCP_ALLOWED_ROOTS"] == "/repo"
+        assert passed_env["QDRANT_URL"] == "http://q"
+        # ...merged OVER os.environ (a pre-existing key survives → not a replace).
+        assert passed_env["PATH"] == os.environ["PATH"]
+
 
 class TestDisconnectAllPostKill:
     """Additional disconnect_all tests for post-SIGKILL wait behaviour."""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -121,6 +121,19 @@ def test_load_manifest():
     assert len(manifest.servers) > 0
 
 
+def test_index_it_mcp_uses_stdio_transport() -> None:
+    """index-it-mcp must launch the stdio MCP child, not the serve surface (#89)."""
+    server = load_manifest().get_server("index-it-mcp")
+
+    assert server is not None
+    assert server.args[-1] == "stdio"
+    assert "serve" not in server.args
+
+    for platform, argv in server.install.items():
+        assert argv[-1] == "stdio", f"{platform} install must end in stdio"
+        assert "serve" not in argv, f"{platform} install still references serve"
+
+
 def test_manifest_server_auth_metadata_fields_are_optional() -> None:
     server = ServerConfig(
         name="remote-auth",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2111,6 +2111,84 @@ class TestDescribe:
         assert any(a.name == "title" and a.required for a in result.args)
 
     @pytest.mark.asyncio
+    async def test_describe_exposes_nested_array_item_schema(
+        self, gateway_tools: GatewayTools
+    ) -> None:
+        # Mirror brightdata::search_engine_batch: an array of objects with a
+        # required item field, plus a scalar arg (regression) and an
+        # array-of-scalars / no-required-field edge case.
+        tool = gateway_tools._client_manager._tools["github::create_issue"]
+        tool.input_schema = {
+            "type": "object",
+            "properties": {
+                "queries": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"field": {"type": "string"}},
+                    },
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {"owner": {"type": "string"}},
+                    "required": ["owner"],
+                },
+                "name": {"type": "string"},
+            },
+            "required": ["queries", "name"],
+        }
+
+        result = await gateway_tools.describe({"tool_id": "github::create_issue"})
+        by_name = {arg.name: arg for arg in result.args}
+
+        # Array-of-objects: item schema exposes item type + required field name/type.
+        queries = by_name["queries"]
+        assert queries.type == "array"
+        assert queries.item_schema == {
+            "type": "object",
+            "required": ["query"],
+            "properties": {"query": "string"},
+        }
+
+        # Array-of-scalars: item type recorded only.
+        assert by_name["tags"].item_schema == {"type": "string"}
+
+        # Array-of-objects with no required fields: falls back to all item props.
+        assert by_name["filters"].item_schema == {
+            "type": "object",
+            "required": [],
+            "properties": {"field": "string"},
+        }
+
+        # Top-level object property: summarized (no "type" key, object is implied).
+        assert by_name["metadata"].item_schema == {
+            "required": ["owner"],
+            "properties": {"owner": "string"},
+        }
+
+        # Scalar arg unchanged.
+        assert by_name["name"].type == "string"
+        assert by_name["name"].item_schema is None
+
+        placeholders = result.invoke_template.arguments
+        # Nested array placeholder shows the {"query": ...} shape, not <required: array>.
+        assert placeholders["queries"] == '[{"query": "<string>"}]'
+        assert placeholders["tags"] == '["<string>"]'
+        assert placeholders["filters"] == '[{"field": "<string>"}]'
+        assert placeholders["metadata"] == '{"owner": "<string>"}'
+        # Scalar placeholder is byte-identical to today's form.
+        assert placeholders["name"] == "<required: string>"
+
+    @pytest.mark.asyncio
     async def test_describe_returns_modern_tool_metadata(
         self, gateway_tools: GatewayTools
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.19.0"
+version = "1.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Patch **v1.19.1** — two confirmed PMCP bugs from the open-issue triage (plan: `plans/detailed-describe-nested-schema-and-indexit-stdio-20260706-0920.md`).

## #87 — `gateway.describe` drops nested array/object schema
The describe handler flattened each arg to its top-level `type`, so `queries: array<object{query: string, required}>` showed as bare `array` and agents burned calls guessing `["str"]` / `[{"q":...}]`. Now a new `ArgInfo.item_schema` (optional, backward-compatible) + `_summarize_arg_schema` helper expose the item type and required item fields **one level deep**, and the `invoke_template` placeholder shows the real nested shape (e.g. `[{"query": "<string>"}]`). Scalar-arg output is byte-identical to before.

## #89 (PMCP slice) — index-it-mcp stdio transport + pilot docs
The shipped `index-it-mcp` manifest entry launched `serve` (HTTP/admin) where PMCP's local path needs a **stdio** child → fixed to `stdio` in `command`/`args` + all four install platforms (`index-it-mcp stdio` is a real CLI subcommand). README adds a copyable **`.mcp.json`** pilot config pinning `index-it-mcp==<version>` with the operational env block, and documents that env goes via `.mcp.json` (the manifest/overlay schema has **no `env:` block**). Deferred (separate cross-repo effort): the readiness contract, repo-registration/bootstrap UX, and Code-Index-MCP-side work.

## Tests / verification
3 new tests (describe nested schema incl. edge cases; index-it-mcp stdio regression; local config `env` reaches the spawned subprocess). Full suite **2190 passing** in a clean environment; ruff (lint+format) + mypy clean; version 1.19.1 across pyproject/`__init__`/uv.lock.

*Note:* one pre-existing test (`test_run_secrets_check_...`) fails only on a dev box that has a real index-it-mcp `~/.mcp.json` (test-isolation leak, unrelated to this change, green in CI) — tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)