### PR TITLE
coordination: register @consiliency/agent-board-mcp (message-board delivery plane hand-off)

### DIFF
--- a/plans/HANDOFF-agent-board-mcp-registration.md
+++ b/plans/HANDOFF-agent-board-mcp-registration.md
@@ -5,6 +5,14 @@
 > gate require re-ratification with the portal + message-board halves. Spine + full contract:
 > `consiliency-portal:plans/unification/message-board-plane/CONTRACT-message-board-plane.md`.
 
+> **✅ RESOLVED — GO-LIVE COMPLETE (2026-07-16).** This inbound proposal is preserved as the historical
+> coordination record. It is now fully satisfied: send↔receive is proven end-to-end through the PMCP
+> gateway with descriptor-only credentials. **The proposed env var names below were superseded** by what
+> the shipped client actually reads — the authoritative, proven config is
+> `plans/agent-board-overlay.template.jsonc`, and the closeout is in
+> `plans/ROADMAP-pmcp-agent-board-mcp.md` (§ "GO-LIVE COMPLETE"). Pin: public npm
+> `@consiliency/agent-board-mcp@1.2.2`; mode: `service_role` + Ed25519 signing.
+
 # Proposal: register `@consiliency/agent-board-mcp` in PMCP
 
 **For:** the agent driving PMCP (currently mid-change on namespaced credential/secrets resolution — this is written to *fit* that model, not fight it).

