### PR TITLE
feat(manifest): add blacksmith CLI alternative

### DIFF
--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -93,6 +93,21 @@ cli_alternatives:
       - "terraform fmt -check"
       - "terraform providers"
 
+  # Blacksmith ships no MCP server: [code]smith is an MCP *client*, and Testbox
+  # integrates with agents through a generated skill file, not a server. The CLI
+  # is the supported agent surface ("agent-first ... the intended consumer is a
+  # coding agent"), so it belongs here rather than under servers:.
+  blacksmith:
+    keywords: [blacksmith, testbox, github actions, ci runner, ci analytics, flaky tests]
+    check_command: ["blacksmith", "--version"]
+    help_command: ["blacksmith", "--help"]
+    description: "Blacksmith CI runners and Testbox CLI"
+    examples:
+      - "blacksmith testbox status"
+      - "blacksmith testbox warmup <workflow>"
+      - "blacksmith testbox run --id <id> \"<command>\""
+    prefer_mcp_for: [github issues, pull requests, github api]
+
   curl:
     keywords: [curl, http, request, api, download]
     check_command: ["curl", "--version"]


### PR DESCRIPTION
## Summary

Adds a `blacksmith` entry under `cli_alternatives` so agents discover the Blacksmith CLI instead of hunting for an MCP server that does not exist.

## Why cli_alternatives and not servers

**Blacksmith publishes no MCP server.** `[code]smith` is an MCP *client* — per [their integrations docs](https://docs.blacksmith.sh/codesmith/integrations), it consumes external servers ("Local MCP servers will be installed and run on Blacksmith infra in an isolated sandbox") rather than exposing one. Testbox integrates with agents through a **generated skill file**, not MCP. Their docs describe the CLI as *"agent-first ... the intended consumer is a coding agent, not a human"*, which is exactly what this section is for.

The reasoning is recorded in a comment above the entry so it is not re-researched later.

## How this was checked

| Check | Result |
|---|---|
| Full docs index (`llms.txt`, 30 pages) | No MCP-server page; only mention is *consuming* MCP |
| Public MCP Registry (`gateway.search_registry`) | No results |
| Advertised OpenAPI spec | `404 Asset not found` — no public REST API to wrap |
| `mcp.blacksmith.sh` | NXDOMAIN |
| `api.blacksmith.sh/mcp` | 404 |
| `app.blacksmith.sh/mcp` | Next.js `[org]` catch-all, not an endpoint |

## Community package rejected

`npm blacksmith-mcp` exists but is not manifest-worthy: it authenticates by **extracting the user's Blacksmith session cookie out of Chrome** (there is no public API to hold a token against), and has 3 stars / 11 commits / 34 weekly downloads.

## Test plan

- [x] `manifest.yaml` parses; `cli_alternatives` count 11 → 12
- [x] `uv run pytest tests/test_manifest.py` — 102 passed, 1 skipped
- [x] Matches the manifest-only shape of #102 (pangram): no version bump, no CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->