### PR TITLE
feat: add scoped advisor audit for pmcp#103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-07-26
+
+### Security
+- Add the fail-closed `scoped_advisor_audit.v1` profile for isolated advisor
+  research. Explicit policy failures now terminate startup, gateway-owned tools
+  are filtered in discovery and dispatch, and the shipped profile exposes only
+  health, catalog search, describe, and invoke controls over approved Firecrawl
+  and Bright Data research patterns.
+- Add typed run/seat/evidence correlations and an explicit JSONL audit sink with
+  privacy-safe source/result digests, contiguous sequence/count validation, and
+  exactly one fsynced terminal marker. Raw URLs, queries, arguments,
+  credentials, and result bodies are not written to the audit. (Consiliency/pmcp#103)
+
+### Added
+- `pmcp capabilities --json`, `--audit-jsonl`, and `PMCP_AUDIT_JSONL` expose the
+  released feature contract required by Consiliency/agent-harness#310.
+
 ## [1.19.4] - 2026-07-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1245,7 +1245,9 @@ pmcp \
 
 The profile exposes only `gateway.health`, `gateway.catalog_search`,
 `gateway.describe`, and `gateway.invoke`; downstream invocation is limited to
-the policy's Firecrawl and Bright Data research patterns. Every invoke must
+the policy's Firecrawl and Bright Data research patterns. MCP resource and
+prompt surfaces are denied, and scoped catalog results omit native-CLI,
+registry, and provision candidates. Every invoke must
 supply `run_correlation_id`, `seat_correlation_id`, and a SHA-256
 `evidence_label_digest` together. The append-only audit stores correlations,
 tool/status/policy/result digests, and a hashed public-source reference—not raw

--- a/README.md
+++ b/README.md
@@ -1225,6 +1225,43 @@ redaction:
     - "(password|secret)[\\s]*[:=][\\s]*[\"']?([^\\s\"']+)"
 ```
 
+An explicitly requested policy (`--policy` or `PMCP_POLICY`) is a fail-closed
+boundary: a missing, unreadable, malformed, or schema-invalid file terminates
+startup. Best-effort fallback applies only to automatically discovered default
+locations when the operator did not request a policy.
+
+#### Scoped advisor research
+
+PMCP v1.20.0 adds the `scoped_advisor_audit.v1` profile for isolated advisor
+research. Start each seat with the shipped policy, a unique lock directory, and
+an explicit audit sink:
+
+```bash
+pmcp \
+  --policy examples/scoped-advisor-policy.yaml \
+  --audit-jsonl /run/board/seat-1/audit.jsonl \
+  --lock-dir /run/board/seat-1/locks
+```
+
+The profile exposes only `gateway.health`, `gateway.catalog_search`,
+`gateway.describe`, and `gateway.invoke`; downstream invocation is limited to
+the policy's Firecrawl and Bright Data research patterns. Every invoke must
+supply `run_correlation_id`, `seat_correlation_id`, and a SHA-256
+`evidence_label_digest` together. The append-only audit stores correlations,
+tool/status/policy/result digests, and a hashed public-source reference—not raw
+URLs, queries, arguments, credentials, or result bodies—and ends with one
+fsynced completeness marker.
+
+Consumers can fail closed on older installations with:
+
+```bash
+pmcp capabilities --json
+```
+
+The capability is active in `gateway.health` only when the exact explicit
+advisor policy and audit sink are both present. Concurrent seats must use unique
+`--lock-dir` and `--audit-jsonl` paths.
+
 Tenant code-mode hosting uses the same policy fields. This example allows only
 the tenant server, blocks a high-risk submission tool, bounds output, and adds a
 tenant artifact redaction pattern without granting access to unrelated MCP

--- a/examples/scoped-advisor-policy.yaml
+++ b/examples/scoped-advisor-policy.yaml
@@ -1,0 +1,27 @@
+servers:
+  allowlist:
+    - firecrawl
+    - brightdata
+gateway_tools:
+  allowlist:
+    - gateway.health
+    - gateway.catalog_search
+    - gateway.describe
+    - gateway.invoke
+tools:
+  allowlist:
+    - firecrawl::*search*
+    - firecrawl::*scrape*
+    - firecrawl::*crawl*
+    - firecrawl::*map*
+    - firecrawl::*extract*
+    - brightdata::*search*
+    - brightdata::*scrape*
+    - brightdata::*crawl*
+    - brightdata::*query*
+    - brightdata::*fetch*
+    - brightdata::*unlocker*
+resources:
+  allowlist: []
+prompts:
+  allowlist: []

--- a/examples/scoped-advisor-policy.yaml
+++ b/examples/scoped-advisor-policy.yaml
@@ -23,5 +23,9 @@ tools:
     - brightdata::*unlocker*
 resources:
   allowlist: []
+  denylist:
+    - "*"
 prompts:
   allowlist: []
+  denylist:
+    - "*"

--- a/plans/detailed-103-scoped-advisor-audit-20260726.md
+++ b/plans/detailed-103-scoped-advisor-audit-20260726.md
@@ -30,6 +30,8 @@ uv run ruff check src tests/test_scoped_advisor_audit.py
 uv run pytest tests/test_policy.py tests/test_server.py tests/test_tools.py \
   tests/test_cli.py tests/test_singleton_lock_scope.py \
   tests/test_scoped_advisor_audit.py -q
+uv run pytest tests/test_scoped_advisor_audit.py \
+  tests/test_offline_discovery.py -q
 uv run pytest -q
 ```
 

--- a/plans/detailed-103-scoped-advisor-audit-20260726.md
+++ b/plans/detailed-103-scoped-advisor-audit-20260726.md
@@ -1,0 +1,45 @@
+# Detailed plan: scoped advisor policy and privacy-safe audit
+
+## Task
+
+Implement and release the PMCP prerequisite for Consiliency/agent-harness#310
+under Consiliency/pmcp#103. Scoped advisor sessions must fail closed on policy or
+audit failure, expose only approved research controls and downstream tools, and
+produce complete privacy-safe provenance.
+
+## Changes
+
+- Make explicitly requested policy files fatal on missing, unreadable, malformed,
+  or schema-invalid input while retaining best-effort default discovery.
+- Add case-sensitive `gateway_tools` allow/deny policy and enforce it in both
+  discovery and dispatch.
+- Add typed atomic run/seat/evidence correlations to `gateway.invoke`.
+- Add an explicit `--audit-jsonl`/`PMCP_AUDIT_JSONL` sink with started,
+  per-invocation, and exactly one fsynced completed record.
+- Store only tool/status/correlation/digests and hashed public source references;
+  never raw URLs, queries, arguments, credentials, or results.
+- Advertise `scoped_advisor_audit.v1` only for the exact explicit advisor policy
+  with an active audit sink; expose install support through `pmcp capabilities`.
+- Prove four concurrent stdio instances operate with unique lock and audit dirs.
+- Document and release the capability as PMCP v1.20.0.
+
+## Verification
+
+```bash
+uv run ruff check src tests/test_scoped_advisor_audit.py
+uv run pytest tests/test_policy.py tests/test_server.py tests/test_tools.py \
+  tests/test_cli.py tests/test_singleton_lock_scope.py \
+  tests/test_scoped_advisor_audit.py -q
+uv run pytest -q
+```
+
+## Acceptance criteria
+
+- [x] Explicit policy failure exits non-zero without permissive fallback.
+- [x] Gateway controls are filtered in discovery and dispatch.
+- [x] Invoke reaches only approved Firecrawl/Bright Data research tools.
+- [x] Four concurrent stdio instances use unique lock and audit directories.
+- [x] Audit proves tool/status/policy/run/seat correlation and hashed source evidence.
+- [x] JSONL has typed correlations, contiguous sequence/count, and one fsynced completion.
+- [x] Audit contains no raw URL, query, arguments, credentials, or result body.
+- [x] Released capability/version probing lets consumers reject older PMCP.

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -809,6 +809,20 @@
             "verification_summary": "PASS - strict policy, control filtering, pre-lazy-start denial, correlated private audit, four isolated stdio instances, capability probe, lint, typecheck, and full suite passed."
           },
           "transition": "completed"
+        },
+        {
+          "at": "2026-07-26T07:24:11Z",
+          "by": "codex-execute-detailed",
+          "metadata": {
+            "acceptance_status": "satisfied_after_panel_reconciliation",
+            "diagnostic": "exact-head review blockers reconciled and complete suite reverified",
+            "full_suite": "2251 passed, 3 skipped, 24 deselected",
+            "panel_reconciliation": "latched audit failure; deny resource and prompt surfaces; ASCII correlations; privacy-safe unknown controls; single-use ledgers; pre-start describe denial; scoped discovery suppression only with active audited session",
+            "verification_artifact_path": "/tmp/codex-execute-detailed-pmcp-103-scoped-advisor-audit-verification.md",
+            "verification_status": "passed",
+            "verification_summary": "PASS - all exact-head Codex and Grok blockers reconciled; lint, format, typecheck, focused compatibility, and full suite passed."
+          },
+          "transition": "completed"
         }
       ],
       "owner_skill": "codex-plan-detailed",
@@ -816,7 +830,7 @@
       "status": "completed",
       "task_summary": "Release fail-closed scoped advisor policy and privacy-safe audit capability for Consiliency/pmcp#103.",
       "type": "detailed",
-      "updated_at": "2026-07-26T06:54:58Z"
+      "updated_at": "2026-07-26T07:24:11Z"
     }
   ],
   "schema_version": 1

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -777,6 +777,46 @@
       "task_summary": "gateway.describe nested-schema fidelity (#87) + index-it-mcp stdio transport & pilot docs (#89); ship v1.19.1",
       "type": "detailed",
       "updated_at": "2026-07-06T09:20:00Z"