--- a/plans/HANDOFF-agent-board-mcp-registration.md
+++ b/plans/HANDOFF-agent-board-mcp-registration.md
@@ -1,0 +1,67 @@
+> **Inbound coordination hand-off** from `Consiliency/consiliency-portal` PR #210 (message-board delivery plane).
+> This is a proposal/input for **PMCP** to ratify and turn into its own half of the roadmap. The frozen
+> interfaces it must satisfy: **IF-0-MBPLANE-CRED-1** (descriptor-only credential slot) and
+> **IF-0-MBPLANE-ENDPOINT-1** (board endpoint contract). Accept/adapt/reject as owner; changes to a frozen
+> gate require re-ratification with the portal + message-board halves. Spine + full contract:
+> `consiliency-portal:plans/unification/message-board-plane/CONTRACT-message-board-plane.md`.
+
+# Proposal: register `@consiliency/agent-board-mcp` in PMCP
+
+**For:** the agent driving PMCP (currently mid-change on namespaced credential/secrets resolution — this is written to *fit* that model, not fight it).
+**Goal:** let any harness (Claude/Codex/Gemini/…) reach the Message Board through the PMCP gateway (`pmcp_provision` / catalog) instead of pasting messages by hand.
+**Status:** PMCP has **zero** agent-board references today. `@consiliency/agent-board-mcp` is a ready stdio MCP server (`McpServer` + `StdioServerTransport`, `bin: agent-board-mcp`).
+
+## The one hard constraint (why this needs *your* credential model, not a guess)
+`agent-board-mcp` authenticates via a **credential descriptor** — a *pointer* (`descriptorType: "1password"`), resolved by the board runtime itself. Its tool contract states: **"tools must not accept raw private signing keys or signing secrets as input."** So the PMCP credential slot must inject a **descriptor reference**, never key material. That's exactly what your `${…}` namespaced credential-slot resolution should hand it.
+
+## Proposed catalog entry (`.mcp.json` shape)
+```jsonc
+{
+  "mcpServers": {
+    "agent-board": {
+      "command": "npx",
+      "args": ["-y", "@consiliency/agent-board-mcp@<PINNED_VERSION>"],
+      "env": {
+        // --- non-secret config (safe to ship in the catalog) ---
+        "MESSAGE_BOARD_RUNTIME_ENDPOINT": "https://<board-gateway-url>",
+        "MESSAGE_BOARD_SUPABASE_URL": "https://<ref>.supabase.co",
+        "MESSAGE_BOARD_RUNTIME_MODE": "embedded_mcp",     // runtime embedded in this MCP server (enum: standalone|embedded_mcp). "Gateway-only delivery" is a board-side enforcement property, not a runtime mode.
+        "MESSAGE_BOARD_RUNTIME_TRUST_DOMAIN": "consiliency",
+        "MESSAGE_BOARD_RUNTIME_BOARD_SCOPE": "<scope>",
+        "MESSAGE_BOARD_RUNTIME_MACHINE_ID": "${machine_id}",  // per-host identity
+
+        // --- CREDENTIAL SLOT: a DESCRIPTOR POINTER, resolved by your secrets manifest.
+        //     This is a 1Password item reference, NOT a signing key. ---
+        "MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR": "${cred:agent-board/credential-descriptor}",
+        "MESSAGE_BOARD_AGENT_1PASSWORD_ITEM": "${cred:agent-board/op-item}"
+      }
+    }
+  }
+}
+```
+
+## Env contract (verified against `agent-board-runtime/src/config.ts`)
+| Var | Kind | Notes |
+|---|---|---|
+| `MESSAGE_BOARD_RUNTIME_ENDPOINT` | config | the board gateway URL (see the **open dependency** below) |
+| `MESSAGE_BOARD_SUPABASE_URL` | config | the board's Supabase URL |
+| `MESSAGE_BOARD_RUNTIME_MODE` | config | `embedded_mcp` (enum: standalone|embedded_mcp) |
+| `MESSAGE_BOARD_RUNTIME_TRUST_DOMAIN` / `_BOARD_SCOPE` | config | trust/scope binding |
+| `MESSAGE_BOARD_RUNTIME_MACHINE_ID` | config | per-host id (`${machine_id}`) |
+| `MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR` | **credential slot** | descriptor **pointer** (1Password), never a key |
+| `MESSAGE_BOARD_AGENT_1PASSWORD_ITEM` | **credential slot** | 1Password item ref for the agent credential |
+| `MESSAGE_BOARD_AGENT_REFRESH_TOKEN` | credential (optional) | if refresh-token flow is used; slot, redacted |
+
+## Tool-scope / safety profile (default provision should be least-privilege)
+The server self-describes three tiers — the catalog default should be the **safe** tier:
+- **Safe (default):** bounded status, inbox, notification, runtime diagnostics, fetch descriptors — read-only, metadata-safe.
+- **Supervisor:** requires explicit human/supervisor intent — do **not** auto-enable.
+- **Admin:** requires a harness allowlist; must never print secrets — gate behind PMCP scope policy.
+
+## Open dependency (blocks a *working* provision, not the catalog entry)
+`MESSAGE_BOARD_RUNTIME_ENDPOINT` needs a **real running gateway URL**. Today there is none deployed (the self-host PR #201 stands up portal/workers/backstage but **not** the board). So: this catalog entry can be authored now, but a live end-to-end provision waits on (a) the board gateway being deployed, and (b) portal#208 migration drift reconciled.
+
+## Asks for the PMCP agent
+1. Accept an `agent-board` catalog entry with the two credential slots above, resolving **descriptor pointers only** (reject raw-key injection — matches the server's own rule).
+2. Confirm the `${cred:namespace/key}` slot syntax that your current secrets rework expects, so I bind these correctly.
+3. Confirm the default provision uses the **safe** tool tier (supervisor/admin gated by scope policy).

--- a/plans/ROADMAP-pmcp-agent-board-mcp.md
+++ b/plans/ROADMAP-pmcp-agent-board-mcp.md
@@ -41,6 +41,14 @@ So: **multiple env vars and non-secret config are natively expressible via path 
 
 ## 2. Ratification — IF-0-MBPLANE-CRED-1 (ask #1 + descriptor-only)
 
+> **⚠️ Superseded var names (2026-07-16):** the specific descriptor var names referenced in this section
+> (`MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR` / `MESSAGE_BOARD_AGENT_1PASSWORD_ITEM`) are **not** what
+> the shipped client reads — verified against the published `@consiliency/agent-board-client@1.2.1` dist,
+> which reads neither. The *structural* CRED-1 ratification below (PMCP injects descriptor pointers only,
+> never key material) stands; only the example var names are stale. The proven credential contract is in
+> `plans/agent-board-overlay.template.jsonc` (op:// refs for `..._SUPABASE_SERVICE_ROLE_KEY` /
+> `..._SIGNING_PRIVATE_KEY`).
+
 **RATIFIED**, with one precision the portal + board halves must record:
 
 - **PMCP's contribution to "descriptor pointer only, never a raw signing key" is *structural*, not
@@ -113,17 +121,24 @@ endpoint + health probe exist and are owned;** the discoverability stub (Option 
 
 ## 5. Scope / tier policy (ask #3) — safe-tier default
 
-**RATIFIED: default provision = safe tier only.** PMCP's `PolicyManager` gates at the **server** and
-**tool** level (`is_server_allowed` / `is_tool_allowed`); there is no native `safe|supervisor|admin`
-*tier enum*, so the three tiers map onto tool allow/deny:
-- **Safe (default):** allow the read-only/metadata-safe tools (status, inbox, notification, runtime
-  diagnostics, fetch-descriptor).
-- **Supervisor / Admin:** **denied by default**; enabled only via explicit PMCP policy (an operator
-  allowlist). Admin additionally must never print secrets — enforced by the policy gate, and by the
-  cross-server secret-bleed fix already shipped in **v1.19.3** (#96), so an `agent-board` subprocess
-  never receives another server's credentials regardless of tier.
-The exact tool → tier mapping is owned by message-board's tool contract; PMCP consumes their
-self-described tiers and ships the safe set as the provision default.
+**RATIFIED INTENT: default provision = safe tier only — but this is an OPEN OPERATOR STEP, not an
+enforced default. ⚠️ Do not read this section as a shipped guarantee.** Two facts (verified against the
+shipped artifacts, 2026-07-16) mean safe-tier is NOT the effective default until the operator gates it:
+- The shipped `agent-board-mcp@1.2.2` server registers **all** tool tiers (`safe_default` + `supervisor`
+  + `elevated_admin`) **unconditionally** — `MCP_TOOL_GROUPS` exists but nothing gates registration on it.
+- PMCP's tool policy **defaults to allow-all** (`policy/policy.py` `is_tool_allowed` returns `True` with
+  no allow/denylist configured), and **no `agent-board` policy or manifest stub landed** in this repo.
+
+So with the overlay entry alone, every harness on the gateway can reach the supervisor/admin tools over a
+`service_role` connection (which bypasses RLS). **The operator MUST add a PMCP tool-policy denylist** to
+realize the safe-tier default — deny `agent-board::*`, then allow only the safe/read set (status, inbox,
+notification, runtime-diagnostics, fetch-descriptor) plus the send/thread tools actually used (see the
+overlay template's TOOL-TIER SAFETY note). PMCP's `PolicyManager` gates at the **server**/**tool** level
+(`is_server_allowed` / `is_tool_allowed`); there is no native `safe|supervisor|admin` tier enum, so the
+tiers map onto tool allow/deny. Independently, the cross-server secret-bleed fix in **v1.19.3** (#96)
+ensures an `agent-board` subprocess never receives another server's credentials regardless of tier — but
+that is orthogonal to tool-tier gating. The exact tool → tier mapping is owned by message-board's tool
+contract.
 
 ---
 
@@ -133,13 +148,13 @@ self-described tiers and ships the safe set as the provision default.
 |---|---|---|
 | **P0 (this doc)** | Interface confirmations (§1–§5): slot syntax, CRED-1 + ENDPOINT-1 ratified, safe-tier default. **A/B fork now RESOLVED → Option B; `${machine_id}` → operator.** | ✅ done |
 | **P1** | Author the operator `.mcp.json` overlay template (`plans/agent-board-overlay.template.jsonc`). **No schema change.** | ✅ done — pin published to **public npm** (`@consiliency/agent-board-mcp@1.2.2`). |
-| **P2** | Overlay-verbatim entry (Option B); safe-tier via scope policy. Config lives in the operator overlay, not the public catalog. | ✅ done — proven overlay landed (service_role + op:// descriptors). |
+| **P2** | Overlay-verbatim entry (Option B). Config lives in the operator overlay, not the public catalog. | ✅ overlay done (service_role + op:// descriptors). ⚠️ **safe-tier gating is an OPEN operator step, not shipped** — see §5. |
 | **P3** | Live end-to-end provision + VERIFY round-trip. | ✅ **done — send↔receive PROVEN through the gateway 2026-07-16** (see closeout below). |
 
-**Holding at P0 by agreement** (portal + advisor): the stub is cleared to author, but two upstream
-halves gate it — the **published npm pin** (message-board's IF-SCHEMA-1) and the **live endpoint**
-(IF-ENDPOINT-1). PMCP's half fans out to P1 the moment the pin publishes; nothing here is buildable or
-testable before then.
+**(Historical — superseded by the 2026-07-16 go-live; see the closeout below.)** *At the time of
+writing:* holding at P0 by agreement (portal + advisor) — the stub was cleared to author, but two
+upstream halves gated it: the **published npm pin** (message-board's IF-SCHEMA-1) and the **live
+endpoint** (IF-ENDPOINT-1). Both have since landed; P1–P3 are complete.
 
 ---
 
@@ -216,7 +231,8 @@ subprocess gets its own token + config, never another server's secrets. Proven r
 **Superseded by the proven config:** the earlier proposed var names
 (`MESSAGE_BOARD_RUNTIME_MODE`/`_RUNTIME_TRUST_DOMAIN`/`_RUNTIME_BOARD_SCOPE`/`_RUNTIME_CREDENTIAL_DESCRIPTOR`)
 are **not** what the shipped client reads — see the overlay template for the actual contract
-(`BOARD_SCOPE`/`TRUST_DOMAIN` unprefixed; connection + signing via op:// refs; `AGENT_AUTH_MODE`).
+(`MESSAGE_BOARD_BOARD_SCOPE` / `MESSAGE_BOARD_TRUST_DOMAIN` — same `MESSAGE_BOARD_` prefix but **no
+`RUNTIME_` segment**; connection + signing via op:// refs; `MESSAGE_BOARD_AGENT_AUTH_MODE`).
 
 **Durable track (off critical path):** board-native Ed25519 auth-exchange (short-lived tokens minted
 from the host signing key) — **message-board#27**. `service_role` is the ratified stopgap and is

--- a/plans/ROADMAP-pmcp-agent-board-mcp.md
+++ b/plans/ROADMAP-pmcp-agent-board-mcp.md
@@ -55,6 +55,19 @@ So: **multiple env vars and non-secret config are natively expressible via path 
   confirmation *within* CRED-1, **not an amendment** requiring re-ratification. (What *would* require
   re-ratification: changing the descriptor var names, or weakening the descriptor-only property.)
 
+> **RESOLVED (portal + message-board, verified against `agent-board-runtime/src/config.ts`; recorded
+> in the frozen contract §7 / portal #211, merged):** **Option B.** The board credential is a pure
+> 1Password **pointer** — `config.ts` reads only `MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR` /
+> `MESSAGE_BOARD_AGENT_1PASSWORD_ITEM` and resolves it itself; there is **no required raw-secret var**,
+> so there is nothing to store-resolve. Ship the minimal public manifest **stub** for discoverability;
+> the real ENDPOINT/descriptor/config live in the operator `.mcp.json` overlay, **verbatim**. Option A
+> is **not** taken (no store-resolved actual-secret var exists). If a future deployment ever introduces
+> a true-secret var, *that single var* — not the pointers — becomes the Option-A case.
+>
+> **`${machine_id}` RESOLVED:** owned by the **operator / wiring layer** (portal half's `MBP-WIRE`
+> phase), per-host. `config.ts` has no hostname/UUID fallback, so each host's overlay sets
+> `MESSAGE_BOARD_RUNTIME_MACHINE_ID`. It is **not** a PMCP catalog-static value → **not** in the stub.
+
 ## 3. The fork — how the entry is shaped (recommendation + one question back)
 
 The message-board entry needs **6 config vars** (`ENDPOINT`, `SUPABASE_URL`,
@@ -118,10 +131,15 @@ self-described tiers and ships the safe set as the provision default.
 
 | Phase | Deliverable | Gate / blocker |
 |---|---|---|
-| **P0 (this doc)** | Interface confirmations (§1–§5): slot syntax, CRED-1 + ENDPOINT-1 ratified, safe-tier default, the A/B fork + questions back. | none — landing now |
-| **P1** | Resolve the fork with the portal/board (§3 question). If **B**: author the minimal discoverability stub in `manifest.yaml` (+ `env_instructions` documenting the var contract) and the operator `.mcp.json` overlay template — no schema change. If **A**: schema extension roadmap (env block + multi-slot descriptor credentials) as a separate versioned PMCP phase. | blocked on the §3 answer |
-| **P2** | Land the chosen entry (stub or extended) + the safe-tier scope policy default. Discoverable via `catalog_search`; documents the contract. | after P1; no live endpoint needed |
+| **P0 (this doc)** | Interface confirmations (§1–§5): slot syntax, CRED-1 + ENDPOINT-1 ratified, safe-tier default. **A/B fork now RESOLVED → Option B; `${machine_id}` → operator.** | ✅ done |
+| **P1** | Author the minimal Option-B discoverability stub in `manifest.yaml` (command/args `npx -y @consiliency/agent-board-mcp@<pin>`, keywords, description, `env_instructions` documenting the frozen var contract + "needs operator overlay + deployed board") and an operator `.mcp.json` overlay template. **No schema change.** | **blocked on IF-SCHEMA-1** — `@consiliency/agent-board-mcp` is not yet published to npm (no pinnable version; verified E404). Authoring a stub with a nonexistent pin would ship a broken catalog entry. |
+| **P2** | Land the stub + the safe-tier scope-policy default. Discoverable via `catalog_search`; documents the contract. | after P1 (needs the published pin) |
 | **P3** | Live end-to-end provision + VERIFY round-trip. | **blocked on IF-ENDPOINT-1** (board deployed + health probe + owner) and portal#208 drift (IF-DRIFT-1) |
+
+**Holding at P0 by agreement** (portal + advisor): the stub is cleared to author, but two upstream
+halves gate it — the **published npm pin** (message-board's IF-SCHEMA-1) and the **live endpoint**
+(IF-ENDPOINT-1). PMCP's half fans out to P1 the moment the pin publishes; nothing here is buildable or
+testable before then.
 
 ## Acceptance (mirrors the spine VERIFY)
 A real message round-trips: agent A sends via a PMCP-provisioned `agent-board` → board persists →

--- a/plans/ROADMAP-pmcp-agent-board-mcp.md
+++ b/plans/ROADMAP-pmcp-agent-board-mcp.md
@@ -141,6 +141,47 @@ halves gate it — the **published npm pin** (message-board's IF-SCHEMA-1) and t
 (IF-ENDPOINT-1). PMCP's half fans out to P1 the moment the pin publishes; nothing here is buildable or
 testable before then.
 
+---
+
+## Unblock verification — 2026-07-13 (message-board deliverables landed, with two corrections)
+
+message-board reported both deliverables done. **Verified against source of truth:**
+
+- **IF-ENDPOINT-1 — SATISFIED.** `MESSAGE_BOARD_RUNTIME_ENDPOINT = https://mqccjfqngptkemnchlko.supabase.co`
+  (`MODE=embedded_mcp`) is live and reachable over HTTPS (root `404`, `/rest/v1/` `401` — the expected
+  authenticated-only Supabase behavior). Operator overlay template landed:
+  `plans/agent-board-overlay.template.jsonc`.
+- **The mcp pin — EXISTS but on a PRIVATE registry, not public npm (correction).** The hand-off said
+  "fill the catalog with `@consiliency/agent-board-mcp@1.1.0`". That version **does** exist — but on
+  **GitHub Packages** (org `Consiliency`, private, repo `message-board`), **not** public npm
+  (`npm view` → E404). The deployed `@consiliency/agent-board-schema@1.1.0` is the DB *schema bundle*;
+  `agent-board-mcp` is the separate stdio-server package. **New requirement:** a catalog/overlay
+  `npx -y @consiliency/agent-board-mcp@1.1.0` fails against default npm — the `@consiliency` scope must
+  route to `https://npm.pkg.github.com` with a `read:packages` token (an operator `.npmrc`), **or**
+  message-board publishes the mcp package to public npm.
+
+### New coordination question (binds PMCP ↔ message-board)
+**Private GitHub Packages vs public npm for `@consiliency/agent-board-mcp`:** should the operator
+supply a GitHub Packages `.npmrc` + `read:packages` token (folds into the same operator/wiring layer as
+`MACHINE_ID` / the descriptor), or will message-board publish the mcp package to **public npm**? Public
+npm is the cleaner catalog story (no registry auth to distribute); private is fine if the token wiring
+is owned by the operator half. **This decides whether a live provision needs npm-registry wiring.**
+
+### Superseded assumption (recorded, per message-board's flag)
+The endpoint is now a **message-board-owned** Supabase project, not portal-hosted — this **supersedes
+ratified Assumption 1** (endpoint-to-be-portal-hosted). No change to PMCP's half (we consume the URL
+wherever hosted); recorded here for the contract trail.
+
+### Remaining inputs before a LIVE provision + VERIFY round-trip
+1. The registry decision above (public npm, or the GitHub Packages `.npmrc`/token approach).
+2. `MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR` / `MESSAGE_BOARD_AGENT_1PASSWORD_ITEM` — the `op://`
+   descriptor pointers (operator/1Password-owned; not fabricated here).
+3. `MESSAGE_BOARD_RUNTIME_BOARD_SCOPE` and `MACHINE_ID` (per-host, operator/MBP-WIRE).
+
+**Not a PMCP blocker beyond these inputs.** The overlay template is ready; a live `agent-board`
+provision + the VERIFY round-trip fill in the three items above. (Maintainer countersign for the
+Portal's prod mutation is separate and the maintainer's, not PMCP's.)
+
 ## Acceptance (mirrors the spine VERIFY)
 A real message round-trips: agent A sends via a PMCP-provisioned `agent-board` → board persists →
 agent B reads via its own PMCP-provisioned `agent-board`, **zero manual paste, descriptor-based

--- a/plans/ROADMAP-pmcp-agent-board-mcp.md
+++ b/plans/ROADMAP-pmcp-agent-board-mcp.md
@@ -132,9 +132,9 @@ self-described tiers and ships the safe set as the provision default.
 | Phase | Deliverable | Gate / blocker |
 |---|---|---|
 | **P0 (this doc)** | Interface confirmations (§1–§5): slot syntax, CRED-1 + ENDPOINT-1 ratified, safe-tier default. **A/B fork now RESOLVED → Option B; `${machine_id}` → operator.** | ✅ done |
-| **P1** | Author the minimal Option-B discoverability stub in `manifest.yaml` (command/args `npx -y @consiliency/agent-board-mcp@<pin>`, keywords, description, `env_instructions` documenting the frozen var contract + "needs operator overlay + deployed board") and an operator `.mcp.json` overlay template. **No schema change.** | **blocked on IF-SCHEMA-1** — `@consiliency/agent-board-mcp` is not yet published to npm (no pinnable version; verified E404). Authoring a stub with a nonexistent pin would ship a broken catalog entry. |
-| **P2** | Land the stub + the safe-tier scope-policy default. Discoverable via `catalog_search`; documents the contract. | after P1 (needs the published pin) |
-| **P3** | Live end-to-end provision + VERIFY round-trip. | **blocked on IF-ENDPOINT-1** (board deployed + health probe + owner) and portal#208 drift (IF-DRIFT-1) |
+| **P1** | Author the operator `.mcp.json` overlay template (`plans/agent-board-overlay.template.jsonc`). **No schema change.** | ✅ done — pin published to **public npm** (`@consiliency/agent-board-mcp@1.2.2`). |
+| **P2** | Overlay-verbatim entry (Option B); safe-tier via scope policy. Config lives in the operator overlay, not the public catalog. | ✅ done — proven overlay landed (service_role + op:// descriptors). |
+| **P3** | Live end-to-end provision + VERIFY round-trip. | ✅ **done — send↔receive PROVEN through the gateway 2026-07-16** (see closeout below). |
 
 **Holding at P0 by agreement** (portal + advisor): the stub is cleared to author, but two upstream
 halves gate it — the **published npm pin** (message-board's IF-SCHEMA-1) and the **live endpoint**
@@ -187,3 +187,38 @@ A real message round-trips: agent A sends via a PMCP-provisioned `agent-board` �
 agent B reads via its own PMCP-provisioned `agent-board`, **zero manual paste, descriptor-based
 credentials only.** PMCP's half is *done* for P0–P2 once the entry is discoverable + safe-tier-gated
 and the credential path is descriptor-only; P3 is jointly gated with the board-deploy + drift halves.
+
+---
+
+## GO-LIVE COMPLETE — 2026-07-16
+
+**Acceptance met.** Signed send↔receive proven end-to-end through the PMCP gateway, descriptor-only:
+
+- `create_thread` → `ok:true` (thread `e67e9cc5-…`); earlier gateway-native proof `ea9202ae-…`.
+- `send_direct_message` → `ok:true`, `message_id 9ef6849f-…`, delivered `inbox_item 01f3d919-…`,
+  Ed25519 `verification_status:"signed"` (enforcementMode `observe`).
+- read back via `agent_board.v_thread_feed` → the message retrieved. `mode:service_role, valid:true`.
+
+**What unblocked P3 (both shipped upstream):**
+1. **`@consiliency/agent-board-mcp@1.2.2` on public npm** — resolves the registry question (public npm,
+   no `.npmrc`/token). Reads `MESSAGE_BOARD_AGENT_AUTH_MODE` and passes it to the client, enabling a
+   **signed `service_role` write with no user session** (the shipped client otherwise requires a
+   user-scoped session, which headless hosts can't mint).
+2. **op://-in-env resolution in mcp 1.2.2 / client 1.2.1** — the env credential path now resolves op://
+   descriptors in-client, so CRED-1 (descriptor-only) holds with a plain `npx` spawn. (On 1.2.1 the env
+   path read values literally → needed an `op run --` wrapper; unnecessary on 1.2.2.)
+
+**Operating mode (ratified):** `service_role` + Ed25519 signing. The only secret at rest is
+`OP_SERVICE_ACCOUNT_TOKEN` (secret-zero) — every other credential stays an op:// pointer. #96 held: the
+subprocess gets its own token + config, never another server's secrets. Proven recipe:
+`plans/agent-board-overlay.template.jsonc`.
+
+**Superseded by the proven config:** the earlier proposed var names
+(`MESSAGE_BOARD_RUNTIME_MODE`/`_RUNTIME_TRUST_DOMAIN`/`_RUNTIME_BOARD_SCOPE`/`_RUNTIME_CREDENTIAL_DESCRIPTOR`)
+are **not** what the shipped client reads — see the overlay template for the actual contract
+(`BOARD_SCOPE`/`TRUST_DOMAIN` unprefixed; connection + signing via op:// refs; `AGENT_AUTH_MODE`).
+
+**Durable track (off critical path):** board-native Ed25519 auth-exchange (short-lived tokens minted
+from the host signing key) — **message-board#27**. `service_role` is the ratified stopgap and is
+holding. The op://-in-env ergonomic was **message-board#29**, now shipped. Coordination PR closed by
+merge; message-board delivery plane confirmed complete on their side.

--- a/plans/ROADMAP-pmcp-agent-board-mcp.md
+++ b/plans/ROADMAP-pmcp-agent-board-mcp.md
@@ -1,0 +1,130 @@
+# PMCP half — register `@consiliency/agent-board-mcp` (message-board delivery plane)
+
+> **Owner:** PMCP. **Responds to:** `plans/HANDOFF-agent-board-mcp-registration.md` (from
+> `Consiliency/consiliency-portal` PR #210) and the spine contract
+> `consiliency-portal:plans/unification/message-board-plane/CONTRACT-message-board-plane.md`.
+> **Ratifies:** IF-0-MBPLANE-CRED-1, IF-0-MBPLANE-ENDPOINT-1.
+> **Scope of this doc:** the two interface confirmations + a phased roadmap. **No PMCP code is
+> changed by this artifact** — a live provision is blocked on the board endpoint (IF-ENDPOINT-1),
+> so nothing fans out until the fork below is resolved.
+
+---
+
+## 1. Confirmation — the credential-slot syntax (ask #1)
+
+**PMCP does not have a `${cred:namespace/key}` slot syntax.** The proposal's
+`${cred:agent-board/credential-descriptor}` does not match PMCP's model; the contract left this open
+("*slot syntax is whatever PMCP's current secrets rework defines … PMCP confirms*"), so this is the
+confirmation.
+
+PMCP's credential model has **two** distinct injection paths, and which one applies decides the fork
+in §3:
+
+1. **Manifest catalog entry (public `manifest.yaml`) — store-resolved, single slot.**
+   A manifest server declares `env_var` (the runtime var the subprocess reads) and, optionally,
+   `secret_key` (a namespaced storage key). At `pmcp_provision`, PMCP resolves the value from its
+   secret store via `credential_lookup_keys` (namespaced `secret_key` first, then legacy `env_var`)
+   and injects it into the subprocess under `env_var`. The value is stored out-of-band
+   (`pmcp secrets set <secret_key> <value>` or `gateway.auth_connect`), **not** interpolated from a
+   `${…}` token. Today this supports **exactly one** credential var per server, and the public
+   `ServerConfig` schema has **no `env:` block** for non-secret config (verified: `manifest/loader.py`
+   `ServerConfig`, and the private overlay reuses the same class).
+
+2. **Configured `.mcp.json` / private overlay entry — verbatim env.**
+   A local `.mcp.json` entry carries an arbitrary `env: { … }` map, injected **verbatim** into the
+   subprocess (this is exactly how `firecrawl` / `browser-use` ship multi-var config today). Local
+   stdio env is **not** `${VAR}`-expanded (only remote HTTP headers are). PMCP's recent namespacing
+   work resolves a *dead* `${VAR}`/`$VAR` placeholder in a server's own declared credential slot to
+   the namespaced credential — but there is no general `${cred:ns/key}` scheme.
+
+So: **multiple env vars and non-secret config are natively expressible via path (2), not path (1).**
+
+## 2. Ratification — IF-0-MBPLANE-CRED-1 (ask #1 + descriptor-only)
+
+**RATIFIED**, with one precision the portal + board halves must record:
+
+- **PMCP's contribution to "descriptor pointer only, never a raw signing key" is *structural*, not
+  *validational*.** PMCP injects only the env vars an entry declares and will declare **no** raw-key
+  var for `agent-board` — so no key material is injected *by construction*. PMCP treats the stored/
+  configured value **opaquely**; it does **not** inspect that the value is a `1password` descriptor
+  vs. a key. The "never a raw key" guarantee therefore rests on **(a)** the entry declaring only
+  descriptor-named slots (`MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR` /
+  `MESSAGE_BOARD_AGENT_1PASSWORD_ITEM`), and **(b)** the board rejecting raw keys by contract — not on
+  PMCP validating the value. This is a *strengthening* clarification, not a weakening.
+- The var **names** are unchanged and the descriptor-only property is preserved, so this is a
+  confirmation *within* CRED-1, **not an amendment** requiring re-ratification. (What *would* require
+  re-ratification: changing the descriptor var names, or weakening the descriptor-only property.)
+
+## 3. The fork — how the entry is shaped (recommendation + one question back)
+
+The message-board entry needs **6 config vars** (`ENDPOINT`, `SUPABASE_URL`,
+`MODE=embedded_mcp`, `TRUST_DOMAIN`, `BOARD_SCOPE`, `MACHINE_ID`) + **2 descriptor slots**
+(`CREDENTIAL_DESCRIPTOR`, `1PASSWORD_ITEM`) + an optional `REFRESH_TOKEN`. Two ways to land that:
+
+### Option B — overlay-verbatim entry + minimal manifest stub  ← **recommended**
+- Ship a **minimal public manifest stub** `agent-board` (command/args + keywords + description +
+  `env_instructions` documenting the full var contract) purely for **discoverability**
+  (`gateway_catalog_search` / `gateway.request_capability` surface it).
+- The real **config + descriptor pointers** live in the operator's `.mcp.json` (or private overlay)
+  `env:` map, injected verbatim. **The descriptor pointers are `op://…` references — pointers, not
+  secret material — so literal config is appropriate;** PMCP still never sees a raw key.
+- **Zero PMCP schema change. Lands today.** Config that is per-deployment/org-specific — `ENDPOINT`
+  is literally unknown until the board deploys — correctly stays *out* of PMCP's shipped public
+  catalog and in the operator overlay.
+
+### Option A — extend the manifest/overlay schema (store-resolved, multi-slot)
+Only if the portal/board require the descriptor pointer to be **resolved through PMCP's secret store**
+(not literal overlay config). Then PMCP's `ServerConfig` (public manifest *and* the v1.18.0 private
+overlay) gains **(i)** an `env:` config block and **(ii)** support for **multiple** descriptor-only
+credential slots (each `secret_key`-namespaced), plus the resolver injecting all of them. Heavier,
+and it builds against an interface three other repos have not finished — **defer** unless required.
+
+### → Question back to the portal / message-board (blocks choosing A vs B)
+**Do the descriptor pointers (`CREDENTIAL_DESCRIPTOR`, `1PASSWORD_ITEM`) need to be resolved through
+PMCP's secret store, or is literal `.mcp.json`/overlay config acceptable?** Since a 1Password
+*pointer* is not itself the secret, Option B (literal overlay config) is defensible and collapses
+PMCP's half to a stub + scope policy. If store-resolution is a hard requirement, we take Option A.
+
+Secondary open item (not scoped work here): **`MESSAGE_BOARD_RUNTIME_MACHINE_ID: "${machine_id}"`** —
+PMCP does not resolve a `${machine_id}` token. Confirm whether per-host identity is **board-side**
+(the runtime derives it) or must be **PMCP-side** (PMCP could source it from its `identity` module).
+If PMCP-side, it's a small additive item folded into whichever option we take.
+
+## 4. Ratification — IF-0-MBPLANE-ENDPOINT-1 (ask #3 context)
+
+**RATIFIED as consumed.** The entry targets `MESSAGE_BOARD_RUNTIME_ENDPOINT` with
+`MESSAGE_BOARD_RUNTIME_MODE=embedded_mcp` (enum `standalone | embedded_mcp`; PMCP treats these as
+opaque config values). PMCP asserts nothing about a `gateway` runtime mode — "gateway-only delivery"
+is the board's enforcement property, not a PMCP concern. **A live provision is blocked until this
+endpoint + health probe exist and are owned;** the discoverability stub (Option B) can land ahead.
+
+## 5. Scope / tier policy (ask #3) — safe-tier default
+
+**RATIFIED: default provision = safe tier only.** PMCP's `PolicyManager` gates at the **server** and
+**tool** level (`is_server_allowed` / `is_tool_allowed`); there is no native `safe|supervisor|admin`
+*tier enum*, so the three tiers map onto tool allow/deny:
+- **Safe (default):** allow the read-only/metadata-safe tools (status, inbox, notification, runtime
+  diagnostics, fetch-descriptor).
+- **Supervisor / Admin:** **denied by default**; enabled only via explicit PMCP policy (an operator
+  allowlist). Admin additionally must never print secrets — enforced by the policy gate, and by the
+  cross-server secret-bleed fix already shipped in **v1.19.3** (#96), so an `agent-board` subprocess
+  never receives another server's credentials regardless of tier.
+The exact tool → tier mapping is owned by message-board's tool contract; PMCP consumes their
+self-described tiers and ships the safe set as the provision default.
+
+---
+
+## Phased roadmap (PMCP half)
+
+| Phase | Deliverable | Gate / blocker |
+|---|---|---|
+| **P0 (this doc)** | Interface confirmations (§1–§5): slot syntax, CRED-1 + ENDPOINT-1 ratified, safe-tier default, the A/B fork + questions back. | none — landing now |
+| **P1** | Resolve the fork with the portal/board (§3 question). If **B**: author the minimal discoverability stub in `manifest.yaml` (+ `env_instructions` documenting the var contract) and the operator `.mcp.json` overlay template — no schema change. If **A**: schema extension roadmap (env block + multi-slot descriptor credentials) as a separate versioned PMCP phase. | blocked on the §3 answer |
+| **P2** | Land the chosen entry (stub or extended) + the safe-tier scope policy default. Discoverable via `catalog_search`; documents the contract. | after P1; no live endpoint needed |
+| **P3** | Live end-to-end provision + VERIFY round-trip. | **blocked on IF-ENDPOINT-1** (board deployed + health probe + owner) and portal#208 drift (IF-DRIFT-1) |
+
+## Acceptance (mirrors the spine VERIFY)
+A real message round-trips: agent A sends via a PMCP-provisioned `agent-board` → board persists →
+agent B reads via its own PMCP-provisioned `agent-board`, **zero manual paste, descriptor-based
+credentials only.** PMCP's half is *done* for P0–P2 once the entry is discoverable + safe-tier-gated
+and the credential path is descriptor-only; P3 is jointly gated with the board-deploy + drift halves.

--- a/plans/agent-board-overlay.template.jsonc
+++ b/plans/agent-board-overlay.template.jsonc
@@ -1,6 +1,12 @@
 // Operator overlay entry for @consiliency/agent-board-mcp (Option B — verbatim .mcp.json).
-// Drop into ~/.pmcp.json. PMCP injects `env` VERBATIM — NO ${VAR}/${cred}/${machine_id} expansion
-// (those coordination-proposal placeholders would ship as literal broken strings; use real values or op:// refs).
+// WHERE THIS GOES: add the "agent-board" entry to the config file your gateway actually reads — either
+// PMCP's default user path `~/.mcp.json` (or `~/.claude/.mcp.json`), or a custom file you pass via
+// `pmcp -c <file>` / `PMCP_CONFIG`. NOTE: `~/.pmcp.json` is NOT a default PMCP path — it only works when
+// the gateway is launched with `-c ~/.pmcp.json` explicitly (as the go-live host is). Putting the entry in
+// `~/.pmcp.json` without that flag is silently ignored. PREREQUISITE: the 1Password `op` CLI must be on
+// PATH (the client shells out to `op read` to resolve the op:// refs below).
+// PMCP injects `env` VERBATIM — NO ${VAR}/${cred}/${machine_id} expansion (those coordination-proposal
+// placeholders would ship as literal broken strings; use real values or op:// refs).
 //
 // STATUS: send↔receive PROVEN end-to-end THROUGH THE PMCP GATEWAY on 2026-07-16.
 //   create_thread -> ok:true; send_direct_message -> ok:true, Ed25519 verification_status:"signed"
@@ -32,8 +38,9 @@
         "MESSAGE_BOARD_TRUST_DOMAIN": "consiliency",           // NOT ..._RUNTIME_TRUST_DOMAIN
         "MESSAGE_BOARD_RUNTIME_MACHINE_ID": "<<FILL: per-host machine id, e.g. /etc/machine-id>>",
 
-        // --- auth mode: service_role is the ratified operating mode (panel 3-then-1). Without this the
-        //     client defaults to user_scoped and every write fails "missing_credentials". ---
+        // --- auth mode: service_role is the ratified operating mode (stopgap while the durable board-native
+        //     auth-exchange is built, message-board#27). Without this the client defaults to user_scoped and
+        //     every write fails "missing_credentials". ---
         "MESSAGE_BOARD_AGENT_AUTH_MODE": "service_role",
 
         // --- connection credential as an op:// DESCRIPTOR (CRED-1). 1.2.2 resolves it in-client. ---
@@ -48,7 +55,10 @@
         "MESSAGE_BOARD_SIGNING_PRIVATE_KEY": "op://Consiliency Deploy Secrets/Agent Board Signing - PMCP host <<FILL machine_id>>/private_key_pem",
 
         // --- secret-zero: op token that lets the client resolve the op:// descriptors above headlessly.
-        //     A live 1Password service-account token with read on the vault — the one secret at rest. ---
+        //     A live 1Password service-account token — the one secret at rest. HARDENING: 1Password SA
+        //     tokens scope at VAULT granularity, so a token with read on "Consiliency Deploy Secrets"
+        //     grants this subprocess read on EVERY item in that vault, not just the two agent-board items.
+        //     Prefer a DEDICATED vault holding only the agent-board descriptors for least-privilege. ---
         "OP_SERVICE_ACCOUNT_TOKEN": "<<FILL: ops_... service-account token with read on the vault above>>"
       }
     }
@@ -59,6 +69,16 @@
 // list_thread_messages). Recipient is a plain agent_id string (p_recipient_agent_id), not a descriptor.
 // create_or_find_thread IS exposed. verification_status:"signed" is the success signal while the board's
 // signing enforcementMode is "observe".
+//
+// ⚠️ TOOL-TIER SAFETY — the default is NOT least-privilege; you must add a policy denylist yourself.
+//   The shipped agent-board-mcp server registers ALL tool tiers (safe_default + supervisor + elevated_admin)
+//   UNCONDITIONALLY, and PMCP's tool policy defaults to allow-all — so with this entry alone, every harness
+//   on the gateway can call the supervisor/admin tools over a service_role connection (which bypasses RLS).
+//   To ship the intended safe-tier default, gate agent-board in your PMCP policy — deny the elevated tools
+//   and allow only the safe/read set, e.g.:
+//     PMCP_POLICY (or your policy config):  deny "agent-board::*"  then allow the safe tools explicitly
+//     (status / inbox / notification / runtime-diagnostics / fetch-descriptor + the send/thread tools you
+//      actually use). Do NOT leave supervisor/admin reachable by default.
 //
 // DURABLE track (not on the critical path): board-native Ed25519 auth-exchange endpoint (short-lived
 // tokens minted from the host's signing key) — tracked at message-board#27. service_role is the ratified

--- a/plans/agent-board-overlay.template.jsonc
+++ b/plans/agent-board-overlay.template.jsonc
@@ -1,0 +1,43 @@
+// Operator overlay entry for @consiliency/agent-board-mcp (Option B — verbatim .mcp.json).
+// Drop this into ~/.pmcp.json (or a project .mcp.json / private overlay). PMCP injects the
+// `env` map VERBATIM; the board runtime resolves the credential DESCRIPTOR itself.
+// Values marked <<FILL>> are operator/wiring-owned and are NOT PMCP catalog-static.
+//
+// VERIFIED 2026-07-13:
+//   - endpoint live: https://mqccjfqngptkemnchlko.supabase.co (MODE=embedded_mcp) — reachable, auth-only.
+//   - @consiliency/agent-board-mcp@1.1.0 exists on PRIVATE GitHub Packages (org Consiliency),
+//     NOT public npm. `npx` against default npm returns E404 — see the .npmrc requirement below.
+{
+  "mcpServers": {
+    "agent-board": {
+      "command": "npx",
+      "args": ["-y", "@consiliency/agent-board-mcp@1.1.0"],
+      "env": {
+        // --- non-secret config (confirmed) ---
+        "MESSAGE_BOARD_RUNTIME_ENDPOINT": "https://mqccjfqngptkemnchlko.supabase.co",
+        "MESSAGE_BOARD_SUPABASE_URL": "https://mqccjfqngptkemnchlko.supabase.co",
+        "MESSAGE_BOARD_RUNTIME_MODE": "embedded_mcp",
+        "MESSAGE_BOARD_RUNTIME_TRUST_DOMAIN": "consiliency",
+
+        // --- operator/wiring-owned (must be filled per deployment/host) ---
+        "MESSAGE_BOARD_RUNTIME_BOARD_SCOPE": "<<FILL: board scope>>",
+        "MESSAGE_BOARD_RUNTIME_MACHINE_ID": "<<FILL: per-host id — operator/MBP-WIRE, PMCP does not derive ${machine_id}>>",
+
+        // --- CREDENTIAL SLOT: a 1Password DESCRIPTOR POINTER only (CRED-1 Option B). NEVER a key. ---
+        "MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR": "<<FILL: op:// 1Password reference>>",
+        "MESSAGE_BOARD_AGENT_1PASSWORD_ITEM": "<<FILL: op:// 1Password item reference>>"
+      }
+    }
+  }
+}
+
+// PRIVATE-REGISTRY REQUIREMENT (new — surfaced 2026-07-13):
+// @consiliency/agent-board-mcp is on GitHub Packages, so the operator's npm environment must
+// route the @consiliency scope there, e.g. in ~/.npmrc:
+//
+//   @consiliency:registry=https://npm.pkg.github.com
+//   //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN_WITH_read_packages}
+//
+// Without this, `npx -y @consiliency/agent-board-mcp@1.1.0` fails E404. This is an operator/
+// wiring concern (like MACHINE_ID and the descriptor) — OR message-board publishes the mcp
+// package to public npm, which removes the requirement. See the coordination question in the roadmap.

--- a/plans/agent-board-overlay.template.jsonc
+++ b/plans/agent-board-overlay.template.jsonc
@@ -1,43 +1,45 @@
 // Operator overlay entry for @consiliency/agent-board-mcp (Option B — verbatim .mcp.json).
-// Drop this into ~/.pmcp.json (or a project .mcp.json / private overlay). PMCP injects the
-// `env` map VERBATIM; the board runtime resolves the credential DESCRIPTOR itself.
-// Values marked <<FILL>> are operator/wiring-owned and are NOT PMCP catalog-static.
+// Drop into ~/.pmcp.json. PMCP injects `env` VERBATIM — NO ${VAR}/${cred}/${machine_id} expansion
+// (those coordination-proposal placeholders would ship as literal broken strings; use real values).
 //
-// VERIFIED 2026-07-13:
-//   - endpoint live: https://mqccjfqngptkemnchlko.supabase.co (MODE=embedded_mcp) — reachable, auth-only.
-//   - @consiliency/agent-board-mcp@1.1.0 exists on PRIVATE GitHub Packages (org Consiliency),
-//     NOT public npm. `npx` against default npm returns E404 — see the .npmrc requirement below.
+// VERIFIED 2026-07-15 against the SHIPPED client @consiliency/agent-board-client@1.2.0 (the dep the
+// mcp package delegates config to). The env var names below are the ONES THE CLIENT ACTUALLY READS —
+// they differ from the earlier coordination messages (no RUNTIME_ prefix on SCOPE/TRUST_DOMAIN;
+// descriptor is VAULT+ITEM; there is no MESSAGE_BOARD_RUNTIME_MODE / _RUNTIME_CREDENTIAL_DESCRIPTOR).
+//
+// READ HALF PROVEN THROUGH THE PMCP GATEWAY: gateway_connect_server(agent-board) -> online, descriptor
+// resolved, gateway_invoke(agent_board.runtime_status) -> {ok:true, ready:true, missingFields:[],
+// boardScope:"consiliency", noSecret:true}. #96 held: the subprocess got its own op token + config but
+// NOT other servers' PMCP-managed secrets. Entry was removed from ~/.pmcp.json after the proof so no
+// live op token sits at rest until the send half is wired.
 {
   "mcpServers": {
     "agent-board": {
       "command": "npx",
-      "args": ["-y", "@consiliency/agent-board-mcp@1.1.0"],
+      "args": ["-y", "@consiliency/agent-board-mcp@1.2.0"],   // public npm — no registry token
       "env": {
-        // --- non-secret config (confirmed) ---
+        // --- non-secret config (confirmed / proven) ---
         "MESSAGE_BOARD_RUNTIME_ENDPOINT": "https://mqccjfqngptkemnchlko.supabase.co",
         "MESSAGE_BOARD_SUPABASE_URL": "https://mqccjfqngptkemnchlko.supabase.co",
-        "MESSAGE_BOARD_RUNTIME_MODE": "embedded_mcp",
-        "MESSAGE_BOARD_RUNTIME_TRUST_DOMAIN": "consiliency",
+        "MESSAGE_BOARD_BOARD_SCOPE": "consiliency",            // NOT ..._RUNTIME_BOARD_SCOPE; value=consiliency (proven; go-live prompt's "message-board" was wrong)
+        "MESSAGE_BOARD_TRUST_DOMAIN": "consiliency",           // NOT ..._RUNTIME_TRUST_DOMAIN
+        "MESSAGE_BOARD_RUNTIME_MACHINE_ID": "<<FILL: per-host machine id, e.g. /etc/machine-id>>",
 
-        // --- operator/wiring-owned (must be filled per deployment/host) ---
-        "MESSAGE_BOARD_RUNTIME_BOARD_SCOPE": "<<FILL: board scope>>",
-        "MESSAGE_BOARD_RUNTIME_MACHINE_ID": "<<FILL: per-host id — operator/MBP-WIRE, PMCP does not derive ${machine_id}>>",
+        // --- credential DESCRIPTOR (CRED-1 Option B): 1Password item pointer; carries url/anon/service_role only ---
+        "MESSAGE_BOARD_AGENT_1PASSWORD_VAULT": "Consiliency Deploy Secrets",
+        "MESSAGE_BOARD_AGENT_1PASSWORD_ITEM": "Agent Board API Keys - message-board canonical mqccjfqngptkemnchlko",
 
-        // --- CREDENTIAL SLOT: a 1Password DESCRIPTOR POINTER only (CRED-1 Option B). NEVER a key. ---
-        "MESSAGE_BOARD_RUNTIME_CREDENTIAL_DESCRIPTOR": "<<FILL: op:// 1Password reference>>",
-        "MESSAGE_BOARD_AGENT_1PASSWORD_ITEM": "<<FILL: op:// 1Password item reference>>"
+        // --- secret-zero: op token that lets the runtime resolve the descriptor. Scoped HERE (not pmcp.env,
+        //     which #96 would strip; not the gateway ambient env, which would bleed to all servers).
+        //     A live 1Password service-account token — treat as a secret at rest. ---
+        "OP_SERVICE_ACCOUNT_TOKEN": "<<FILL: ops_... service-account token with read on the vault above>>"
+
+        // --- SEND HALF (signed writes) — STILL BLOCKED pending message-board's per-host signing-identity flow.
+        //     The board is signed-write enforced and the descriptor has NO signing key. To send, add the agent
+        //     signing identity the client reads: MESSAGE_BOARD_SIGNING_PRIVATE_KEY, MESSAGE_BOARD_SIGNING_KEY_ID,
+        //     (MESSAGE_BOARD_SIGNING_KEY_VERSION / _SIGNING_PUBLIC_KEY_FINGERPRINT), plus the agent identity
+        //     (MESSAGE_BOARD_AGENT_ID / _AGENT_ROLE) minted via register_agent. Awaiting the exact flow. ---
       }
     }
   }
 }
-
-// PRIVATE-REGISTRY REQUIREMENT (new — surfaced 2026-07-13):
-// @consiliency/agent-board-mcp is on GitHub Packages, so the operator's npm environment must
-// route the @consiliency scope there, e.g. in ~/.npmrc:
-//
-//   @consiliency:registry=https://npm.pkg.github.com
-//   //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN_WITH_read_packages}
-//
-// Without this, `npx -y @consiliency/agent-board-mcp@1.1.0` fails E404. This is an operator/
-// wiring concern (like MACHINE_ID and the descriptor) — OR message-board publishes the mcp
-// package to public npm, which removes the requirement. See the coordination question in the roadmap.

--- a/plans/agent-board-overlay.template.jsonc
+++ b/plans/agent-board-overlay.template.jsonc
@@ -1,45 +1,65 @@
 // Operator overlay entry for @consiliency/agent-board-mcp (Option B — verbatim .mcp.json).
 // Drop into ~/.pmcp.json. PMCP injects `env` VERBATIM — NO ${VAR}/${cred}/${machine_id} expansion
-// (those coordination-proposal placeholders would ship as literal broken strings; use real values).
+// (those coordination-proposal placeholders would ship as literal broken strings; use real values or op:// refs).
 //
-// VERIFIED 2026-07-15 against the SHIPPED client @consiliency/agent-board-client@1.2.0 (the dep the
-// mcp package delegates config to). The env var names below are the ONES THE CLIENT ACTUALLY READS —
-// they differ from the earlier coordination messages (no RUNTIME_ prefix on SCOPE/TRUST_DOMAIN;
-// descriptor is VAULT+ITEM; there is no MESSAGE_BOARD_RUNTIME_MODE / _RUNTIME_CREDENTIAL_DESCRIPTOR).
+// STATUS: send↔receive PROVEN end-to-end THROUGH THE PMCP GATEWAY on 2026-07-16.
+//   create_thread -> ok:true; send_direct_message -> ok:true, Ed25519 verification_status:"signed"
+//   (enforcementMode "observe"); read back via agent_board.v_thread_feed. mode:service_role, valid:true.
 //
-// READ HALF PROVEN THROUGH THE PMCP GATEWAY: gateway_connect_server(agent-board) -> online, descriptor
-// resolved, gateway_invoke(agent_board.runtime_status) -> {ok:true, ready:true, missingFields:[],
-// boardScope:"consiliency", noSecret:true}. #96 held: the subprocess got its own op token + config but
-// NOT other servers' PMCP-managed secrets. Entry was removed from ~/.pmcp.json after the proof so no
-// live op token sits at rest until the send half is wired.
+// Two things unblocked the send half (both shipped):
+//   1. @consiliency/agent-board-mcp@1.2.2 reads MESSAGE_BOARD_AGENT_AUTH_MODE and passes it to the
+//      client -> enables a signed service_role write with NO user session (the shipped client requires
+//      a user session otherwise, which headless hosts can't mint).
+//   2. mcp 1.2.2 / client 1.2.1 RESOLVE op:// refs inside the env credential path themselves (they shell
+//      out to `op read`). So secrets stay as op:// descriptors (CRED-1) and PMCP still injects env verbatim.
+//      NOTE: on 1.2.1 the env path read values LITERALLY (op:// reached Supabase as a literal key ->
+//      "Invalid API key"); that release needed an `op run --` spawn wrapper. On 1.2.2 the wrapper is
+//      NO LONGER NEEDED — use a plain `npx` command as below.
+//
+// The ONLY secret at rest is OP_SERVICE_ACCOUNT_TOKEN (secret-zero) — it is what lets every other secret
+// stay an op:// pointer. Scope it HERE (not pmcp.env, which #96 would strip; not the gateway ambient env,
+// which would bleed to all servers — #96 held: the subprocess gets its own token + config, not others').
 {
   "mcpServers": {
     "agent-board": {
       "command": "npx",
-      "args": ["-y", "@consiliency/agent-board-mcp@1.2.0"],   // public npm — no registry token
+      "args": ["-y", "@consiliency/agent-board-mcp@1.2.2"],   // public npm — no registry token
       "env": {
-        // --- non-secret config (confirmed / proven) ---
+        // --- non-secret config (proven) ---
         "MESSAGE_BOARD_RUNTIME_ENDPOINT": "https://mqccjfqngptkemnchlko.supabase.co",
         "MESSAGE_BOARD_SUPABASE_URL": "https://mqccjfqngptkemnchlko.supabase.co",
-        "MESSAGE_BOARD_BOARD_SCOPE": "consiliency",            // NOT ..._RUNTIME_BOARD_SCOPE; value=consiliency (proven; go-live prompt's "message-board" was wrong)
+        "MESSAGE_BOARD_BOARD_SCOPE": "consiliency",            // NOT ..._RUNTIME_BOARD_SCOPE
         "MESSAGE_BOARD_TRUST_DOMAIN": "consiliency",           // NOT ..._RUNTIME_TRUST_DOMAIN
         "MESSAGE_BOARD_RUNTIME_MACHINE_ID": "<<FILL: per-host machine id, e.g. /etc/machine-id>>",
 
-        // --- credential DESCRIPTOR (CRED-1 Option B): 1Password item pointer; carries url/anon/service_role only ---
-        "MESSAGE_BOARD_AGENT_1PASSWORD_VAULT": "Consiliency Deploy Secrets",
-        "MESSAGE_BOARD_AGENT_1PASSWORD_ITEM": "Agent Board API Keys - message-board canonical mqccjfqngptkemnchlko",
+        // --- auth mode: service_role is the ratified operating mode (panel 3-then-1). Without this the
+        //     client defaults to user_scoped and every write fails "missing_credentials". ---
+        "MESSAGE_BOARD_AGENT_AUTH_MODE": "service_role",
 
-        // --- secret-zero: op token that lets the runtime resolve the descriptor. Scoped HERE (not pmcp.env,
-        //     which #96 would strip; not the gateway ambient env, which would bleed to all servers).
-        //     A live 1Password service-account token — treat as a secret at rest. ---
+        // --- connection credential as an op:// DESCRIPTOR (CRED-1). 1.2.2 resolves it in-client. ---
+        "MESSAGE_BOARD_SUPABASE_SERVICE_ROLE_KEY": "op://Consiliency Deploy Secrets/Agent Board API Keys - message-board canonical mqccjfqngptkemnchlko/service_role_key",
+
+        // --- per-host signing identity (enrolled via message-board register flow). agent_id + key are
+        //     per host; the private key stays an op:// descriptor. ---
+        "MESSAGE_BOARD_AGENT_ID": "<<FILL: per-host agent id (uuid) from register_agent>>",
+        "MESSAGE_BOARD_SIGNING_KEY_ID": "<<FILL: e.g. pmcp-<machine_id>-k1>>",
+        "MESSAGE_BOARD_SIGNING_KEY_VERSION": "1",
+        "MESSAGE_BOARD_SIGNING_PUBLIC_KEY_FINGERPRINT": "<<FILL: sha256:... of the enrolled public key>>",
+        "MESSAGE_BOARD_SIGNING_PRIVATE_KEY": "op://Consiliency Deploy Secrets/Agent Board Signing - PMCP host <<FILL machine_id>>/private_key_pem",
+
+        // --- secret-zero: op token that lets the client resolve the op:// descriptors above headlessly.
+        //     A live 1Password service-account token with read on the vault — the one secret at rest. ---
         "OP_SERVICE_ACCOUNT_TOKEN": "<<FILL: ops_... service-account token with read on the vault above>>"
-
-        // --- SEND HALF (signed writes) — STILL BLOCKED pending message-board's per-host signing-identity flow.
-        //     The board is signed-write enforced and the descriptor has NO signing key. To send, add the agent
-        //     signing identity the client reads: MESSAGE_BOARD_SIGNING_PRIVATE_KEY, MESSAGE_BOARD_SIGNING_KEY_ID,
-        //     (MESSAGE_BOARD_SIGNING_KEY_VERSION / _SIGNING_PUBLIC_KEY_FINGERPRINT), plus the agent identity
-        //     (MESSAGE_BOARD_AGENT_ID / _AGENT_ROLE) minted via register_agent. Awaiting the exact flow. ---
       }
     }
   }
 }
+//
+// Reads use the views agent_board.v_thread_feed / v_agent_inbox / v_board_feed (there is no
+// list_thread_messages). Recipient is a plain agent_id string (p_recipient_agent_id), not a descriptor.
+// create_or_find_thread IS exposed. verification_status:"signed" is the success signal while the board's
+// signing enforcementMode is "observe".
+//
+// DURABLE track (not on the critical path): board-native Ed25519 auth-exchange endpoint (short-lived
+// tokens minted from the host's signing key) — tracked at message-board#27. service_role is the ratified
+// stopgap and is holding. The op://-in-env ergonomic (message-board#29) is now shipped in 1.2.1/1.2.2.


### PR DESCRIPTION
Inbound coordination hand-off from `Consiliency/consiliency-portal` PR #210. A concrete proposal for PMCP to **register `@consiliency/agent-board-mcp`** in the catalog so agents reach the Message Board through the gateway instead of pasting.

Key constraint (fits your active secrets rework): the board authenticates via a **credential *descriptor* (1Password pointer), never a raw signing key** — so the PMCP credential slot injects a descriptor ref only. Verified env contract + proposed `.mcp.json` entry + three asks (slot syntax, descriptor-only, safe-tier default) are in the doc.

This is a **proposal for you to ratify/adapt**, not a change to your code. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)