### PR TITLE
feat(manifest): add pangram — first-party AI-text-detection server

### DIFF
--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -634,6 +634,21 @@ servers:
     env_var: "EVERART_API_KEY"
     env_instructions: "Get API key at https://everart.ai"
 
+  pangram:
+    transport: "local"
+    description: "Detect AI-generated text with Pangram Labs - classifies text as human-written, AI-generated, or AI-assisted, with per-class fractions and a per-segment breakdown"
+    keywords: [pangram, ai detection, ai-generated, ai detector, authenticity, plagiarism, text classification, human or ai, content provenance, ai text]
+    install:
+      mac: ["uvx", "pangram-mcp"]
+      linux: ["uvx", "pangram-mcp"]
+      wsl: ["uvx", "pangram-mcp"]
+      windows: ["uvx", "pangram-mcp"]
+    command: "uvx"
+    args: ["pangram-mcp"]
+    requires_api_key: true
+    env_var: "PANGRAM_API_KEY"
+    env_instructions: "Get an API key from https://pangram.com and set PANGRAM_API_KEY (e.g. `pmcp secrets set PANGRAM_API_KEY <key>`, or an op:// descriptor in the operator overlay)"
+
   # === Finance & Data ===
 
   coinmarketcap:

--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -637,7 +637,7 @@ servers:
   pangram:
     transport: "local"
     description: "Detect AI-generated text with Pangram Labs - classifies text as human-written, AI-generated, or AI-assisted, with per-class fractions and a per-segment breakdown"
-    keywords: [pangram, ai detection, ai-generated, ai detector, authenticity, plagiarism, text classification, human or ai, content provenance, ai text]
+    keywords: [pangram, ai detection, ai-generated, ai detector, authenticity, llm detection, text classification, human or ai, content provenance, ai text]
     install:
       mac: ["uvx", "pangram-mcp"]
       linux: ["uvx", "pangram-mcp"]


### PR DESCRIPTION
## What

Adds a **`pangram`** entry to the public manifest (under **AI & LLM**) — our first-party AI-generated-text detection server.

- `uvx pangram-mcp` · `requires_api_key: true` · `env_var: PANGRAM_API_KEY`
- One `analyze` tool: text/file → human / AI / AI-assisted classification with per-class fractions and a per-segment breakdown.

## Provenance

- Server repo: **[Consiliency/pangram-mcp](https://github.com/Consiliency/pangram-mcp)** (MIT, Python/FastMCP), published to PyPI as **`pangram-mcp` 0.1.0** via trusted publishing (provenance signed by `Consiliency/pangram-mcp`).
- **Validated against the live Pangram `/v3` API** — the tool's output schema matches the real response (`prediction`, `fraction_ai`/`fraction_ai_assisted`/`fraction_human`, `num_*_segments`, `windows[]`, `version`).

## Secret handling

The API key stays behind the gateway: resolved at provision (`pmcp secrets set PANGRAM_API_KEY …` or an `op://` descriptor in the overlay), injected into the subprocess (scoped per #96), sent by the server as `x-api-key`. **No agent ever handles the key.** A `PANGRAM_API_KEY` item already exists in the `Consiliency Deploy Secrets` vault.

## Validation

Loads via the manifest loader (`credential_lookup_keys` → `['PANGRAM_API_KEY']`); catalog goes 105 → 106 servers. Ships in the next `pmcp` release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->