+    },
+    {
+      "acceptance_criteria_count": 8,
+      "created_at": "2026-07-26T06:42:14Z",
+      "file": "plans/detailed-103-scoped-advisor-audit-20260726.md",
+      "handoff_ref": null,
+      "lifecycle": [
+        {
+          "at": "2026-07-26T06:42:14Z",
+          "by": "codex-execute-detailed",
+          "metadata": {
+            "branch": "codex/103-scoped-advisor-audit",
+            "source_plan": "Consiliency/agent-harness plans/detailed-310-pmcp-scoped-advisor-prerequisite-20260726.md"
+          },
+          "transition": "executing"
+        },
+        {
+          "at": "2026-07-26T06:54:58Z",
+          "by": "codex-execute-detailed",
+          "metadata": {
+            "acceptance_status": "satisfied",
+            "diagnostic": "verified and ready for exact-head review",
+            "dirty_path_classification": "all tracked changes plan-owned",
+            "doc_delta_decision": "docs_and_release_metadata_updated",
+            "full_suite": "2250 passed, 3 skipped, 24 deselected",
+            "reflection_path": "/home/viperjuice/.codex/skills/codex-execute-detailed/reflections/a40182b2/codex-103-scoped-advisor-audit/20260726T064214Z-05-103-scoped-advisor-audit.md",
+            "run_id": "20260726T064214Z-05-103-scoped-advisor-audit",
+            "verification_artifact_path": "/tmp/codex-execute-detailed-pmcp-103-scoped-advisor-audit-verification.md",
+            "verification_status": "passed",
+            "verification_summary": "PASS - strict policy, control filtering, pre-lazy-start denial, correlated private audit, four isolated stdio instances, capability probe, lint, typecheck, and full suite passed."
+          },
+          "transition": "completed"
+        }
+      ],
+      "owner_skill": "codex-plan-detailed",
+      "slug": "detailed-103-scoped-advisor-audit-20260726",
+      "status": "completed",
+      "task_summary": "Release fail-closed scoped advisor policy and privacy-safe audit capability for Consiliency/pmcp#103.",
+      "type": "detailed",
+      "updated_at": "2026-07-26T06:54:58Z"
     }
   ],
   "schema_version": 1

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -823,6 +823,20 @@
             "verification_summary": "PASS - all exact-head Codex and Grok blockers reconciled; lint, format, typecheck, focused compatibility, and full suite passed."
           },
           "transition": "completed"
+        },
+        {
+          "at": "2026-07-26T07:52:23Z",
+          "by": "codex-execute-detailed",
+          "metadata": {
+            "acceptance_status": "satisfied_after_second_panel_reconciliation",
+            "diagnostic": "Grok exact-head discovery finding reproduced and closed",
+            "focused_suite": "195 passed",
+            "full_suite": "2251 passed, 3 skipped, 24 deselected",
+            "panel_reconciliation": "audited scoped catalog now suppresses registry candidates and stale update notices; adversarial injected-result regression added",
+            "verification_artifact_path": "/tmp/codex-execute-detailed-pmcp-103-scoped-advisor-audit-verification.md",
+            "verification_status": "passed"
+          },
+          "transition": "completed"
         }
       ],
       "owner_skill": "codex-plan-detailed",
@@ -830,7 +844,7 @@
       "status": "completed",
       "task_summary": "Release fail-closed scoped advisor policy and privacy-safe audit capability for Consiliency/pmcp#103.",
       "type": "detailed",
-      "updated_at": "2026-07-26T07:24:11Z"
+      "updated_at": "2026-07-26T07:52:23Z"
     }
   ],
   "schema_version": 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.19.4"
+version = "1.20.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.19.4"
+__version__ = "1.20.0"

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -115,7 +115,7 @@ def parse_args() -> argparse.Namespace:
 
 Environment overrides:
   PMCP_CONFIG, PMCP_POLICY, PMCP_LOG_LEVEL,
-  PMCP_TRANSPORT, PMCP_HOST, PMCP_PORT, PMCP_LOCK_DIR
+  PMCP_TRANSPORT, PMCP_HOST, PMCP_PORT, PMCP_LOCK_DIR, PMCP_AUDIT_JSONL
 """
 
     parser = argparse.ArgumentParser(
@@ -192,6 +192,12 @@ Environment overrides:
         type=Path,
         default=None,
         help="Directory for singleton lock file. Default: ~/.pmcp (global per-user lock)",
+    )
+    parser.add_argument(
+        "--audit-jsonl",
+        type=Path,
+        default=None,
+        help="Explicit scoped-advisor JSONL audit sink. Also read from PMCP_AUDIT_JSONL.",
     )
     parser.add_argument(
         "--auth-token",
@@ -456,6 +462,12 @@ Environment overrides:
         action="store_true",
         help="Overwrite existing configuration",
     )
+
+    capabilities_parser = subparsers.add_parser(
+        "capabilities",
+        help="Print machine-readable PMCP capability/version metadata",
+    )
+    capabilities_parser.add_argument("--json", action="store_true")
 
     # Setup command
     setup_parser = subparsers.add_parser(
@@ -2108,6 +2120,8 @@ async def run_server(args: argparse.Namespace) -> None:
         args.config = Path(os.environ["PMCP_CONFIG"])
     if not args.policy and os.environ.get("PMCP_POLICY"):
         args.policy = Path(os.environ["PMCP_POLICY"])
+    if not getattr(args, "audit_jsonl", None) and os.environ.get("PMCP_AUDIT_JSONL"):
+        args.audit_jsonl = Path(os.environ["PMCP_AUDIT_JSONL"])
     if os.environ.get("PMCP_LOG_LEVEL"):
         args.log_level = os.environ["PMCP_LOG_LEVEL"]
 
@@ -2213,6 +2227,7 @@ async def run_server(args: argparse.Namespace) -> None:
         host=args.host,
         port=args.port,
         lock_dir=lock_dir,
+        audit_jsonl=getattr(args, "audit_jsonl", None),
         auth_token=getattr(args, "auth_token", None),
         max_concurrent_spawns=getattr(args, "max_concurrent_spawns", 8),
         rate_limit_rpm=getattr(args, "rate_limit", 0),
@@ -2319,6 +2334,34 @@ def run_guidance(args: argparse.Namespace) -> None:
     print("To change configuration:")
     print("  Edit ~/.claude/gateway-guidance.yaml")
     print("  Or set level: off | minimal | standard")
+
+
+def run_capabilities(args: argparse.Namespace) -> None:
+    """Print the installed capability contract for fail-closed consumers."""
+    from pmcp.scoped_advisor_audit import SCOPED_ADVISOR_AUDIT_CAPABILITY
+
+    payload: dict[str, Any] = {
+        "pmcp_version": importlib.metadata.version("pmcp"),
+        "capabilities": [
+            {
+                "name": SCOPED_ADVISOR_AUDIT_CAPABILITY,
+                "activation_requires": [
+                    "explicit_policy",
+                    "gateway_tool_filtering",
+                    "typed_correlations",
+                    "explicit_audit_jsonl",
+                    "unique_lock_dir",
+                    "terminal_completion_fsync",
+                ],
+            }
+        ],
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(f"pmcp {payload['pmcp_version']}")
+        for capability in payload["capabilities"]:
+            print(capability["name"])
 
 
 def _build_gateway_auth_client(args: argparse.Namespace) -> tuple[Any, Any]:
@@ -2526,6 +2569,8 @@ async def async_main(args: argparse.Namespace) -> None:
         run_config(args)  # Synchronous command
     elif args.command == "guidance":
         run_guidance(args)  # Synchronous command
+    elif args.command == "capabilities":
+        run_capabilities(args)  # Synchronous command
     elif args.command == "doctor":
         await run_doctor(args)
     elif args.command == "upgrade":

--- a/src/pmcp/policy/policy.py
+++ b/src/pmcp/policy/policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import json
 import logging
 import re
@@ -41,19 +42,20 @@ class PolicyManager:
     def __init__(self, policy_path: Path | None = None) -> None:
         self._policy = GatewayPolicy()
         self._redaction_regexes: list[re.Pattern[str]] = []
+        self._explicit_policy = policy_path is not None
 
         if policy_path:
-            self._load_policy(policy_path)
+            self._load_policy(policy_path, fatal=True)
         else:
             # Try default locations
             for default_path in DEFAULT_POLICY_PATHS:
                 if default_path.exists():
-                    self._load_policy(default_path)
+                    self._load_policy(default_path, fatal=False)
                     break
 
         self._compile_redaction_patterns()
 
-    def _load_policy(self, policy_path: Path) -> None:
+    def _load_policy(self, policy_path: Path, *, fatal: bool) -> None:
         """Load policy from file."""
         try:
             content = policy_path.read_text()
@@ -63,10 +65,15 @@ class PolicyManager:
             else:
                 data = json.loads(content)
 
-            if data:
-                self._policy = GatewayPolicy.model_validate(data)
+            if not isinstance(data, dict):
+                raise ValueError("policy root must be an object")
+            self._policy = GatewayPolicy.model_validate(data)
             logger.info(f"Loaded policy from {policy_path}")
         except Exception as e:
+            if fatal:
+                raise ValueError(
+                    f"Failed to load explicit policy {policy_path}: {e}"
+                ) from e
             logger.warning(f"Failed to load policy from {policy_path}: {e}")
 
     def _compile_redaction_patterns(self) -> None:
@@ -122,6 +129,59 @@ class PolicyManager:
             return self._matches_any(tool_id, allowlist)
 
         return True
+
+    def is_gateway_tool_allowed(self, tool_name: str) -> bool:
+        """Check a PMCP-owned gateway control against the explicit policy."""
+        denylist = self._policy.gateway_tools.denylist
+        allowlist = self._policy.gateway_tools.allowlist
+        if denylist and self._matches_any(tool_name, denylist):
+            return False
+        if allowlist:
+            return self._matches_any(tool_name, allowlist)
+        return True
+
+    @property
+    def explicit_policy(self) -> bool:
+        return self._explicit_policy
+
+    @property
+    def policy_digest(self) -> str:
+        payload = self._policy.model_dump_json(exclude_none=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def is_scoped_advisor_policy(self) -> bool:
+        """Return whether the loaded policy is the exact safe advisor profile."""
+        required_controls = {
+            "gateway.health",
+            "gateway.catalog_search",
+            "gateway.describe",
+            "gateway.invoke",
+        }
+        if not self._explicit_policy:
+            return False
+        if set(self._policy.gateway_tools.allowlist) != required_controls:
+            return False
+        if self._policy.gateway_tools.denylist:
+            return False
+        if set(self._policy.servers.allowlist) != {"firecrawl", "brightdata"}:
+            return False
+        if self._policy.servers.denylist or self._policy.tools.denylist:
+            return False
+        allowed_patterns = {
+            "firecrawl::*search*",
+            "firecrawl::*scrape*",
+            "firecrawl::*crawl*",
+            "firecrawl::*map*",
+            "firecrawl::*extract*",
+            "brightdata::*search*",
+            "brightdata::*scrape*",
+            "brightdata::*crawl*",
+            "brightdata::*query*",
+            "brightdata::*fetch*",
+            "brightdata::*unlocker*",
+        }
+        configured = set(self._policy.tools.allowlist)
+        return bool(configured) and configured <= allowed_patterns
 
     def is_resource_allowed(self, resource_id: str) -> bool:
         """Check if resource is allowed by policy.

