### PR TITLE
fix(security): stop bleeding PMCP-managed secrets across server subprocesses (#96)

### DIFF
--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -24,6 +24,7 @@ from mcp.shared.message import SessionMessage
 
 from pmcp.auth import sanitize_auth_diagnostic
 from pmcp.config.loader import make_tool_id
+from pmcp.env_store import sanitized_subprocess_env
 from pmcp.remote_auth import (
     MissingRemoteHeaderAuthError,
     resolve_remote_headers_for_tenant,
@@ -1273,10 +1274,10 @@ class ClientManager:
 
         logger.info(f"Connecting to MCP server: {name}")
 
-        # Build environment
-        env = os.environ.copy()
-        if local_config.env:
-            env.update(local_config.env)
+        # Build environment: inherit the gateway env MINUS PMCP-managed secrets
+        # (so this server never receives another server's stored credentials),
+        # then apply this server's own resolved credentials.
+        env = sanitized_subprocess_env(local_config.env, self._project_root)
 
         # Spawn process (semaphore caps concurrent spawns to avoid FD exhaustion)
         async with self._spawn_semaphore:

--- a/src/pmcp/env_store.py
+++ b/src/pmcp/env_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Mapping
 from pathlib import Path
 
 from dotenv import dotenv_values
@@ -101,6 +102,45 @@ def write_env_file(path: Path, values: dict[str, str]) -> None:
     os.fchmod(fd, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as env_file:
         env_file.write(content)
+
+
+def managed_secret_keys(project: Path | None = None) -> set[str]:
+    """Env-var keys of credentials PMCP manages in its user/project secret stores.
+
+    These are the keys ``auth_connect`` / ``pmcp secrets set`` write (and that the
+    gateway loads into its own ``os.environ`` at startup). Used to avoid bleeding
+    one server's PMCP-stored credentials into another server's subprocess env.
+    Only PMCP-managed keys are enumerated — not secrets that reached ``os.environ``
+    from the operator's shell or a plain ``.env``.
+    """
+    keys: set[str] = set(read_env_file(resolve_scope_path("user")))
+    try:
+        keys.update(read_env_file(resolve_scope_path("project", project)))
+    except (OSError, ValueError):
+        pass
+    return keys
+
+
+def sanitized_subprocess_env(
+    own_env: Mapping[str, str] | None = None, project: Path | None = None
+) -> dict[str, str]:
+    """Build the environment for a downstream server subprocess.
+
+    Inherits the gateway's environment MINUS PMCP-managed credentials — so a
+    server never receives ANOTHER server's PMCP-stored secrets — then applies the
+    server's OWN resolved credentials (``own_env``), which win over the strip
+    (e.g. a server whose runtime env_var equals a managed key gets its own value
+    back). Non-secret ambient vars (PATH/HOME/NODE_*/proxy/locale) are preserved.
+
+    Note: this removes only PMCP-managed keys; secrets the operator exported into
+    the shell or a plain ``.env`` are not sanitized here.
+    """
+    env = os.environ.copy()
+    for key in managed_secret_keys(project):
+        env.pop(key, None)
+    if own_env:
+        env.update(own_env)
+    return env
 
 
 def set_env_value(

--- a/src/pmcp/manifest/installer.py
+++ b/src/pmcp/manifest/installer.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from pmcp.env_store import resolve_scope_path
+from pmcp.env_store import resolve_scope_path, sanitized_subprocess_env
 from pmcp.manifest.environment import Platform
 from pmcp.manifest.loader import ServerConfig, credential_lookup_keys
 
@@ -518,15 +518,17 @@ def build_install_child_env(server_config: ServerConfig) -> dict[str, str]:
     gateway's own ``os.environ`` only holds the namespaced storage key after
     ``auth_connect``, so a bare inherited environment would omit the runtime var.
     """
-    child_env = os.environ.copy()
+    own_env: dict[str, str] = {}
     env_var = server_config.env_var
     if env_var:
         for key in credential_lookup_keys(server_config):
             value = os.environ.get(key)
             if value:
-                child_env[env_var] = value
+                own_env[env_var] = value
                 break
-    return child_env
+    # Inherit the gateway env minus PMCP-managed secrets (no cross-server bleed),
+    # then apply this server's own resolved credential.
+    return sanitized_subprocess_env(own_env)
 
 
 async def check_api_key(server_config: ServerConfig) -> None:

--- a/src/pmcp/manifest/installer.py
+++ b/src/pmcp/manifest/installer.py
@@ -634,13 +634,16 @@ async def verify_installation(server_config: ServerConfig) -> bool:
         True if server can be started, False otherwise
     """
     try:
-        # Try to start the server briefly
+        # Try to start the server briefly. Sanitized env: this executes the
+        # server's own package code, so it must not inherit other servers'
+        # credentials from the gateway environment.
         process = await asyncio.create_subprocess_exec(
             server_config.command,
             *server_config.args[:1],  # Just first arg to test
             "--help",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=build_install_child_env(server_config),
         )
 
         await asyncio.wait_for(process.communicate(), timeout=5.0)

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -54,6 +54,7 @@ from pmcp.manifest.environment import CLIInfo, detect_platform, probe_clis
 from pmcp.templates.code_snippets_loader import get_code_snippet
 from pmcp.manifest.installer import (
     MissingApiKeyError,
+    build_install_child_env,
     get_job_manager,
     InstallError,
 )
@@ -3394,12 +3395,20 @@ class GatewayTools:
             )
         return None
 
-    async def _run_update_probe_command(self, command: list[str]) -> tuple[bool, str]:
-        """Run an update probe command and return (ok, output)."""
+    async def _run_update_probe_command(
+        self, command: list[str], env: dict[str, str] | None = None
+    ) -> tuple[bool, str]:
+        """Run an update probe command and return (ok, output).
+
+        ``env`` should be sanitized (this probe runs the downstream server's own
+        package code, e.g. ``npx <pkg> --help``, so it must not inherit other
+        servers' credentials from the gateway's environment).
+        """
         process = await asyncio.create_subprocess_exec(
             *command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
         stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60.0)
         output = (
@@ -4780,7 +4789,11 @@ class GatewayTools:
             update_cmd = ["uvx", "--refresh", package_name, "--help"]
 
         try:
-            ok, output = await self._run_update_probe_command(update_cmd)
+            # Sanitized env: the probe executes the server's own package code, so
+            # it gets only this server's resolved credential, never other servers'.
+            ok, output = await self._run_update_probe_command(
+                update_cmd, env=build_install_child_env(server_config)
+            )
         except TimeoutError:
             return UpdateServerOutput(
                 ok=False,

--- a/tests/test_env_store.py
+++ b/tests/test_env_store.py
@@ -1,0 +1,94 @@
+"""Tests for PMCP credential env-store helpers, focused on the subprocess
+environment sanitization that prevents cross-server secret bleed (#96)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pmcp.env_store import managed_secret_keys, sanitized_subprocess_env
+
+
+def _write_user_store(home: Path, body: str) -> None:
+    (home / ".config" / "pmcp").mkdir(parents=True, exist_ok=True)
+    (home / ".config" / "pmcp" / "pmcp.env").write_text(body)
+
+
+def test_managed_secret_keys_reads_user_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_user_store(tmp_path, "BRIGHTDATA_API_TOKEN=bd\nOPENAI_API_KEY=oai\n")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert managed_secret_keys() >= {"BRIGHTDATA_API_TOKEN", "OPENAI_API_KEY"}
+
+
+def test_subprocess_env_strips_other_servers_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A server receives its OWN credential but NOT another server's stored one,
+    and non-secret ambient vars survive."""
+    _write_user_store(tmp_path, "BRIGHTDATA_API_TOKEN=bd\nOPENAI_API_KEY=oai\n")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BRIGHTDATA_API_TOKEN", "bd")
+    monkeypatch.setenv("OPENAI_API_KEY", "oai")
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    # brightdata's own resolved env injects the runtime var API_TOKEN.
+    env = sanitized_subprocess_env({"API_TOKEN": "bd"})
+
+    assert env["API_TOKEN"] == "bd"  # own credential present
+    assert "OPENAI_API_KEY" not in env  # other server's secret stripped
+    assert "BRIGHTDATA_API_TOKEN" not in env  # own storage key stripped (runtime-only)
+    assert env["PATH"] == "/usr/bin"  # ambient non-secret preserved
+
+
+def test_subprocess_env_readds_own_var_that_collides_with_managed_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A server whose runtime env_var IS a managed key (e.g. browser-use's
+    OPENAI_API_KEY) gets its own value back after the strip, while another
+    server's secret is still removed."""
+    _write_user_store(tmp_path, "BRIGHTDATA_API_TOKEN=bd\nOPENAI_API_KEY=oai\n")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BRIGHTDATA_API_TOKEN", "bd")
+    monkeypatch.setenv("OPENAI_API_KEY", "oai")
+
+    env = sanitized_subprocess_env({"OPENAI_API_KEY": "oai"})
+
+    assert env["OPENAI_API_KEY"] == "oai"  # own var re-added
+    assert "BRIGHTDATA_API_TOKEN" not in env  # other server's secret stripped
+
+
+def test_subprocess_env_does_not_mutate_process_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stripping happens on the COPY — os.environ itself is untouched, so upstream
+    credential resolution that reads os.environ.get(storage_key) is unaffected by
+    a later spawn."""
+    import os
+
+    _write_user_store(tmp_path, "BRIGHTDATA_API_TOKEN=bd\n")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BRIGHTDATA_API_TOKEN", "bd")
+
+    _ = sanitized_subprocess_env({"API_TOKEN": "bd"})
+
+    # The storage key must still be resolvable from os.environ for the NEXT
+    # server's credential resolution.
+    assert os.environ.get("BRIGHTDATA_API_TOKEN") == "bd"
+
+
+def test_subprocess_env_no_own_env_still_strips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_user_store(tmp_path, "SOME_TOKEN=x\n")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SOME_TOKEN", "x")
+    monkeypatch.setenv("PATH", "/bin")
+
+    env = sanitized_subprocess_env()
+
+    assert "SOME_TOKEN" not in env
+    assert env["PATH"] == "/bin"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4253,11 +4253,13 @@ class TestCapabilityAndProvision:
             discovery_queue_path=".mcp-gateway/discovery_queue.json",
         )
         monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: manifest)
-        monkeypatch.setattr(
-            gateway_tools,
-            "_run_update_probe_command",
-            lambda command: __import__("asyncio").sleep(0, result=(True, "ok")),
-        )
+        probe_calls: dict[str, object] = {}
+
+        def _fake_probe(command, env=None):
+            probe_calls["env"] = env
+            return __import__("asyncio").sleep(0, result=(True, "ok"))
+
+        monkeypatch.setattr(gateway_tools, "_run_update_probe_command", _fake_probe)
         monkeypatch.setattr(
             gateway_tools,
             "refresh",
@@ -4280,6 +4282,9 @@ class TestCapabilityAndProvision:
         assert result.server == "playwright"
         assert result.package_type == "npm"
         assert result.latest_version == "1.2.3"
+        # The update probe runs the server's own package code, so it must get a
+        # sanitized env (a dict), not inherit the gateway's full environment.
+        assert isinstance(probe_calls["env"], dict)
 
     @pytest.mark.asyncio
     async def test_invoke_includes_update_warning(self, monkeypatch):


### PR DESCRIPTION
Closes #96.

## Problem
`_connect_stdio` and `build_install_child_env` copied the gateway's **entire** `os.environ` into every downstream server subprocess. Since PMCP loads all stored credentials into its own `os.environ` (from the user `pmcp.env` + project `.env.pmcp` at startup, plus `auth_connect`'s `os.environ[key]=…`), every server received **every other server's** credentials — e.g. `@brightdata/mcp` got the OpenAI key and vice versa.

## Fix (deny-list)
New `env_store.sanitized_subprocess_env(own_env, project)`:
- inherits the gateway env **minus the PMCP-managed secret keys** (union of the user/project secret-store keys), then
- applies the server's **own** resolved credentials (`own_env`), which win over the strip — so a server whose runtime `env_var` equals a managed key (browser-use's `OPENAI_API_KEY`) gets its own value back, while another server's secret is gone.

Non-secret ambient vars (`PATH`/`HOME`/`NODE_*`/proxy/locale) are preserved. The strip is on the **copy** only; `os.environ` is untouched, so upstream credential resolution (which reads `os.environ.get(storage_key)`) is unaffected. Applied to the only two `os.environ.copy()` subprocess-spawn sites (grep-verified).

## Scope (precise)
Removes only **PMCP-managed** secrets — not secrets the operator exported into the shell or a plain `.env`. **Behavior change:** a server that today relies on *ambient inheritance* of a secret it does not declare (no config `env` block, no manifest credential) stops receiving it. Everything with an explicit config `env` or a manifest credential is unaffected.

## Verification
- Unit: own-credential-present-but-not-others; own-var-colliding-with-managed-key re-added; `os.environ` not mutated (resolution-ordering invariant); `PATH` survives. Full suite 2229 passed; ruff+mypy clean.
- **Live (`/proc`):** the gateway env holds `BRIGHTDATA_API_TOKEN` + `OPENAI_API_KEY`; the connected brightdata subprocess env has **only** `API_TOKEN` + `PATH` — no `OPENAI_API_KEY`, no storage key.

## Durable direction (future, not this PR)
The permanent fix is to stop loading secrets into the global `os.environ` at all (a per-server injected store), which makes the deny-list unnecessary. That's a large refactor touching every `os.environ.get` resolution site; tracked as the eventual direction in #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)