### PR TITLE
feat(manifest): broaden blacksmith entry to its analytics commands

### DIFF
--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -98,14 +98,19 @@ cli_alternatives:
   # is the supported agent surface ("agent-first ... the intended consumer is a
   # coding agent"), so it belongs here rather than under servers:.
   blacksmith:
-    keywords: [blacksmith, testbox, github actions, ci runner, ci analytics, flaky tests]
+    keywords: [blacksmith, testbox, github actions, ci runner, ci analytics,
+      flaky tests, job logs, log search, test timings, ci cost, billing, runner skus]
     check_command: ["blacksmith", "--version"]
     help_command: ["blacksmith", "--help"]
-    description: "Blacksmith CI runners and Testbox CLI"
+    description: "Blacksmith CI runners, Testbox, and CI analytics CLI"
+    # Capped at 4 by test_packaged_cli_alternatives_have_compact_examples, so
+    # these cover one capability each: job history, test timings, log search,
+    # testbox. Cost/runner-SKU discovery rides on the keywords instead.
     examples:
+      - "blacksmith jobs list"
+      - "blacksmith jobs tests <job_id>"
+      - "blacksmith logs search --query 'level:error' --since 24h"
       - "blacksmith testbox status"
-      - "blacksmith testbox warmup <workflow>"
-      - "blacksmith testbox run --id <id> \"<command>\""
     prefer_mcp_for: [github issues, pull requests, github api]
 
   curl:


### PR DESCRIPTION
Follow-up to #106.

## Summary

#106 gave the `blacksmith` entry keywords like `ci analytics` and `flaky tests`, but every example was a `testbox` command — so none of the analytics surface was discoverable. Installing the CLI to verify #106's open question showed why: **the binary is much larger than Blacksmith's docs describe.**

Their [CLI reference](https://docs.blacksmith.sh/blacksmith-testbox/cli) documents only `testbox *` and `auth login`. The installed binary (0.4.50) also ships:

| Command | What it does |
|---|---|
| `jobs list` / `stats` / `steps` | Job run history, per-run CPU/memory/OOM metrics |
| `jobs tests` | Structured test timings, slowest-first |
| `jobs aggregate` / `sample` | Cross-run percentiles by repo/workflow/job/runner |
| `jobs diagnose` / `thread-profiles` | Job diagnosis, D-state thread debugging |
| `logs search` / `histogram` | Org-wide log search with a query language |
| `usage` | Billable/billing/runtime minutes, estimated cost |
| `runners catalog` | Runner SKUs with vcpu/memory/arch/cost |

## Why this reinforces #106

This is the same ground the rejected community MCP server covered — by scraping the user's Blacksmith session cookie out of Chrome. The CLI does it first-party and properly authenticated, which makes `cli_alternatives` the right home rather than a workaround.

## Resolves the #106 open question

I flagged in [#106's self-review](https://github.com/Consiliency/pmcp/pull/106#issuecomment-5151968696) that `check_command: ["blacksmith", "--version"]` was unverified because the docs list no such flag. Now confirmed on the installed binary:

```
$ blacksmith --version
blacksmith version 0.4.50          # exit 0
$ blacksmith --help
Blacksmith CLI — run CI against local changes, instantly   # exit 0
```

Both are correct as merged; no change needed there. Their own install script calls `blacksmith --version` too.

## Test plan

- [x] `tests/test_manifest.py` — 102 passed, 1 skipped
- [x] Examples capped at 4 by `test_packaged_cli_alternatives_have_compact_examples` (`tests/test_manifest.py:566`), which **caught an initial 7-example version** — kept at 4, one per capability, with the cap noted inline so the next editor does not trip it
- [x] All example signatures taken from `--help` on the installed binary, not from the docs (e.g. `logs search` takes `--query`, not a positional; `jobs tests` takes `<job_id>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->