--- a/src/pmcp/policy/policy.py
+++ b/src/pmcp/policy/policy.py
@@ -43,6 +43,7 @@ class PolicyManager:
         self._policy = GatewayPolicy()
         self._redaction_regexes: list[re.Pattern[str]] = []
         self._explicit_policy = policy_path is not None
+        self._scoped_advisor_active = False
 
         if policy_path:
             self._load_policy(policy_path, fatal=True)
@@ -167,6 +168,10 @@ class PolicyManager:
             return False
         if self._policy.servers.denylist or self._policy.tools.denylist:
             return False
+        if self._policy.resources.allowlist or self._policy.resources.denylist != ["*"]:
+            return False
+        if self._policy.prompts.allowlist or self._policy.prompts.denylist != ["*"]:
+            return False
         allowed_patterns = {
             "firecrawl::*search*",
             "firecrawl::*scrape*",
@@ -182,6 +187,17 @@ class PolicyManager:
         }
         configured = set(self._policy.tools.allowlist)
         return bool(configured) and configured <= allowed_patterns
+
+    @property
+    def scoped_advisor_active(self) -> bool:
+        """Return whether the audited scoped-advisor session is active."""
+        return self._scoped_advisor_active
+
+    def activate_scoped_advisor(self) -> None:
+        """Activate scoped behavior after the policy and audit sink are ready."""
+        if not self.is_scoped_advisor_policy():
+            raise ValueError("scoped advisor activation requires the exact policy")
+        self._scoped_advisor_active = True
 
     def is_resource_allowed(self, resource_id: str) -> bool:
         """Check if resource is allowed by policy.

--- a/src/pmcp/scoped_advisor_audit.py
+++ b/src/pmcp/scoped_advisor_audit.py
@@ -17,6 +17,12 @@ SCOPED_ADVISOR_AUDIT_CAPABILITY = "scoped_advisor_audit.v1"
 _CORRELATION_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 _DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _TOOL_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+::[A-Za-z0-9_.-]{1,192}$")
+_SCOPED_GATEWAY_TOOLS = {
+    "gateway.health",
+    "gateway.catalog_search",
+    "gateway.describe",
+    "gateway.invoke",
+}
 
 
 class ScopedAdvisorAuditError(RuntimeError):
@@ -136,7 +142,7 @@ class ScopedAdvisorAudit:
         self._file: TextIO | None = None
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            self._file = self.path.open("a", encoding="utf-8")
+            self._file = self.path.open("x", encoding="utf-8")
             self._write(
                 {
                     "event": "audit.started",
@@ -168,6 +174,11 @@ class ScopedAdvisorAudit:
             self._close_quietly()
             raise ScopedAdvisorAuditError("scoped advisor audit write failed") from exc
 
+    def require_available(self) -> None:
+        """Fail before dispatch when the durable audit channel is no longer live."""
+        if self._failed or self._completed or self._file is None or self._file.closed:
+            raise ScopedAdvisorAuditError("scoped advisor audit sink is unavailable")
+
     def record_invocation(
         self,
         *,
@@ -181,6 +192,9 @@ class ScopedAdvisorAudit:
         run_correlation_id = arguments.get("run_correlation_id")
         seat_correlation_id = arguments.get("seat_correlation_id")
         evidence_label_digest = arguments.get("evidence_label_digest")
+        safe_gateway_tool = (
+            gateway_tool if gateway_tool in _SCOPED_GATEWAY_TOOLS else None
+        )
         self._write(
             {
                 "event": "audit.invocation",
@@ -196,7 +210,8 @@ class ScopedAdvisorAudit:
                 if isinstance(seat_correlation_id, str)
                 and _CORRELATION_PATTERN.fullmatch(seat_correlation_id)
                 else None,
-                "gateway_tool": gateway_tool,
+                "gateway_tool": safe_gateway_tool,
+                "gateway_tool_digest": _digest(gateway_tool),
                 "downstream_tool_id": downstream_tool_id
                 if isinstance(downstream_tool_id, str)
                 and _TOOL_ID_PATTERN.fullmatch(downstream_tool_id)

--- a/src/pmcp/scoped_advisor_audit.py
+++ b/src/pmcp/scoped_advisor_audit.py
@@ -1,0 +1,241 @@
+"""Privacy-safe durable audit for scoped advisor research sessions."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Any, TextIO
+from urllib.parse import urlsplit, urlunsplit
+
+SCOPED_ADVISOR_AUDIT_CAPABILITY = "scoped_advisor_audit.v1"
+_CORRELATION_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_TOOL_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+::[A-Za-z0-9_.-]{1,192}$")
+
+
+class ScopedAdvisorAuditError(RuntimeError):
+    """Raised when the trusted audit channel cannot be completed."""
+
+
+def validate_scoped_advisor_audit(path: Path) -> list[dict[str, Any]]:
+    """Validate contiguous records and the single terminal completeness marker."""
+    try:
+        records = [
+            json.loads(line)
+            for line in Path(path).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except Exception as exc:
+        raise ScopedAdvisorAuditError("scoped advisor audit is unreadable") from exc
+    if not records:
+        raise ScopedAdvisorAuditError("scoped advisor audit is empty")
+    starts = [record for record in records if record.get("event") == "audit.started"]
+    if len(starts) != 1 or records[0] is not starts[0]:
+        raise ScopedAdvisorAuditError(
+            "scoped advisor audit start is missing or duplicated"
+        )
+    if [record.get("sequence") for record in records] != list(
+        range(1, len(records) + 1)
+    ):
+        raise ScopedAdvisorAuditError("scoped advisor audit sequence gap")
+    completions = [
+        record for record in records if record.get("event") == "audit.completed"
+    ]
+    if len(completions) != 1 or records[-1] is not completions[0]:
+        raise ScopedAdvisorAuditError(
+            "scoped advisor audit completion is missing or duplicated"
+        )
+    terminal = completions[0]
+    if (
+        terminal.get("first_sequence") != 1
+        or terminal.get("last_sequence") != len(records)
+        or terminal.get("record_count") != len(records)
+    ):
+        raise ScopedAdvisorAuditError("scoped advisor audit completion bounds mismatch")
+    session_ids = {record.get("audit_session_id") for record in records}
+    policy_digests = {record.get("policy_digest") for record in records}
+    if len(session_ids) != 1 or None in session_ids:
+        raise ScopedAdvisorAuditError("scoped advisor audit session mismatch")
+    if len(policy_digests) != 1 or None in policy_digests:
+        raise ScopedAdvisorAuditError("scoped advisor audit policy mismatch")
+    return records
+
+
+def _digest(value: Any) -> str:
+    try:
+        payload = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+    except Exception:
+        payload = type(value).__name__
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _public_source_hash(value: Any) -> str | None:
+    """Hash the first public HTTP(S) source without retaining its raw value."""
+    candidates: list[str] = []
+
+    def collect(candidate: Any) -> None:
+        if isinstance(candidate, str):
+            candidates.extend(re.findall(r"https?://[^\s\"'<>]+", candidate))
+        elif isinstance(candidate, dict):
+            for child in candidate.values():
+                collect(child)
+        elif isinstance(candidate, list):
+            for child in candidate:
+                collect(child)
+
+    collect(value)
+    for candidate in candidates:
+        try:
+            parsed = urlsplit(candidate)
+            hostname = (parsed.hostname or "").lower()
+            if (
+                not hostname
+                or parsed.username
+                or parsed.password
+                or hostname == "localhost"
+            ):
+                continue
+            try:
+                if not ipaddress.ip_address(hostname).is_global:
+                    continue
+            except ValueError:
+                if "." not in hostname:
+                    continue
+            port = f":{parsed.port}" if parsed.port else ""
+            normalized = urlunsplit(
+                (parsed.scheme.lower(), f"{hostname}{port}", parsed.path or "/", "", "")
+            )
+            return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+class ScopedAdvisorAudit:
+    """Append-only JSONL writer with a single fsynced terminal marker."""
+
+    def __init__(self, path: Path, *, policy_digest: str) -> None:
+        self.path = Path(path)
+        self.policy_digest = policy_digest
+        self.audit_session_id = uuid.uuid4().hex
+        self._sequence = 0
+        self._completed = False
+        self._failed = False
+        self._file: TextIO | None = None
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._file = self.path.open("a", encoding="utf-8")
+            self._write(
+                {
+                    "event": "audit.started",
+                    "schema": SCOPED_ADVISOR_AUDIT_CAPABILITY,
+                    "audit_session_id": self.audit_session_id,
+                    "timestamp": time.time(),
+                    "policy_digest": self.policy_digest,
+                }
+            )
+        except Exception as exc:
+            self._close_quietly()
+            raise ScopedAdvisorAuditError(
+                "scoped advisor audit sink unavailable"
+            ) from exc
+
+    def _write(self, record: dict[str, Any], *, terminal: bool = False) -> None:
+        if self._file is None or self._completed or self._failed:
+            raise ScopedAdvisorAuditError("scoped advisor audit sink is closed")
+        self._sequence += 1
+        record = {"sequence": self._sequence, **record}
+        try:
+            self._file.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
+            self._file.write("\n")
+            self._file.flush()
+            if terminal:
+                os.fsync(self._file.fileno())
+        except Exception as exc:
+            self._failed = True
+            self._close_quietly()
+            raise ScopedAdvisorAuditError("scoped advisor audit write failed") from exc
+
+    def record_invocation(
+        self,
+        *,
+        gateway_tool: str,
+        terminal_status: str,
+        arguments: dict[str, Any] | None,
+        result: Any,
+    ) -> None:
+        arguments = arguments or {}
+        downstream_tool_id = arguments.get("tool_id")
+        run_correlation_id = arguments.get("run_correlation_id")
+        seat_correlation_id = arguments.get("seat_correlation_id")
+        evidence_label_digest = arguments.get("evidence_label_digest")
+        self._write(
+            {
+                "event": "audit.invocation",
+                "schema": SCOPED_ADVISOR_AUDIT_CAPABILITY,
+                "audit_session_id": self.audit_session_id,
+                "timestamp": time.time(),
+                "policy_digest": self.policy_digest,
+                "run_correlation_id": run_correlation_id
+                if isinstance(run_correlation_id, str)
+                and _CORRELATION_PATTERN.fullmatch(run_correlation_id)
+                else None,
+                "seat_correlation_id": seat_correlation_id
+                if isinstance(seat_correlation_id, str)
+                and _CORRELATION_PATTERN.fullmatch(seat_correlation_id)
+                else None,
+                "gateway_tool": gateway_tool,
+                "downstream_tool_id": downstream_tool_id
+                if isinstance(downstream_tool_id, str)
+                and _TOOL_ID_PATTERN.fullmatch(downstream_tool_id)
+                else None,
+                "terminal_status": terminal_status,
+                "redacted_result_digest": _digest(result),
+                "source_reference_hash": _public_source_hash(result)
+                or _public_source_hash(arguments),
+                "evidence_label_digest": evidence_label_digest
+                if isinstance(evidence_label_digest, str)
+                and _DIGEST_PATTERN.fullmatch(evidence_label_digest)
+                else None,
+            }
+        )
+
+    def complete(self) -> None:
+        if self._completed:
+            return
+        terminal_sequence = self._sequence + 1
+        self._write(
+            {
+                "event": "audit.completed",
+                "schema": SCOPED_ADVISOR_AUDIT_CAPABILITY,
+                "audit_session_id": self.audit_session_id,
+                "timestamp": time.time(),
+                "policy_digest": self.policy_digest,
+                "first_sequence": 1,
+                "last_sequence": terminal_sequence,
+                "record_count": terminal_sequence,
+            },
+            terminal=True,
+        )
+        self._completed = True
+        self._close_quietly()
+
+    def _close_quietly(self) -> None:
+        if self._file is not None:
+            try:
+                self._file.close()
+            except Exception:
+                pass
+            self._file = None

--- a/src/pmcp/server.py
+++ b/src/pmcp/server.py
@@ -41,6 +41,7 @@ from pmcp.identity import (
     acquire_singleton_lock,
     release_singleton_lock,
 )
+from pmcp.errors import ErrorCode, GatewayException
 from pmcp.manifest.loader import load_manifest
 from pmcp.manifest.refresher import (
     get_cache_path,
@@ -144,6 +145,7 @@ class GatewayServer:
             self._scoped_advisor_audit = ScopedAdvisorAudit(
                 self._audit_jsonl, policy_digest=self._policy_manager.policy_digest
             )
+            self._policy_manager.activate_scoped_advisor()
         self._gateway_tools.set_transport_diagnostics(
             GatewayDiagnosticsInfo(
                 transport="gateway",
@@ -189,6 +191,10 @@ class GatewayServer:
             result=result,
         )
 
+    def _require_scoped_audit(self) -> None:
+        if self._scoped_advisor_audit is not None:
+            self._scoped_advisor_audit.require_available()
+
     def _setup_handlers(self) -> None:
         """Set up MCP request handlers."""
         if self._server is None:
@@ -196,6 +202,7 @@ class GatewayServer:
 
         @self._server.list_tools()
         async def list_tools() -> list[Tool]:
+            self._require_scoped_audit()
             return sorted(
                 (
                     tool
@@ -209,6 +216,7 @@ class GatewayServer:
         async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             try:
                 result: Any
+                self._require_scoped_audit()
 
                 if not self._policy_manager.is_gateway_tool_allowed(name):
                     payload = {
@@ -325,9 +333,15 @@ class GatewayServer:
             except Exception as e:
                 logger.error(f"Tool execution error: {e}")
                 try:
+                    failure_status = (
+                        "denied"
+                        if isinstance(e, GatewayException)
+                        and e.code == ErrorCode.E402_TOOL_DENIED
+                        else "failure"
+                    )
                     self._record_scoped_invocation(
                         gateway_tool=name,
-                        terminal_status="failure",
+                        terminal_status=failure_status,
                         arguments=arguments,
                         result={"error_type": type(e).__name__},
                     )
@@ -354,6 +368,7 @@ class GatewayServer:
         # Resource handlers - proxy from downstream servers + L3 guidance
         @self._server.list_resources()
         async def list_resources() -> list[Resource]:
+            self._require_scoped_audit()
             resources = self._client_manager.get_all_resources()
             # Filter by policy
             allowed_resources = [
@@ -372,7 +387,12 @@ class GatewayServer:
             ]
 
             # Add L3 guidance resource if enabled
-            if self._guidance_config.include_methodology_resource:
+            if (
+                self._guidance_config.include_methodology_resource
+                and self._policy_manager.is_resource_allowed(
+                    "pmcp::pmcp://guidance/code-execution"
+                )
+            ):
                 resource_list.append(
                     Resource(
                         uri=AnyUrl("pmcp://guidance/code-execution"),
@@ -386,11 +406,16 @@ class GatewayServer:
 
         @self._server.read_resource()
         async def read_resource(uri: AnyUrl) -> list[TextResourceContents]:
+            self._require_scoped_audit()
             # Find resource by URI
             uri_str = str(uri)
 
             # Check if it's our L3 guidance resource
             if uri_str == "pmcp://guidance/code-execution":
+                if not self._policy_manager.is_resource_allowed(
+                    "pmcp::pmcp://guidance/code-execution"
+                ):
+                    raise ValueError(f"Resource blocked by policy: {uri_str}")
                 if not self._guidance_config.include_methodology_resource:
                     raise ValueError("Code execution guidance resource is disabled")
 
@@ -440,6 +465,7 @@ class GatewayServer:
         # Prompt handlers - proxy from downstream servers
         @self._server.list_prompts()
         async def list_prompts() -> list[Prompt]:
+            self._require_scoped_audit()
             prompts = self._client_manager.get_all_prompts()
             # Filter by policy
             allowed_prompts = [
@@ -470,6 +496,7 @@ class GatewayServer:
         async def get_prompt(
             name: str, arguments: dict[str, str] | None = None
         ) -> GetPromptResult:
+            self._require_scoped_audit()
             # name is the prompt_id (server::name format)
             # Check policy
             if not self._policy_manager.is_prompt_allowed(name):
@@ -593,7 +620,12 @@ class GatewayServer:
 
         statuses = self._client_manager.get_all_server_statuses()
         online = sum(1 for s in statuses if s.status.value == "online")
-        tools = self._client_manager.get_all_tools()
+        tools = [
+            tool
+            for tool in self._client_manager.get_all_tools()
+            if self._policy_manager.is_server_allowed(tool.server_name)
+            and self._policy_manager.is_tool_allowed(tool.tool_id)
+        ]
 
         logger.info(
             f"Gateway initialized: {online}/{len(statuses)} servers online, {len(tools)} tools indexed"
@@ -602,15 +634,22 @@ class GatewayServer:
         # Generate capability summary for MCP instructions
         # Try pre-built cache first, then LLM, then template
         logger.info("Generating capability summary...")
-        self._capability_summary = await generate_capability_summary(
-            tools,
-            cache=self._descriptions_cache,
-            include_code_guidance=self._guidance_config.include_mcp_instructions,
-            custom_instructions=self._guidance_config.custom_instructions,
-            provisionable_categories=manifest.get_category_summary()
-            if manifest
-            else None,
-        )
+        if self._policy_manager.scoped_advisor_active:
+            self._capability_summary = (
+                "PMCP scoped advisor research: only approved Firecrawl and Bright "
+                "Data tools are available. Use gateway.catalog_search, "
+                "gateway.describe, and correlated gateway.invoke calls."
+            )
+        else:
+            self._capability_summary = await generate_capability_summary(
+                tools,
+                cache=self._descriptions_cache,
+                include_code_guidance=self._guidance_config.include_mcp_instructions,
+                custom_instructions=self._guidance_config.custom_instructions,
+                provisionable_categories=manifest.get_category_summary()
+                if manifest
+                else None,
+            )
 
         # If no cache and we have tools, auto-generate cache for next time
         if not self._descriptions_cache and tools and manifest:

--- a/src/pmcp/server.py
+++ b/src/pmcp/server.py
@@ -48,9 +48,20 @@ from pmcp.manifest.refresher import (
     refresh_all,
 )
 from pmcp.policy.policy import PolicyManager
+from pmcp.scoped_advisor_audit import (
+    SCOPED_ADVISOR_AUDIT_CAPABILITY,
+    ScopedAdvisorAudit,
+    ScopedAdvisorAuditError,
+)
 from pmcp.summary import generate_capability_summary
 from pmcp.tools.handlers import GatewayTools, get_gateway_tool_definitions
-from pmcp.types import DescriptionsCache, LocalMcpServerConfig, ResolvedServerConfig
+from pmcp.types import (
+    DescriptionsCache,
+    GatewayDiagnosticsInfo,
+    InvokeInput,
+    LocalMcpServerConfig,
+    ResolvedServerConfig,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +79,7 @@ class GatewayServer:
         host: str = "127.0.0.1",
         port: int = 3344,
         lock_dir: Path | str | None = None,
+        audit_jsonl: Path | str | None = None,
         auth_token: str | None = None,
         max_concurrent_spawns: int = 8,
         rate_limit_rpm: int = 0,
@@ -99,6 +111,13 @@ class GatewayServer:
 
         # Initialize policy manager
         self._policy_manager = PolicyManager(policy_path)
+        self._scoped_advisor_audit: ScopedAdvisorAudit | None = None
+        self._audit_jsonl = Path(audit_jsonl) if audit_jsonl is not None else None
+        if audit_jsonl is not None:
+            if not self._policy_manager.is_scoped_advisor_policy():
+                raise ValueError(
+                    "--audit-jsonl requires the exact explicit scoped-advisor policy"
+                )
 
         # Initialize guidance config
         self._guidance_config: GuidanceConfig = load_guidance_config(
@@ -121,6 +140,25 @@ class GatewayServer:
             custom_config_path=custom_config_path,
             guidance_config=self._guidance_config,
         )
+        if self._audit_jsonl is not None:
+            self._scoped_advisor_audit = ScopedAdvisorAudit(
+                self._audit_jsonl, policy_digest=self._policy_manager.policy_digest
+            )
+        self._gateway_tools.set_transport_diagnostics(
+            GatewayDiagnosticsInfo(
+                transport="gateway",
+                capabilities=(
+                    [SCOPED_ADVISOR_AUDIT_CAPABILITY]
+                    if self._scoped_advisor_audit is not None
+                    else []
+                ),
+                policy_digest=(
+                    self._policy_manager.policy_digest
+                    if self._scoped_advisor_audit is not None
+                    else None
+                ),
+            )
+        )
 
         # Server will be created after initialization with capability summary
         self._server: Server | None = None
@@ -134,6 +172,23 @@ class GatewayServer:
         self._server = Server("mcp-gateway", instructions=instructions)
         self._setup_handlers()
 
+    def _record_scoped_invocation(
+        self,
+        *,
+        gateway_tool: str,
+        terminal_status: str,
+        arguments: dict[str, Any] | None,
+        result: Any,
+    ) -> None:
+        if self._scoped_advisor_audit is None:
+            return
+        self._scoped_advisor_audit.record_invocation(
+            gateway_tool=gateway_tool,
+            terminal_status=terminal_status,
+            arguments=arguments,
+            result=result,
+        )
+
     def _setup_handlers(self) -> None:
         """Set up MCP request handlers."""
         if self._server is None:
@@ -141,12 +196,41 @@ class GatewayServer:
 
         @self._server.list_tools()
         async def list_tools() -> list[Tool]:
-            return sorted(get_gateway_tool_definitions(), key=lambda tool: tool.name)
+            return sorted(
+                (
+                    tool
+                    for tool in get_gateway_tool_definitions()
+                    if self._policy_manager.is_gateway_tool_allowed(tool.name)
+                ),
+                key=lambda tool: tool.name,
+            )
 
         @self._server.call_tool()
         async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             try:
                 result: Any
+
+                if not self._policy_manager.is_gateway_tool_allowed(name):
+                    payload = {
+                        "error": True,
+                        "message": f"Gateway tool blocked by policy: {name}",
+                    }
+                    self._record_scoped_invocation(
+                        gateway_tool=name,
+                        terminal_status="denied",
+                        arguments=arguments,
+                        result=payload,
+                    )
+                    return [
+                        TextContent(type="text", text=json.dumps(payload, indent=2))
+                    ]
+
+                if self._scoped_advisor_audit is not None and name == "gateway.invoke":
+                    scoped_input = InvokeInput.model_validate(arguments)
+                    if scoped_input.run_correlation_id is None:
+                        raise ValueError(
+                            "scoped advisor invoke requires run, seat, and evidence correlations"
+                        )
 
                 if name == "gateway.catalog_search":
                     result = await self._gateway_tools.catalog_search(arguments)
@@ -209,10 +293,57 @@ class GatewayServer:
                 if hasattr(result, "model_dump"):
                     result = result.model_dump()
 
+                terminal_status = "success"
+                if isinstance(result, dict) and result.get("ok") is False:
+                    terminal_status = (
+                        "denied"
+                        if result.get("auth_state") == "policy_denied"
+                        else "failure"
+                    )
+                self._record_scoped_invocation(
+                    gateway_tool=name,
+                    terminal_status=terminal_status,
+                    arguments=arguments,
+                    result=result,
+                )
+
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
+            except ScopedAdvisorAuditError:
+                logger.error("Scoped advisor audit channel failed")
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "error": True,
+                                "message": "Scoped advisor audit channel failed",
+                            }
+                        ),
+                    )
+                ]
             except Exception as e:
                 logger.error(f"Tool execution error: {e}")
+                try:
+                    self._record_scoped_invocation(
+                        gateway_tool=name,
+                        terminal_status="failure",
+                        arguments=arguments,
+                        result={"error_type": type(e).__name__},
+                    )
+                except ScopedAdvisorAuditError:
+                    logger.error("Scoped advisor audit channel failed")
+                    return [
+                        TextContent(
+                            type="text",
+                            text=json.dumps(
+                                {
+                                    "error": True,
+                                    "message": "Scoped advisor audit channel failed",
+                                }
+                            ),
+                        )
+                    ]
                 return [
                     TextContent(
                         type="text",
@@ -576,18 +707,20 @@ class GatewayServer:
         # Acquire singleton lock to prevent multiple gateway instances
         # Uses self._lock_dir (None = global lock at ~/.pmcp)
         if not acquire_singleton_lock(self._lock_dir):
+            if self._scoped_advisor_audit is not None:
+                self._scoped_advisor_audit.complete()
             logger.error(
                 "Another gateway instance is already running. "
                 "Only one gateway should run at a time to prevent recursive spawning."
             )
             raise RuntimeError("Another gateway instance is already running")
 
-        await self.initialize()
-
-        if self._server is None:
-            raise RuntimeError("Server not initialized after initialization")
-
         try:
+            await self.initialize()
+
+            if self._server is None:
+                raise RuntimeError("Server not initialized after initialization")
+
             async with stdio_server() as (read_stream, write_stream):
                 logger.info("MCP Gateway server started (stdio)")
                 await self._server.run(
@@ -607,18 +740,20 @@ class GatewayServer:
         # Acquire singleton lock to prevent multiple gateway instances
         # Uses self._lock_dir (None = global lock at ~/.pmcp)
         if not acquire_singleton_lock(self._lock_dir):
+            if self._scoped_advisor_audit is not None:
+                self._scoped_advisor_audit.complete()
             logger.error(
                 "Another gateway instance is already running. "
                 "Only one gateway should run at a time to prevent recursive spawning."
             )
             raise RuntimeError("Another gateway instance is already running")
 
-        await self.initialize()
-
-        if self._server is None:
-            raise RuntimeError("Server not initialized after initialization")
-
         try:
+            await self.initialize()
+
+            if self._server is None:
+                raise RuntimeError("Server not initialized after initialization")
+
             app = create_http_app(
                 self._server,
                 auth_token=self._auth_token,
@@ -659,4 +794,6 @@ class GatewayServer:
         finally:
             # Always release singleton lock
             release_singleton_lock()
+            if self._scoped_advisor_audit is not None:
+                self._scoped_advisor_audit.complete()
         logger.info("MCP Gateway shut down")

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -1435,8 +1435,9 @@ class GatewayTools:
         """gateway.catalog_search - Search for available tools."""
         parsed = CatalogSearchInput.model_validate(input_data)
         cli_hints = []
+        scoped_advisor = self._policy_manager.scoped_advisor_active is True
         query = parsed.query.strip() if parsed.query else ""
-        if query:
+        if query and not scoped_advisor:
             manifest = load_manifest()
             detected_clis, detected_cli_infos = await self._resolve_cli_availability(
                 manifest
@@ -1501,7 +1502,7 @@ class GatewayTools:
             ]
 
         # Text search (if query provided) - word-based matching
-        if parsed.query:
+        if parsed.query and not scoped_advisor:
             query_words = parsed.query.lower().split()
             tools = [
                 t
@@ -1542,7 +1543,7 @@ class GatewayTools:
         # Surface manifest-provisionable servers that have never been started
         # (no cached tools) so agents can provision them directly (#78).
         manifest_candidates: list[CapabilityCandidate] = []
-        if parsed.include_offline and parsed.query:
+        if parsed.include_offline and parsed.query and not scoped_advisor:
             manifest_candidates = self._manifest_candidates_for_query(
                 parsed.query,
                 manifest=load_manifest(),
@@ -1591,7 +1592,10 @@ class GatewayTools:
                 f"Update available for '{sn}': {current} -> {latest}. "
                 f"Call gateway.update_server(server_name='{sn}') to update."
                 for sn, (_, current, latest) in self._stale_check_cache.items()
-                if current and latest and is_version_newer(current, latest)
+                if current
+                and latest
+                and is_version_newer(current, latest)
+                and self._policy_manager.is_server_allowed(sn)
             ]
             if stale:
                 stale_updates = stale
@@ -1610,6 +1614,13 @@ class GatewayTools:
         """gateway.describe - Get detailed info about a tool."""
         parsed = DescribeInput.model_validate(input_data)
 
+        # Match invoke: deny before registry lookup or lazy-start side effects.
+        if not self._policy_manager.is_tool_allowed(parsed.tool_id):
+            raise GatewayException(
+                ErrorCode.E402_TOOL_DENIED,
+                details={"tool_id": parsed.tool_id},
+            )
+
         tool_info = self._client_manager.get_tool(parsed.tool_id)
 
         if not tool_info:
@@ -1627,12 +1638,6 @@ class GatewayTools:
                     ErrorCode.E301_TOOL_NOT_FOUND,
                     details={"tool_id": parsed.tool_id},
                 )
-
-        if not self._policy_manager.is_tool_allowed(parsed.tool_id):
-            raise GatewayException(
-                ErrorCode.E402_TOOL_DENIED,
-                details={"tool_id": parsed.tool_id},
-            )
 
         update_warning = await self._get_update_warning(tool_info.server_name)
         self._record_feedback_event(

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -1535,7 +1535,7 @@ class GatewayTools:
 
         # Apply limit
         registry_candidates: list[CapabilityCandidate] = []
-        if parsed.query:
+        if parsed.query and not scoped_advisor:
             registry_candidates = await self._registry_candidates_for_query(
                 parsed.query, limit=min(5, parsed.limit)
             )
@@ -1587,7 +1587,7 @@ class GatewayTools:
 
         # Collect stale-update notices from precomputed cache (no network call)
         stale_updates: list[str] | None = None
-        if self._stale_check_cache:
+        if self._stale_check_cache and not scoped_advisor:
             stale = [
                 f"Update available for '{sn}': {current} -> {latest}. "
                 f"Call gateway.update_server(server_name='{sn}') to update."

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -356,6 +356,19 @@ def get_gateway_tool_definitions() -> list[Tool]:
                         "type": "object",
                         "description": "Arguments to pass to the tool (must match tool schema)",
                     },
+                    "run_correlation_id": {
+                        "type": "string",
+                        "description": "Scoped-advisor run correlation ID",
+                    },
+                    "seat_correlation_id": {
+                        "type": "string",
+                        "description": "Scoped-advisor seat correlation ID",
+                    },
+                    "evidence_label_digest": {
+                        "type": "string",
+                        "pattern": "^[0-9a-f]{64}$",
+                        "description": "SHA-256 digest of the caller evidence label",
+                    },
                     "options": {
                         "type": "object",
                         "properties": {
@@ -1713,6 +1726,36 @@ class GatewayTools:
         trace_context = self._extract_trace_context(input_data)
         parsed = InvokeInput.model_validate(input_data)
 
+        # Policy denial must happen before registry lookup or lazy-start so an
+        # out-of-scope server cannot be started as a side effect of inspection.
+        if not self._policy_manager.is_tool_allowed(parsed.tool_id):
+            server_name = parsed.tool_id.split("::", 1)[0]
+            error = make_error(
+                ErrorCode.E402_TOOL_DENIED,
+                tool_id=parsed.tool_id,
+            )
+            self._audit(
+                method="gateway.invoke",
+                action="invoke",
+                outcome="refused",
+                started_at=audit_started_at,
+                server_name=server_name,
+                tool_id=parsed.tool_id,
+                auth_state="policy_denied",
+                auth_event="policy_denied",
+                error=error.message,
+                trace_context=trace_context,
+            )
+            return InvokeOutput(
+                tool_id=parsed.tool_id,
+                ok=False,
+                truncated=False,
+                raw_size_estimate=0,
+                errors=[error.model_dump_json()],
+                auth_state="policy_denied",
+                feedback_hint=self._feedback_hint(),
+            )
+
         # Check if tool exists in registry
         tool_info = self._client_manager.get_tool(parsed.tool_id)
 
@@ -1787,35 +1830,6 @@ class GatewayTools:
                     errors=[error.model_dump_json()],
                     feedback_hint=self._feedback_hint(),
                 )
-
-        # Check policy
-        if not self._policy_manager.is_tool_allowed(parsed.tool_id):
-            error = make_error(
-                ErrorCode.E402_TOOL_DENIED,
-                tool_id=parsed.tool_id,
-            )
-            self._audit(
-                method="gateway.invoke",
-                action="invoke",
-                outcome="refused",
-                started_at=audit_started_at,
-                server_name=tool_info.server_name,
-                tool_id=parsed.tool_id,
-                protocol_version=self._protocol_version(tool_info.server_name),
-                auth_state="policy_denied",
-                auth_event="policy_denied",
-                error=error.message,
-                trace_context=trace_context,
-            )
-            return InvokeOutput(
-                tool_id=parsed.tool_id,
-                ok=False,
-                truncated=False,
-                raw_size_estimate=0,
-                errors=[error.model_dump_json()],
-                auth_state="policy_denied",
-                feedback_hint=self._feedback_hint(),
-            )
 
         # Pre-dispatch: validate required arguments
         required = (tool_info.input_schema or {}).get("required", [])

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from pmcp.validation import is_valid_package_name
 
@@ -118,6 +118,8 @@ class GatewayDiagnosticsInfo(BaseModel):
     header_compatibility: dict[str, str] = Field(default_factory=dict)
     session_compatibility: dict[str, str] = Field(default_factory=dict)
     auth_metadata_present: bool = False
+    capabilities: list[str] = Field(default_factory=list)
+    policy_digest: str | None = None
     rate_limit_enabled: bool = False
     rate_limit_rpm: int | None = None
     auth_state_semantics: dict[AuthState, AuthStateSemanticsInfo] = Field(
@@ -708,6 +710,33 @@ class InvokeInput(BaseModel):
     options: InvokeOptions | None = None
     trace_context: TraceContextInfo | None = None
     meta: dict[str, Any] | None = Field(default=None, alias="_meta")
+    run_correlation_id: str | None = Field(default=None, min_length=1, max_length=128)
+    seat_correlation_id: str | None = Field(default=None, min_length=1, max_length=128)
+    evidence_label_digest: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
+
+    @field_validator("run_correlation_id", "seat_correlation_id")
+    @classmethod
+    def _validate_correlation_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not all(char.isalnum() or char in "._:-" for char in value):
+            raise ValueError("correlation IDs may contain only alphanumerics and ._:-")
+        return value
+
+    @model_validator(mode="after")
+    def _reject_partial_scoped_correlation(self) -> "InvokeInput":
+        values = (
+            self.run_correlation_id,
+            self.seat_correlation_id,
+            self.evidence_label_digest,
+        )
+        if any(value is not None for value in values) and not all(
+            value is not None for value in values
+        ):
+            raise ValueError(
+                "scoped advisor correlation fields must be supplied together"
+            )
+        return self
 
 
 class InvokeOutput(BaseModel):
@@ -890,12 +919,16 @@ class ServerPolicy(BaseModel):
     allowlist: list[str] = Field(default_factory=list)
     denylist: list[str] = Field(default_factory=list)
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class ToolPolicy(BaseModel):
     """Tool allow/deny policy."""
 
     allowlist: list[str] = Field(default_factory=list)  # Glob patterns
     denylist: list[str] = Field(default_factory=list)  # Glob patterns
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class ResourcePolicy(BaseModel):
@@ -904,12 +937,16 @@ class ResourcePolicy(BaseModel):
     allowlist: list[str] = Field(default_factory=list)  # Glob patterns (server::uri)
     denylist: list[str] = Field(default_factory=list)  # Glob patterns
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class PromptPolicy(BaseModel):
     """Prompt allow/deny policy."""
 
     allowlist: list[str] = Field(default_factory=list)  # Glob patterns (server::name)
     denylist: list[str] = Field(default_factory=list)  # Glob patterns
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class LimitsPolicy(BaseModel):
@@ -919,22 +956,29 @@ class LimitsPolicy(BaseModel):
     max_output_bytes: int = 50000  # 50KB
     max_output_tokens: int = 4000
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class RedactionPolicy(BaseModel):
     """Secret redaction policy."""
 
     patterns: list[str] = Field(default_factory=list)  # Regex patterns
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class GatewayPolicy(BaseModel):
     """Complete gateway policy."""
 
     servers: ServerPolicy = Field(default_factory=ServerPolicy)
+    gateway_tools: ToolPolicy = Field(default_factory=ToolPolicy)
     tools: ToolPolicy = Field(default_factory=ToolPolicy)
     resources: ResourcePolicy = Field(default_factory=ResourcePolicy)
     prompts: PromptPolicy = Field(default_factory=PromptPolicy)
     limits: LimitsPolicy = Field(default_factory=LimitsPolicy)
     redaction: RedactionPolicy = Field(default_factory=RedactionPolicy)
+
+    model_config = ConfigDict(extra="forbid")
 
 
 # === Capability Request Types ===

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
+import re
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -719,7 +720,7 @@ class InvokeInput(BaseModel):
     def _validate_correlation_id(cls, value: str | None) -> str | None:
         if value is None:
             return None
-        if not all(char.isalnum() or char in "._:-" for char in value):
+        if re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", value) is None:
             raise ValueError("correlation IDs may contain only alphanumerics and ._:-")
         return value
 

--- a/tests/test_scoped_advisor_audit.py
+++ b/tests/test_scoped_advisor_audit.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from mcp.types import CallToolRequest, ListToolsRequest
+from pydantic import ValidationError
+
+from pmcp.policy.policy import PolicyManager
+from pmcp.identity import acquire_singleton_lock, release_singleton_lock
+from pmcp.scoped_advisor_audit import (
+    SCOPED_ADVISOR_AUDIT_CAPABILITY,
+    ScopedAdvisorAudit,
+    ScopedAdvisorAuditError,
+    validate_scoped_advisor_audit,
+)
+from pmcp.server import GatewayServer
+from pmcp.types import InvokeInput
+from tests.conftest import MockClientManager, create_tool_info
+
+
+def _write_scoped_policy(path: Path) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "servers": {"allowlist": ["firecrawl", "brightdata"]},
+                "gateway_tools": {
+                    "allowlist": [
+                        "gateway.health",
+                        "gateway.catalog_search",
+                        "gateway.describe",
+                        "gateway.invoke",
+                    ]
+                },
+                "tools": {
+                    "allowlist": [
+                        "firecrawl::*search*",
+                        "firecrawl::*scrape*",
+                        "brightdata::*search*",
+                        "brightdata::*scrape*",
+                    ]
+                },
+            }
+        )
+    )
+    return path
+
+
+def _correlations() -> dict[str, str]:
+    return {
+        "run_correlation_id": "run-103",
+        "seat_correlation_id": "seat-codex",
+        "evidence_label_digest": "a" * 64,
+    }
+
+
+def test_explicit_policy_failures_are_fatal_but_default_discovery_is_best_effort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(ValueError, match="explicit policy"):
+        PolicyManager(missing)
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{")
+    with pytest.raises(ValueError, match="explicit policy"):
+        PolicyManager(malformed)
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"gateway_tools": {"unknown": []}}))
+    with pytest.raises(ValueError, match="explicit policy"):
+        PolicyManager(invalid)
+
+    monkeypatch.setattr("pmcp.policy.policy.DEFAULT_POLICY_PATHS", [malformed])
+    fallback = PolicyManager()
+    assert fallback.is_gateway_tool_allowed("gateway.provision") is True
+
+    cli = subprocess.run(
+        [sys.executable, "-m", "pmcp", "--policy", str(missing), "--quiet"],
+        capture_output=True,
+        text=True,
+    )
+    assert cli.returncode != 0
+    assert "explicit policy" in cli.stderr
+
+
+def test_gateway_tool_policy_is_case_sensitive_and_scoped() -> None:
+    policy = PolicyManager(Path("examples/scoped-advisor-policy.yaml"))
+    assert policy.is_scoped_advisor_policy() is True
+    assert policy.is_gateway_tool_allowed("gateway.invoke") is True
+    assert policy.is_gateway_tool_allowed("Gateway.invoke") is False
+    assert policy.is_gateway_tool_allowed("gateway.provision") is False
+    assert policy.is_tool_allowed("firecrawl::web_search") is True
+    assert policy.is_tool_allowed("brightdata::scrape_page") is True
+    assert policy.is_tool_allowed("github::create_issue") is False
+
+
+def test_invoke_correlations_are_typed_and_atomic() -> None:
+    with pytest.raises(ValidationError, match="supplied together"):
+        InvokeInput(tool_id="firecrawl::search", run_correlation_id="run-only")
+    with pytest.raises(ValidationError):
+        InvokeInput(
+            tool_id="firecrawl::search",
+            **{**_correlations(), "evidence_label_digest": "not-a-digest"},
+        )
+    parsed = InvokeInput(tool_id="firecrawl::search", **_correlations())
+    assert parsed.seat_correlation_id == "seat-codex"
+
+
+@pytest.mark.asyncio
+async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
+    tmp_path: Path,
+) -> None:
+    policy_path = _write_scoped_policy(tmp_path / "policy.json")
+    audit_path = tmp_path / "audit.jsonl"
+    server = GatewayServer(policy_path=policy_path, audit_jsonl=audit_path)
+    manager = MockClientManager(
+        [
+            create_tool_info("firecrawl", "web_search"),
+            create_tool_info("brightdata", "scrape_page"),
+            create_tool_info("github", "create_issue"),
+        ]
+    )
+    for server_name in ("firecrawl", "brightdata", "github"):
+        manager.set_server_online(server_name)
+    manager.set_call_tool_response(
+        {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "https://source.example/article raw page contents",
+                }
+            ]
+        }
+    )
+    server._client_manager = manager  # type: ignore[assignment]
+    server._gateway_tools._client_manager = manager  # type: ignore[assignment]
+    server._create_server()
+    assert server._server is not None
+    list_handler = server._server.request_handlers[ListToolsRequest]
+    call_handler = server._server.request_handlers[CallToolRequest]
+
+    listed = await list_handler(ListToolsRequest(params={}))
+    assert {tool.name for tool in listed.root.tools} == {
+        "gateway.health",
+        "gateway.catalog_search",
+        "gateway.describe",
+        "gateway.invoke",
+    }
+
+    invoked = await call_handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.invoke",
+                "arguments": {
+                    "tool_id": "firecrawl::web_search",
+                    "arguments": {
+                        "url": "https://example.com/private/path?token=secret",
+                        "query": "super secret query",
+                        "credential": "sk-private-value",
+                    },
+                    **_correlations(),
+                },
+            }
+        )
+    )
+    assert json.loads(invoked.root.content[0].text)["ok"] is True
+
+    brightdata = await call_handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.invoke",
+                "arguments": {
+                    "tool_id": "brightdata::scrape_page",
+                    "arguments": {"query": "current benchmark evidence"},
+                    **{**_correlations(), "seat_correlation_id": "seat-gemini"},
+                },
+            }
+        )
+    )
+    assert json.loads(brightdata.root.content[0].text)["ok"] is True
+
+    downstream_denied = await call_handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.invoke",
+                "arguments": {
+                    "tool_id": "github::create_issue",
+                    "arguments": {"title": "must not mutate"},
+                    **_correlations(),
+                },
+            }
+        )
+    )
+    denied_payload = json.loads(downstream_denied.root.content[0].text)
+    assert denied_payload["ok"] is False
+    assert denied_payload["auth_state"] == "policy_denied"
+
+    async def fail_lazy_start(tool_id: str) -> bool:
+        raise AssertionError(f"policy denial attempted lazy start for {tool_id}")
+
+    server._gateway_tools._ensure_server_for_tool = fail_lazy_start  # type: ignore[method-assign]
+    lazy_denied = await call_handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.invoke",
+                "arguments": {
+                    "tool_id": "github::unregistered_mutation",
+                    "arguments": {},
+                    **_correlations(),
+                },
+            }
+        )
+    )
+    assert json.loads(lazy_denied.root.content[0].text)["auth_state"] == (
+        "policy_denied"
+    )
+
+    denied = await call_handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.provision",
+                "arguments": {
+                    "tool_id": "raw credential value",
+                    "run_correlation_id": "secret query with spaces",
+                    "seat_correlation_id": "seat secret with spaces",
+                    "evidence_label_digest": "not-a-digest-secret",
+                },
+            }
+        )
+    )
+    assert "blocked by policy" in json.loads(denied.root.content[0].text)["message"]
+
+    health = await server._gateway_tools.health()
+    assert health.gateway_diagnostics.capabilities == [SCOPED_ADVISOR_AUDIT_CAPABILITY]
+    await server.shutdown()
+
+    records = validate_scoped_advisor_audit(audit_path)
+    invocations = [r for r in records if r["event"] == "audit.invocation"]
+    assert [record["terminal_status"] for record in invocations] == [
+        "success",
+        "success",
+        "denied",
+        "denied",
+        "denied",
+    ]
+    assert invocations[0]["run_correlation_id"] == "run-103"
+    assert invocations[0]["seat_correlation_id"] == "seat-codex"
+    assert invocations[0]["source_reference_hash"]
+    assert records[-1]["record_count"] == len(records)
+    raw_audit = audit_path.read_text()
+    for forbidden in (
+        "example.com",
+        "private/path",
+        "super secret query",
+        "sk-private-value",
+        "raw page contents",
+        "current benchmark evidence",
+        "must not mutate",
+        "raw credential value",
+        "secret query with spaces",
+        "seat secret with spaces",
+        "not-a-digest-secret",
+    ):
+        assert forbidden not in raw_audit
+
+
+@pytest.mark.asyncio
+async def test_scoped_server_rejects_uncorrelated_invoke_before_dispatch(
+    tmp_path: Path,
+) -> None:
+    policy_path = _write_scoped_policy(tmp_path / "policy.json")
+    server = GatewayServer(
+        policy_path=policy_path, audit_jsonl=tmp_path / "audit.jsonl"
+    )
+    server._create_server()
+    called = False
+
+    async def fake_invoke(arguments: dict) -> dict:
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    server._gateway_tools.invoke = fake_invoke  # type: ignore[method-assign]
+    assert server._server is not None
+    handler = server._server.request_handlers[CallToolRequest]
+    result = await handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.invoke",
+                "arguments": {"tool_id": "firecrawl::web_search"},
+            }
+        )
+    )
+    assert called is False
+    assert json.loads(result.root.content[0].text)["error"] is True
+    await server.shutdown()
+
+
+def test_audit_validator_rejects_truncation_gaps_and_duplicate_completion(
+    tmp_path: Path,
+) -> None:
+    valid = tmp_path / "valid.jsonl"
+    audit = ScopedAdvisorAudit(valid, policy_digest="b" * 64)
+    audit.record_invocation(
+        gateway_tool="gateway.invoke",
+        terminal_status="success",
+        arguments={"tool_id": "firecrawl::search", **_correlations()},
+        result={"ok": True},
+    )
+    audit.complete()
+    records = validate_scoped_advisor_audit(valid)
+
+    truncated = tmp_path / "truncated.jsonl"
+    truncated.write_text("\n".join(json.dumps(r) for r in records[:-1]) + "\n")
+    with pytest.raises(ScopedAdvisorAuditError, match="completion"):
+        validate_scoped_advisor_audit(truncated)
+
+    gap = tmp_path / "gap.jsonl"
+    gap_records = [dict(r) for r in records]
+    gap_records[1]["sequence"] = 7
+    gap.write_text("\n".join(json.dumps(r) for r in gap_records) + "\n")
+    with pytest.raises(ScopedAdvisorAuditError, match="sequence gap"):
+        validate_scoped_advisor_audit(gap)
+
+    duplicate = tmp_path / "duplicate.jsonl"
+    duplicate_records = [dict(r) for r in records]
+    extra = dict(duplicate_records[-1])
+    extra["sequence"] = len(duplicate_records) + 1
+    duplicate_records.append(extra)
+    duplicate.write_text("\n".join(json.dumps(r) for r in duplicate_records) + "\n")
+    with pytest.raises(ScopedAdvisorAuditError, match="completion"):
+        validate_scoped_advisor_audit(duplicate)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="stdio process timing differs on Windows"
+)
+def test_four_scoped_stdio_instances_use_unique_lock_and_audit_dirs(
+    tmp_path: Path,
+) -> None:
+    policy_path = _write_scoped_policy(tmp_path / "policy.json")
+    processes: list[subprocess.Popen[bytes]] = []
+    try:
+        for index in range(4):
+            root = tmp_path / f"seat-{index}"
+            root.mkdir()
+            config = root / "mcp.json"
+            config.write_text(json.dumps({"mcpServers": {}}))
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "pmcp",
+                    "--project",
+                    str(root),
+                    "--config",
+                    str(config),
+                    "--policy",
+                    str(policy_path),
+                    "--audit-jsonl",
+                    str(root / "audit.jsonl"),
+                    "--lock-dir",
+                    str(root / "locks"),
+                    "--quiet",
+                ],
+                cwd=root,
+                env={
+                    **os.environ,
+                    "PYTHONPATH": str(Path(__file__).parents[1] / "src"),
+                },
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            processes.append(process)
+
+        time.sleep(1.5)
+        assert all(process.poll() is None for process in processes)
+    finally:
+        for process in processes:
+            if process.stdin:
+                process.stdin.close()
+        for process in processes:
+            try:
+                assert process.wait(timeout=15) == 0
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+
+    for index in range(4):
+        validate_scoped_advisor_audit(tmp_path / f"seat-{index}" / "audit.jsonl")
+
+
+@pytest.mark.asyncio
+async def test_lock_conflict_still_closes_started_audit(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "locks"
+    assert acquire_singleton_lock(lock_dir) is True
+    try:
+        server = GatewayServer(
+            policy_path=_write_scoped_policy(tmp_path / "policy.json"),
+            audit_jsonl=tmp_path / "audit.jsonl",
+            lock_dir=lock_dir,
+        )
+        with pytest.raises(RuntimeError, match="already running"):
+            await server._run_stdio()
+    finally:
+        release_singleton_lock()
+    records = validate_scoped_advisor_audit(tmp_path / "audit.jsonl")
+    assert [record["event"] for record in records] == [
+        "audit.started",
+        "audit.completed",
+    ]
+
+
+def test_audit_sink_failure_fails_closed(tmp_path: Path) -> None:
+    audit = ScopedAdvisorAudit(tmp_path / "audit.jsonl", policy_digest="c" * 64)
+    assert audit._file is not None
+    audit._file.close()
+    with pytest.raises(ScopedAdvisorAuditError, match="write failed"):
+        audit.record_invocation(
+            gateway_tool="gateway.health",
+            terminal_status="success",
+            arguments={},
+            result={"ok": True},
+        )
+
+
+def test_terminal_completion_is_fsynced_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[int] = []
+    monkeypatch.setattr("pmcp.scoped_advisor_audit.os.fsync", calls.append)
+    audit = ScopedAdvisorAudit(tmp_path / "audit.jsonl", policy_digest="d" * 64)
+    audit.complete()
+    audit.complete()
+    assert len(calls) == 1
+    validate_scoped_advisor_audit(tmp_path / "audit.jsonl")
+
+
+def test_capability_probe_is_machine_readable() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "pmcp", "capabilities", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["pmcp_version"]
+    assert payload["capabilities"][0]["name"] == SCOPED_ADVISOR_AUDIT_CAPABILITY
+    assert (
+        "terminal_completion_fsync" in payload["capabilities"][0]["activation_requires"]
+    )

--- a/tests/test_scoped_advisor_audit.py
+++ b/tests/test_scoped_advisor_audit.py
@@ -8,7 +8,12 @@ import time
 from pathlib import Path
 
 import pytest
-from mcp.types import CallToolRequest, ListToolsRequest
+from mcp.types import (
+    CallToolRequest,
+    ListPromptsRequest,
+    ListResourcesRequest,
+    ListToolsRequest,
+)
 from pydantic import ValidationError
 
 from pmcp.policy.policy import PolicyManager
@@ -45,6 +50,8 @@ def _write_scoped_policy(path: Path) -> Path:
                         "brightdata::*scrape*",
                     ]
                 },
