### PR TITLE
fix(config): resolve user config paths from HOME at call time (test-isolation leak)

### DIFF
--- a/src/pmcp/config/loader.py
+++ b/src/pmcp/config/loader.py
@@ -33,10 +33,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Documents the default user config locations. Do NOT read this frozen list at
+# runtime — it captures Path.home() at import time, so a changed/monkeypatched
+# HOME (e.g. in tests, or a re-homed process) would be ignored. Use
+# default_user_config_paths() instead, which resolves Path.home() at call time
+# (mirrors manifest/loader.py's overlay path handling).
 DEFAULT_USER_CONFIG_PATHS = [
     Path.home() / ".mcp.json",
     Path.home() / ".claude" / ".mcp.json",
 ]
+
+
+def default_user_config_paths() -> list[Path]:
+    """User-level config paths, resolved from Path.home() at call time."""
+    return [
+        Path.home() / ".mcp.json",
+        Path.home() / ".claude" / ".mcp.json",
+    ]
 
 
 class StartupSkipReason(str, Enum):
@@ -271,7 +284,7 @@ def _iter_config_source_paths(
     user_paths = (
         list(user_config_paths)
         if user_config_paths is not None
-        else DEFAULT_USER_CONFIG_PATHS
+        else default_user_config_paths()
     )
     paths.extend(("user", path) for path in user_paths)
 
@@ -684,7 +697,7 @@ def load_configs(
     user_paths = (
         list(user_config_paths)
         if user_config_paths is not None
-        else DEFAULT_USER_CONFIG_PATHS
+        else default_user_config_paths()
     )
     for user_path in user_paths:
         user_config = _parse_config_or_warn(user_path)
@@ -756,7 +769,7 @@ def load_disabled_auto_start(
     user_paths = (
         list(user_config_paths)
         if user_config_paths is not None
-        else DEFAULT_USER_CONFIG_PATHS
+        else default_user_config_paths()
     )
     for user_path in user_paths:
         user_config = parse_json_file(user_path)
@@ -800,7 +813,7 @@ def load_enabled_auto_start(
     user_paths = (
         list(user_config_paths)
         if user_config_paths is not None
-        else DEFAULT_USER_CONFIG_PATHS
+        else default_user_config_paths()
     )
     for user_path in user_paths:
         user_config = parse_json_file(user_path)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -103,6 +103,30 @@ class TestLoadConfigs:
         assert cfg.command == "node"
         assert cfg.args == ["server.js"]
 
+    def test_load_configs_honors_runtime_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default user config paths must resolve HOME at call time, not import
+        time — so a patched/changed HOME is honored and a test never leaks the
+        developer's real ~/.mcp.json into the loaded config set."""
+        from pmcp.config.loader import default_user_config_paths
+
+        fake_home = tmp_path / "home"
+        (fake_home).mkdir()
+        (fake_home / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"home-server": {"command": "home-cmd"}}})
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        # The call-time helper reflects the patched HOME...
+        assert default_user_config_paths()[0] == fake_home / ".mcp.json"
+        # ...and load_configs (no explicit user_config_paths) picks up ONLY that
+        # user config, not any real ~/.mcp.json.
+        empty_project = tmp_path / "proj"
+        empty_project.mkdir()
+        names = {c.name for c in load_configs(project_root=empty_project)}
+        assert names == {"home-server"}
+
     def test_merges_configs_with_precedence(self, tmp_path: Path) -> None:
         # Create project config
         project_config = {


### PR DESCRIPTION
Fixes the test-isolation leak flagged during the v1.19.1 work.

## Root cause
`DEFAULT_USER_CONFIG_PATHS` (`config/loader.py:36`) built its `~/.mcp.json` paths from `Path.home()` **at import time**. So a test that monkeypatches `HOME` can't redirect it — `load_configs` keeps reading the developer's *real* `~/.mcp.json`. On a dev box that has a locally-configured `index-it-mcp` (many env vars), those keys leaked into `test_run_secrets_check_combines_local_and_remote_auth_requirements`, failing it locally while it stayed green in CI's clean container.

This is the same frozen-`Path.home()` pattern I fixed for the v1.18.0 manifest overlay (`manifest/loader.py` recomputes at call time) — the config loader just never got the same treatment.

## Fix
Add `default_user_config_paths()` that resolves `Path.home()` **at call time**, and use it at all four fallback sites (274/687/759/803). The frozen `DEFAULT_USER_CONFIG_PATHS` constant is kept for documentation only (with a comment warning not to read it at runtime). Strictly improves isolation/correctness; no behavior change when HOME is unchanged.

## Verification
New regression test `test_load_configs_honors_runtime_home` (a patched HOME is honored; the real user config isn't leaked). The previously-flaky secrets test now passes on a dev box too. Full suite **2191 passing**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)