### PR TITLE
agent-board overlay: point op:// refs at dedicated 'Agent Board Secrets' vault

### DIFF
--- a/plans/agent-board-overlay.template.jsonc
+++ b/plans/agent-board-overlay.template.jsonc
@@ -44,7 +44,7 @@
         "MESSAGE_BOARD_AGENT_AUTH_MODE": "service_role",
 
         // --- connection credential as an op:// DESCRIPTOR (CRED-1). 1.2.2 resolves it in-client. ---
-        "MESSAGE_BOARD_SUPABASE_SERVICE_ROLE_KEY": "op://Consiliency Deploy Secrets/Agent Board API Keys - message-board canonical mqccjfqngptkemnchlko/service_role_key",
+        "MESSAGE_BOARD_SUPABASE_SERVICE_ROLE_KEY": "op://Agent Board Secrets/Agent Board API Keys - message-board canonical mqccjfqngptkemnchlko/service_role_key",
 
         // --- per-host signing identity (enrolled via message-board register flow). agent_id + key are
         //     per host; the private key stays an op:// descriptor. ---
@@ -52,7 +52,7 @@
         "MESSAGE_BOARD_SIGNING_KEY_ID": "<<FILL: e.g. pmcp-<machine_id>-k1>>",
         "MESSAGE_BOARD_SIGNING_KEY_VERSION": "1",
         "MESSAGE_BOARD_SIGNING_PUBLIC_KEY_FINGERPRINT": "<<FILL: sha256:... of the enrolled public key>>",
-        "MESSAGE_BOARD_SIGNING_PRIVATE_KEY": "op://Consiliency Deploy Secrets/Agent Board Signing - PMCP host <<FILL machine_id>>/private_key_pem",
+        "MESSAGE_BOARD_SIGNING_PRIVATE_KEY": "op://Agent Board Secrets/Agent Board Signing - PMCP host <<FILL machine_id>>/private_key_pem",
 
         // --- secret-zero: op token that lets the client resolve the op:// descriptors above headlessly.
         //     A live 1Password service-account token — the one secret at rest. HARDENING: 1Password SA


### PR DESCRIPTION
The two agent-board secrets (service_role_key + per-host private_key_pem) were moved into a dedicated least-privilege 1Password vault `Agent Board Secrets` so a scoped service-account token reads only them (not all of `Consiliency Deploy Secrets`). This repoints the template's two `op://` refs to the new vault. Template is `<<FILL>>` reference (not deployed). The portal Callback Signing Secret stays in the shared vault (different trust domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->