+                "resources": {"denylist": ["*"]},
+                "prompts": {"denylist": ["*"]},
             }
         )
     )
@@ -92,12 +99,16 @@ def test_explicit_policy_failures_are_fatal_but_default_discovery_is_best_effort
 def test_gateway_tool_policy_is_case_sensitive_and_scoped() -> None:
     policy = PolicyManager(Path("examples/scoped-advisor-policy.yaml"))
     assert policy.is_scoped_advisor_policy() is True
+    assert policy.scoped_advisor_active is False
     assert policy.is_gateway_tool_allowed("gateway.invoke") is True
     assert policy.is_gateway_tool_allowed("Gateway.invoke") is False
     assert policy.is_gateway_tool_allowed("gateway.provision") is False
     assert policy.is_tool_allowed("firecrawl::web_search") is True
     assert policy.is_tool_allowed("brightdata::scrape_page") is True
     assert policy.is_tool_allowed("github::create_issue") is False
+
+    policy.activate_scoped_advisor()
+    assert policy.scoped_advisor_active is True
 
 
 def test_invoke_correlations_are_typed_and_atomic() -> None:
@@ -107,6 +118,11 @@ def test_invoke_correlations_are_typed_and_atomic() -> None:
         InvokeInput(
             tool_id="firecrawl::search",
             **{**_correlations(), "evidence_label_digest": "not-a-digest"},
+        )
+    with pytest.raises(ValidationError):
+        InvokeInput(
+            tool_id="firecrawl::search",
+            **{**_correlations(), "run_correlation_id": "rún-103"},
         )
     parsed = InvokeInput(tool_id="firecrawl::search", **_correlations())
     assert parsed.seat_correlation_id == "seat-codex"
