### PR TITLE
docs(#89): index-it-mcp registry-bootstrap env consistency + readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,36 @@ Notes:
   entry schema has **no `env:` block** — putting `env:` in a manifest overlay
   will be ignored. Per-entry environment is only honored from `.mcp.json`
   `mcpServers` entries.
+- **Pin the Python interpreter** with `"args": ["--python", "3.12", "--from", …]`.
+  `index-it-mcp==1.2.0` depends on `tree-sitter-languages`, which has no wheel for
+  CPython 3.13; without the pin, `uvx` may pick 3.13 and fail to launch.
+
+**Repository registration must use the same storage env as the config.** Before
+agents get indexed results, each repo must be registered *and* the gateway-spawned
+server must read the registry the registration wrote. The registry location is
+resolved from `MCP_INDEX_STORAGE_PATH` / `MCP_REPO_REGISTRY`. If you set those in
+the `.mcp.json` `env` above but run `index-it-mcp repository register` **without**
+them, the CLI writes to the default `~/.mcp/repository_registry.json` while the
+PMCP-spawned server reads `$MCP_INDEX_STORAGE_PATH/repository_registry.json` — so
+the server reports `repositories: []` and every query falls back to native search
+(`unregistered_repository`). Register with the **same** env the config uses:
+
+```bash
+export MCP_INDEX_STORAGE_PATH=/path/to/shared/.indexes
+export MCP_REPO_REGISTRY="$MCP_INDEX_STORAGE_PATH/repository_registry.json"
+for repo in /path/to/repo-a /path/to/repo-b; do
+  uvx --python 3.12 --from index-it-mcp==1.2.0 index-it-mcp repository register "$repo"
+done
+# Verify the server-side view before trusting results:
+uvx --python 3.12 --from index-it-mcp==1.2.0 index-it-mcp repository list   # expect your repos
+uvx --python 3.12 --from index-it-mcp==1.2.0 index-it-mcp preflight         # readiness check
+```
+
+**Check readiness before trusting indexed answers.** The server's status/query
+tools report a readiness state (`ready`, `unregistered_repository`,
+`missing_index`, `stale_commit`, …) and, when not ready, `safe_fallback:
+"native_search"`. Agents should treat any non-`ready` state as non-authoritative
+and fall back to native search rather than reporting stale/empty index results.
 
 The top-level `autoStart` list controls explicit eager startup. Names can refer to
 servers defined in `mcpServers` or packaged manifest entries such as `playwright`


### PR DESCRIPTION
Closes the PMCP-owned doc gap behind #89's `repositories: []` blocker (root-caused live).

**Root cause:** `index-it-mcp repository register` resolves its registry from `MCP_INDEX_STORAGE_PATH`/`MCP_REPO_REGISTRY`. The pilot bootstrap ran registration *without* those env vars, so the CLI wrote 4 repos to the default `~/.mcp/repository_registry.json`, while the PMCP-spawned server (which the `.mcp.json` config points at `…/.indexes/repository_registry.json`) read an empty registry → `repositories: []` → every query fell back to native search (`unregistered_repository`). Verified live: re-registering with the configured env populated the server's registry, and `index-it-mcp repository list` now shows all 4 repos.

**This PR** extends the README `index-it-mcp` pilot section with: the register-must-use-the-same-storage-env requirement (+ exact bootstrap loop and `repository list`/`preflight` verification), the `--python 3.12` pin (3.13 has no `tree-sitter-languages` wheel), and a readiness note (treat any non-`ready` state → native-search fallback). Docs-only; no code change.

Code-Index-MCP's fleet-integration guide gets the same note via a coordination issue (its rollout roadmap is in-flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)