### PR TITLE
chore: v1.19.4 — point packaging URLs to Consiliency org (repo transfer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.4] - 2026-07-18
+
+### Changed
+- **Packaging metadata points at the new owning org.** The project URLs
+  (`Repository`/`Homepage`/`Issues`) now target `Consiliency/pmcp` following the
+  GitHub repository transfer from `ViperJuice/pmcp` (the old URLs still redirect,
+  but the PyPI project page linked to the stale location). No functional or API
+  changes — this is a metadata-only patch. It also serves as the first release
+  published from the new org, validating the trusted-publishing path end-to-end.
+  (#100 follow-up)
+
 ## [1.19.3] - 2026-07-12
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.19.3"
+version = "1.19.4"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"
@@ -40,9 +40,9 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/ViperJuice/pmcp"
-Homepage = "https://github.com/ViperJuice/pmcp"
-Issues = "https://github.com/ViperJuice/pmcp/issues"
+Repository = "https://github.com/Consiliency/pmcp"
+Homepage = "https://github.com/Consiliency/pmcp"
+Issues = "https://github.com/Consiliency/pmcp/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.19.3"
+__version__ = "1.19.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.19.3"
+version = "1.19.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Metadata-only patch bumping **1.19.3 → 1.19.4** after the `ViperJuice/pmcp → Consiliency/pmcp` repository transfer.

- `pyproject.toml` project URLs (`Repository`/`Homepage`/`Issues`) → `Consiliency/pmcp` (the PyPI project page currently links to the stale, redirecting `ViperJuice` location).
- version bump in `pyproject.toml`, `src/pmcp/__init__.py`, `uv.lock`.
- CHANGELOG `1.19.4` entry.

**No functional or API changes.**

## Why now

Two birds: it corrects the stale org metadata on PyPI, and it will be the **first release published from the new org** — so it validates the PyPI **trusted-publishing** path end-to-end under `Consiliency/pmcp`.

## ⚠️ Deploy prerequisite (before tagging)

Publishing is **PyPI trusted publishing** (OIDC), and the live `1.19.3` release was proven (via its signed provenance) to have published from the **old** org `ViperJuice/pmcp`. Before the `v1.19.4` tag is pushed, confirm PyPI has a trusted-publisher entry for **repo `Consiliency/pmcp`, workflow `release.yml`, environment `release`** at `pypi.org/manage/project/pmcp/settings/publishing/`. If it's missing, the publish job fails (harmlessly) until it's added.

## Deliberately out of scope

`authors` (pyproject) and `CODEOWNERS` still reference the lead dev `@ViperJuice` — these are the **lead-developer identity**, explicitly *"Managed via repo-state consolidation (Phase 2)"*, so they're left to that tooling rather than hand-edited here. Flag if you'd rather flip them to an org identity.

## Release flow after merge

Merge → push annotated tag `v1.19.4` (triggers `release.yml` → trusted publish + GH release). Tag/publish is gated on the maintainer's go per our release rule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->