@@ -128,6 +144,8 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     )
     for server_name in ("firecrawl", "brightdata", "github"):
         manager.set_server_online(server_name)
+    manager.get_all_resources = lambda: []  # type: ignore[attr-defined]
+    manager.get_all_prompts = lambda: []  # type: ignore[attr-defined]
     manager.set_call_tool_response(
         {
             "content": [
@@ -152,6 +170,30 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
         "gateway.describe",
         "gateway.invoke",
     }
+    resources = await server._server.request_handlers[ListResourcesRequest](
+        ListResourcesRequest(params={})
+    )
+    prompts = await server._server.request_handlers[ListPromptsRequest](
+        ListPromptsRequest(params={})
+    )
+    assert resources.root.resources == []
+    assert prompts.root.prompts == []
+
+    catalog = await call_handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.catalog_search",
+                "arguments": {
+                    "query": "native cli execution path",
+                    "include_offline": True,
+                },
+            }
+        )
+    )
+    catalog_payload = json.loads(catalog.root.content[0].text)
+    assert catalog_payload["cli_hints"] == []
+    assert catalog_payload["registry_candidates"] == []
+    assert catalog_payload["manifest_candidates"] == []
 
     invoked = await call_handler(
         CallToolRequest(
@@ -221,6 +263,19 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
         "policy_denied"
     )
 
+    describe_denied = await call_handler(
+        CallToolRequest(
+            params={
+                "name": "gateway.describe",
+                "arguments": {"tool_id": "github::unregistered_mutation"},
+            }
+        )
+    )
+    assert (
+        "blocked by policy"
+        in json.loads(describe_denied.root.content[0].text)["message"]
+    )
+
     denied = await call_handler(
         CallToolRequest(
             params={
@@ -236,6 +291,15 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     )
     assert "blocked by policy" in json.loads(denied.root.content[0].text)["message"]
 
+    raw_tool_name = "gateway.sk-secret-token"
+    raw_name_denied = await call_handler(
+        CallToolRequest(params={"name": raw_tool_name, "arguments": {}})
+    )
+    assert (
+        "blocked by policy"
+        in json.loads(raw_name_denied.root.content[0].text)["message"]
+    )
+
     health = await server._gateway_tools.health()
     assert health.gateway_diagnostics.capabilities == [SCOPED_ADVISOR_AUDIT_CAPABILITY]
     await server.shutdown()
@@ -245,13 +309,21 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     assert [record["terminal_status"] for record in invocations] == [
         "success",
         "success",
+        "success",
+        "denied",
+        "denied",
         "denied",
         "denied",
         "denied",
     ]
-    assert invocations[0]["run_correlation_id"] == "run-103"
-    assert invocations[0]["seat_correlation_id"] == "seat-codex"
-    assert invocations[0]["source_reference_hash"]
+    firecrawl_record = next(
+        record
+        for record in invocations
+        if record["downstream_tool_id"] == "firecrawl::web_search"
+    )
+    assert firecrawl_record["run_correlation_id"] == "run-103"
+    assert firecrawl_record["seat_correlation_id"] == "seat-codex"
+    assert firecrawl_record["source_reference_hash"]
     assert records[-1]["record_count"] == len(records)
     raw_audit = audit_path.read_text()
     for forbidden in (
@@ -266,8 +338,11 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
         "secret query with spaces",
         "seat secret with spaces",
         "not-a-digest-secret",
+        raw_tool_name,
     ):
         assert forbidden not in raw_audit
+    assert invocations[-1]["gateway_tool"] is None
+    assert invocations[-1]["gateway_tool_digest"]
 
 
 @pytest.mark.asyncio
@@ -336,6 +411,9 @@ def test_audit_validator_rejects_truncation_gaps_and_duplicate_completion(
     duplicate.write_text("\n".join(json.dumps(r) for r in duplicate_records) + "\n")
     with pytest.raises(ScopedAdvisorAuditError, match="completion"):
         validate_scoped_advisor_audit(duplicate)
+
+    with pytest.raises(ScopedAdvisorAuditError, match="sink unavailable"):
+        ScopedAdvisorAudit(valid, policy_digest="b" * 64)
 
 
 @pytest.mark.skipif(
@@ -429,6 +507,46 @@ def test_audit_sink_failure_fails_closed(tmp_path: Path) -> None:
             arguments={},
             result={"ok": True},
         )
+
+
+@pytest.mark.asyncio
+async def test_failed_audit_latches_before_later_dispatch(tmp_path: Path) -> None:
+    server = GatewayServer(
+        policy_path=_write_scoped_policy(tmp_path / "policy.json"),
+        audit_jsonl=tmp_path / "audit.jsonl",
+    )
+    manager = MockClientManager([create_tool_info("firecrawl", "web_search")])
+    manager.set_server_online("firecrawl")
+    called = False
+
+    async def track_call(tool_id: str, args: dict, timeout_ms: int) -> dict:
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    manager.call_tool = track_call  # type: ignore[method-assign]
+    server._client_manager = manager  # type: ignore[assignment]
+    server._gateway_tools._client_manager = manager  # type: ignore[assignment]
+    server._create_server()
+    assert server._server is not None
+    assert server._scoped_advisor_audit is not None
+    assert server._scoped_advisor_audit._file is not None
+    server._scoped_advisor_audit._file.close()
+
+    result = await server._server.request_handlers[CallToolRequest](
+        CallToolRequest(
+            params={
+                "name": "gateway.invoke",
+                "arguments": {
+                    "tool_id": "firecrawl::web_search",
+                    "arguments": {"query": "must not dispatch"},
+                    **_correlations(),
+                },
+            }
+        )
+    )
+    assert "audit sink is unavailable" in result.root.content[0].text
+    assert called is False
 
 
 def test_terminal_completion_is_fsynced_once(

--- a/tests/test_scoped_advisor_audit.py
+++ b/tests/test_scoped_advisor_audit.py
@@ -179,6 +179,16 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     assert resources.root.resources == []
     assert prompts.root.prompts == []
 
+    async def fail_registry_discovery(*args, **kwargs):
+        raise AssertionError("scoped catalog attempted registry discovery")
+
+    server._gateway_tools._registry_candidates_for_query = fail_registry_discovery  # type: ignore[method-assign]
+    server._gateway_tools._stale_check_cache["firecrawl"] = (
+        time.time(),
+        "1.0.0",
+        "2.0.0",
+    )
+
     catalog = await call_handler(
         CallToolRequest(
             params={
@@ -194,6 +204,7 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     assert catalog_payload["cli_hints"] == []
     assert catalog_payload["registry_candidates"] == []
     assert catalog_payload["manifest_candidates"] == []
+    assert catalog_payload["stale_updates"] is None
 
     invoked = await call_handler(
         CallToolRequest(

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.19.4"
+version = "1.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes Consiliency/pmcp#103. Releases the fail-closed scoped_advisor_audit.v1 prerequisite for Consiliency/agent-harness#310, with exact policy filtering, correlated privacy-safe audit evidence, and isolated concurrent stdio seats.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->