### PR TITLE
docs: point GHCR image ref to Consiliency namespace (org transfer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,7 +1378,7 @@ export PMCP_REQUEST_CEILING_MS=600000
 docker run -it --rm \
   -v ~/.mcp.json:/home/appuser/.mcp.json:ro \
   -v ~/.env:/app/.env:ro \
-  ghcr.io/viperjuice/pmcp:latest
+  ghcr.io/consiliency/pmcp:latest
 
 # Using Docker Compose
 docker-compose up -d


### PR DESCRIPTION
GHCR paths don't follow GitHub's transfer redirect, so the hardcoded `ghcr.io/viperjuice/pmcp` ref (README) pulled the frozen old image. Swap to `ghcr.io/consiliency/pmcp` (where new releases publish — workflows derive the namespace from the repo owner). 1 ref, slug-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->