### PR TITLE
feat(manifest): add extra_env for non-secret server variables

### DIFF
--- a/plans/detailed-overlay-server-env-patch-20260801-1530.md
+++ b/plans/detailed-overlay-server-env-patch-20260801-1530.md
@@ -1,0 +1,116 @@
+# Detailed plan: per-host overlay override of a shipped server's environment
+
+> **Plan Mode was NOT active when this was produced.** Planning artifact only — no implementation has begun.
+
+## Task
+
+Let a private overlay point a **shipped** manifest server at a non-default endpoint (e.g. a self-hosted Firecrawl on another host) **without redeclaring the whole server entry**. Part 2 of Consiliency/pmcp#105; part 1 (`extra_env`) is PR #108.
+
+## Research summary
+
+`extra_env` (PR #108) makes a second, non-secret variable declarable on a `ServerConfig` and applies it in `build_install_child_env` (`src/pmcp/manifest/installer.py`, in the `own_env` block around line 521). That closes the *declaration* gap but not the *per-host* gap.
+
+The blocker is the overlay merge in `load_manifest` — `servers.update(overlay_servers)` (`src/pmcp/manifest/loader.py:564`). Overlay entries are parsed by `_parse_server_config` into complete `ServerConfig` objects and replace the shipped entry by name. To set one URL, an operator must restate `command`, `args`, the four-platform `install` block, `env_var`, `requires_api_key`, and everything else.
+
+**This was a deliberate decision, not an oversight.** `plans/detailed-private-manifest-overlay-20260629-0841.md:23` states: *"an overlay entry with the same name as a shipped/earlier entry **replaces** it (whole-entry replace, not deep-merge) — simplest, predictable."* Any change here must justify revisiting it.
+
+The gap that decision did not anticipate is **silent drift**: a redeclared entry is a frozen copy. When the shipped entry later changes — a package rename, an install-command fix, a new `secret_key` namespace — the overlay keeps overriding with the stale copy and the operator gets no signal. The existing override warning (`loader.py`, in the pre-merge loop around line 560) fires on *every* override, so it cannot distinguish "intentional full replacement" from "stale copy shadowing an upstream fix."
+
+Existing overlay behavior is covered by 8 tests in `tests/test_manifest_overlay.py`, including precedence ordering, fail-soft parsing, symlink containment, and `test_explicit_path_skips_overlays`. All must keep passing unchanged — this plan adds a mechanism, it does not alter `servers:` semantics.
+
+## Options considered
+
+| # | Option | Verdict |
+|---|---|---|
+| A | Deep-merge all fields in `servers:` | **Rejected.** Directly reverses the documented decision and silently changes behavior for existing overlay users: an entry that today fully replaces would start inheriting shipped fields. Also introduces an unanswerable question — how do you *unset* an inherited field? |
+| B | New `server_env:` overlay section that patches only `extra_env` on an existing server | **Recommended.** Additive, leaves `servers:` semantics untouched, solves the motivating case exactly, and no existing overlay changes meaning. |
+| C | `${VAR}` interpolation inside shipped `extra_env` values | **Rejected.** Still requires the variable in the gateway's own environment — precisely the process-global workaround #105 exists to remove. Solves discoverability, not the actual problem. |
+| D | Opt-in `merge: true` marker on a `servers:` entry | **Deferred.** Preserves the default and is more general than B, but it is a broader contract (per-field merge semantics for ~25 fields, including how to unset). If a second patch use case appears, revisit — B does not foreclose it. |
+
+Option B is the bounded change: one new overlay key, one allowed field, no change to any existing path.
+
+## Changes
+
+### `src/pmcp/manifest/loader.py` (modify)
+
+- `_load_overlay_file` — modify — also parse a top-level `server_env` mapping, returning it as a third element `dict[str, dict[str, str]]` (server name → env patch). Reuse `_parse_extra_env` for each value so coercion and fail-soft warnings match `extra_env` exactly. Keep the existing per-entry try/except shape: one bad patch is skipped, siblings survive.
+- `load_manifest` — modify — after the existing `servers.update(overlay_servers)` for each overlay source, apply that source's `server_env` patches. For each `(name, patch)`: if `name` is absent from `servers`, `logger.warning` naming the file and the unknown server, then skip — a patch must never conjure a server. Otherwise replace that entry with `dataclasses.replace(servers[name], extra_env={**servers[name].extra_env, **patch})`. Patching is per-key over the existing `extra_env`, so a patch that sets one variable leaves the others intact.
+- Apply patches **after** the source's own `servers.update`, and within each overlay source in precedence order, so a later source can patch an entry an earlier source replaced.
+
+`dataclasses.replace` is used rather than mutating in place because `ServerConfig` instances from the shipped parse are shared with nothing else in the process, but mutation would make the merge order-dependent in a way that is hard to test; `replace` keeps each step a pure rebind.
+
+### `tests/test_manifest_overlay.py` (modify)
+
+Add cases alongside the existing 8:
+
+- `test_server_env_patches_shipped_server` — overlay supplies only `server_env: {firecrawl: {FIRECRAWL_API_URL: ...}}`; assert the shipped `command`/`args`/`env_var` survive untouched and `extra_env` carries the new value.
+- `test_server_env_merges_with_shipped_extra_env` — shipped entry already has an `extra_env` key; assert the patch adds to it rather than replacing the mapping wholesale.
+- `test_server_env_unknown_server_warns_and_skips` — patch names a server that does not exist; assert no entry is created and a warning naming the file is logged.
+- `test_server_env_malformed_is_skipped` — non-mapping `server_env`, and a mapping whose value is a scalar; assert the rest of the overlay still loads.
+- `test_server_env_precedence_across_sources` — user overlay patches a key, project overlay patches a different key on the same server; assert both survive and a same-key collision resolves to the higher-precedence source.
+- `test_explicit_path_skips_server_env` — mirrors the existing `test_explicit_path_skips_overlays` guarantee.
+
+### `src/pmcp/manifest/manifest.yaml` (modify)
+
+- `firecrawl` — add — `extra_env: {FIRECRAWL_API_URL: "https://api.firecrawl.dev"}`, making the default endpoint explicit and giving `server_env` a documented key to patch.
+
+**Verify before committing this one.** `firecrawl-mcp` currently defaults to the SaaS endpoint when the variable is unset; setting it explicitly must be confirmed a no-op for SaaS users (check the package's own default rather than assuming this URL string). If it cannot be confirmed, drop this change — the mechanism works without it, and a wrong default would break every SaaS Firecrawl user.
+
+## Documentation impact
+
+- `CHANGELOG.md` — modify — under `## [Unreleased]` / `### Added`: overlay `server_env` patches a shipped server's `extra_env` without redeclaring the entry. Pair with the `extra_env` entry from #108.
+- `plans/detailed-private-manifest-overlay-20260629-0841.md` — modify — append a short note under the whole-entry-replace decision recording that `server_env` was added as a narrow exception and that `servers:` semantics are unchanged, so the next reader of that decision finds the amendment rather than believing replace is still the whole story.
+- `README.md` — none. Overlay files are not documented there today; adding a first overlay reference is its own change.
+
+## Dependencies & order
+
+1. **#108 (`extra_env`) must merge first** — `server_env` patches a field that does not exist without it.
+2. Loader change before tests can pass, but write the tests first — the unknown-server and malformed cases are the ones most likely to be missed.
+3. The `manifest.yaml` firecrawl default is independent and last; it is droppable without affecting the rest.
+
+## Verification
+
+```bash
+# Targeted
+uv run pytest tests/test_manifest_overlay.py -q          # 8 existing + 6 new
+uv run pytest tests/test_manifest.py -q                  # extra_env parsing unchanged
+
+# Regression — overlay touches the loader every consumer shares
+uv run pytest tests/ -q                                  # expect 2259+ passed
+
+# Gates
+uv run ruff check src/ tests/
+uv run ruff format --check src/pmcp/manifest/ tests/
+uv run mypy src/pmcp/manifest/loader.py
+```
+
+End-to-end check with a real overlay, which no unit test covers:
+
+```bash
+mkdir -p ~/.pmcp && cat > ~/.pmcp/manifest.yaml <<'YAML'
+server_env:
+  firecrawl:
+    FIRECRAWL_API_URL: "http://100.84.171.76:3002"
+YAML
+uv run python -c "
+from pmcp.manifest.loader import load_manifest
+s = load_manifest().servers['firecrawl']
+print(s.extra_env, s.command, s.args)   # patched URL, shipped command/args intact
+"
+```
+
+Then confirm the spawned server actually receives it — start the gateway with **no** `FIRECRAWL_API_URL` exported, connect firecrawl, and scrape a URL. Success means the overlay alone reached the child process, which is the whole point of #105.
+
+Edge cases to exercise: patch for a server excluded by policy (must not resurrect it); patch whose value is an empty string (should pass through, not be dropped as falsy); overlay containing `server_env` and a `servers:` entry for the same name (replacement applies first, then the patch).
+
+## Acceptance criteria
+
+- [ ] An overlay containing only `server_env` for a shipped server sets that server's `extra_env` while `command`, `args`, `install`, and `env_var` remain byte-identical to the shipped entry — proven by `uv run pytest tests/test_manifest_overlay.py -q`
+- [ ] A `server_env` patch naming an unknown server creates no entry and logs a warning naming the overlay file — proven by `test_server_env_unknown_server_warns_and_skips`
+- [ ] All 8 pre-existing overlay tests pass unmodified, demonstrating `servers:` whole-entry-replace semantics are unchanged — proven by `uv run pytest tests/test_manifest_overlay.py -q`
+- [ ] Full suite green with no new warnings — proven by `uv run pytest tests/ -q`
+- [ ] A self-hosted Firecrawl is reachable through the gateway with the URL supplied **only** by `~/.pmcp/manifest.yaml` and no variable exported into the gateway environment — proven by the end-to-end block above
+
+## Execution Policy
+
+- execute: effort=medium, reason=small surface but merge-order and precedence semantics are easy to get subtly wrong, and the loader is shared by all 19 `load_manifest` call sites

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -845,6 +845,30 @@
       "task_summary": "Release fail-closed scoped advisor policy and privacy-safe audit capability for Consiliency/pmcp#103.",
       "type": "detailed",
       "updated_at": "2026-07-26T07:52:23Z"
+    },
+    {
+      "acceptance_criteria_count": 5,
+      "created_at": "2026-08-01T15:30:00Z",
+      "file": "plans/detailed-overlay-server-env-patch-20260801-1530.md",
+      "handoff_ref": null,
+      "lifecycle": [
+        {
+          "at": "2026-08-01T15:30:00Z",
+          "by": "claude-plan-detailed",
+          "metadata": {
+            "branch": "feat/manifest-extra-env",
+            "issue": "Consiliency/pmcp#105",
+            "part": "2 of 2"
+          },
+          "transition": "committed"
+        }
+      ],
+      "owner_skill": "claude-plan-detailed",
+      "slug": "overlay-server-env-patch",
+      "status": "committed",
+      "task_summary": "Let a private overlay point a shipped manifest server at a non-default endpoint without redeclaring the whole entry (part 2 of #105).",
+      "type": "detailed",
+      "updated_at": "2026-08-01T15:30:00Z"
     }
   ],
   "schema_version": 1

--- a/src/pmcp/manifest/installer.py
+++ b/src/pmcp/manifest/installer.py
@@ -517,8 +517,15 @@ def build_install_child_env(server_config: ServerConfig) -> dict[str, str]:
     receive its ``env_var`` at spawn time it starts without its credential. The
     gateway's own ``os.environ`` only holds the namespaced storage key after
     ``auth_connect``, so a bare inherited environment would omit the runtime var.
+
+    Also applies the server's declared ``extra_env`` — non-secret vars such as a
+    base URL selecting a self-hosted deployment. Without this, the only way to
+    reach a non-default endpoint is to start the whole gateway with the variable
+    already exported, which is process-global and invisible to the manifest.
     """
-    own_env: dict[str, str] = {}
+    # Declared non-secret vars first (e.g. a self-hosted base URL), so the
+    # credential resolved below always wins if the two name the same key.
+    own_env: dict[str, str] = dict(getattr(server_config, "extra_env", {}) or {})
     env_var = server_config.env_var
     if env_var:
         for key in credential_lookup_keys(server_config):

--- a/src/pmcp/manifest/loader.py
+++ b/src/pmcp/manifest/loader.py
@@ -54,6 +54,11 @@ class ServerConfig:
     # servers sharing that runtime name do not collide in the flat secret store.
     secret_key: str | None = None
     env_instructions: str | None = None
+    # Non-secret environment variables passed to the server process alongside its
+    # credential — typically a base URL selecting a self-hosted deployment (e.g.
+    # FIRECRAWL_API_URL). Secrets belong in env_var/secret_key, which are resolved
+    # from the env store and always win over a colliding extra_env key.
+    extra_env: dict[str, str] = field(default_factory=dict)
     auto_start: bool = False
     transport: ServerTransport = "local"
     url: str | None = None
@@ -347,6 +352,37 @@ def _parse_cli_alternative(name: str, data: dict[str, Any]) -> CLIAlternative:
     )
 
 
+def _parse_extra_env(name: str, raw: Any) -> dict[str, str]:
+    """Parse a server's ``extra_env`` mapping, fail-soft.
+
+    Non-mappings and unusable entries are dropped with a warning rather than
+    raising, so one bad key never costs the whole server entry. YAML scalars are
+    coerced to ``str`` because values such as a port or a boolean flag are
+    naturally written unquoted.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        logger.warning(f"Ignoring 'extra_env' for server '{name}': not a mapping")
+        return {}
+
+    parsed: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key:
+            logger.warning(f"Skipping non-string 'extra_env' key for server '{name}'")
+            continue
+        if isinstance(value, bool):
+            parsed[key] = "true" if value else "false"
+        elif isinstance(value, (str, int, float)):
+            parsed[key] = str(value)
+        else:
+            logger.warning(
+                f"Skipping 'extra_env' key '{key}' for server '{name}': "
+                f"unsupported value type {type(value).__name__}"
+            )
+    return parsed
+
+
 def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
     """Parse a server config from raw YAML data."""
     install_data = data.get("install", {})
@@ -360,6 +396,8 @@ def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
         ServerTransport,
         data.get("transport", "streamable-http" if data.get("url") else "local"),
     )
+
+    extra_env = _parse_extra_env(name, data.get("extra_env"))
 
     raw_discovery_metadata = data.get("discovery_metadata", {})
     if not isinstance(raw_discovery_metadata, dict):
@@ -379,6 +417,7 @@ def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
         env_var=data.get("env_var"),
         secret_key=data.get("secret_key"),
         env_instructions=data.get("env_instructions"),
+        extra_env=extra_env,
         auto_start=data.get("auto_start", False),
         transport=transport,
         url=data.get("url"),

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -29,6 +30,7 @@ from pmcp.manifest.loader import (
     CLIAlternative,
     Manifest,
     ServerConfig,
+    _parse_server_config,
     load_manifest,
 )
 from pmcp.manifest.matcher import (
@@ -1170,6 +1172,99 @@ def test_build_install_child_env_legacy_fallback(monkeypatch: pytest.MonkeyPatch
 
     env = build_install_child_env(_brightdata_config())
     assert env["API_TOKEN"] == "legacy-token"
+
+
+def _self_hosted_firecrawl_config(**overrides: Any) -> ServerConfig:
+    """A server pointed at a self-hosted deployment via a non-secret base URL."""
+    kwargs: dict[str, Any] = dict(
+        name="firecrawl",
+        description="Firecrawl",
+        keywords=["firecrawl"],
+        install={"linux": ["npx", "-y", "firecrawl-mcp"]},
+        command="npx",
+        args=["-y", "firecrawl-mcp"],
+        requires_api_key=True,
+        env_var="FIRECRAWL_API_KEY",
+        extra_env={"FIRECRAWL_API_URL": "http://firecrawl.internal:3002"},
+    )
+    kwargs.update(overrides)
+    return ServerConfig(**kwargs)
+
+
+def test_build_install_child_env_applies_extra_env(monkeypatch: pytest.MonkeyPatch):
+    """A declared non-secret var reaches the spawned server, so a self-hosted
+    endpoint no longer requires exporting it into the whole gateway."""
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key")
+
+    env = build_install_child_env(_self_hosted_firecrawl_config())
+    assert env["FIRECRAWL_API_URL"] == "http://firecrawl.internal:3002"
+    assert env["FIRECRAWL_API_KEY"] == "fc-key"
+
+
+def test_build_install_child_env_extra_env_does_not_shadow_credential(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """extra_env must never override the resolved credential: a manifest typo
+    naming the credential key would otherwise silently replace the real secret
+    with a literal from version control."""
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "real-secret")
+
+    config = _self_hosted_firecrawl_config(
+        extra_env={"FIRECRAWL_API_KEY": "placeholder-from-yaml"}
+    )
+    env = build_install_child_env(config)
+    assert env["FIRECRAWL_API_KEY"] == "real-secret"
+
+
+def test_build_install_child_env_extra_env_without_credential(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A no-auth self-hosted endpoint still gets its URL when no credential is
+    stored, rather than the var being dropped along with the missing secret."""
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+
+    env = build_install_child_env(_self_hosted_firecrawl_config())
+    assert env["FIRECRAWL_API_URL"] == "http://firecrawl.internal:3002"
+    assert "FIRECRAWL_API_KEY" not in env
+
+
+def test_parse_extra_env_coerces_scalars_and_skips_bad_entries():
+    """YAML scalars are usable unquoted; unusable entries are dropped rather
+    than costing the whole server entry."""
+    config = _parse_server_config(
+        "demo",
+        {
+            "command": "npx",
+            "extra_env": {
+                "PORT": 3002,
+                "RATIO": 1.5,
+                "DEBUG": True,
+                "OFF": False,
+                "URL": "http://example.internal",
+                "BAD": {"nested": "mapping"},
+            },
+        },
+    )
+    assert config.extra_env == {
+        "PORT": "3002",
+        "RATIO": "1.5",
+        "DEBUG": "true",
+        "OFF": "false",
+        "URL": "http://example.internal",
+    }
+
+
+@pytest.mark.parametrize("raw", ["not-a-mapping", ["a", "b"], 42])
+def test_parse_extra_env_rejects_non_mappings(raw: Any):
+    """A malformed extra_env is ignored, not raised, so it cannot drop a server."""
+    config = _parse_server_config("demo", {"command": "npx", "extra_env": raw})
+    assert config.extra_env == {}
+
+
+def test_server_without_extra_env_defaults_empty():
+    """Every existing manifest entry omits extra_env; it must default to empty."""
+    config = _parse_server_config("demo", {"command": "npx"})
+    assert config.extra_env == {}
 
 
 def test_build_install_child_env_absent_credential_no_injection(


### PR DESCRIPTION
Part 1 of #105.

## Problem

A manifest server entry could declare exactly one environment variable. A server needing a second — most often a base URL selecting a self-hosted deployment — could not be expressed at all. The only workaround was starting the whole gateway with the variable pre-exported:

```bash
FIRECRAWL_API_URL="http://host:3002" FIRECRAWL_API_KEY="..." pmcp --transport http ...
```

That is process-global, invisible to anyone reading the manifest, and lost on any restart that does not reproduce the environment.

## Change

An optional `extra_env` mapping, applied in `build_install_child_env` alongside the resolved credential:

```yaml
  firecrawl:
    env_var: "FIRECRAWL_API_KEY"
    extra_env:
      FIRECRAWL_API_URL: "https://api.firecrawl.dev"
```

The change is contained: all 4 call sites of `build_install_child_env` pass only `server_config`, so none of them changed.

## Deliberate choices

- **Non-secret values only.** Secrets stay in `env_var`/`secret_key`, resolved from the env store, leaving credential-namespacing and redaction untouched.
- **`extra_env` applies *before* the credential**, so the resolved secret always wins on a key collision. A manifest typo naming the credential key cannot replace a real secret with a literal from version control.
- **Fail-soft parsing**, matching the overlay loader's existing convention: a non-mapping or unusable entry is dropped with a warning rather than raising, so one bad key never costs the whole server entry.
- **YAML scalars coerced to `str`**, since a port or boolean flag is naturally written unquoted.

## Scope

**No manifest entries change yet.** Wiring up firecrawl's self-hosted URL needs per-host overlay support, which is deliberately out of scope here — whole-entry replace was an explicit design decision (`plans/detailed-private-manifest-overlay-20260629-0841.md:23`: *"whole-entry replace, not deep-merge — simplest, predictable"*), so revisiting it warrants its own planned change rather than being smuggled in. That is part 2 of #105.

## Test plan

- [x] Full suite: **2259 passed**, 3 skipped
- [x] `tests/test_manifest.py`: 110 passed (7 new)
- [x] `ruff check` clean, `ruff format --check` clean, `mypy` clean on both changed modules
- [x] New cases cover: var reaches the child env; credential is not shadowed; URL still applied when no credential is stored; scalar coercion; malformed input dropped; absent field defaults empty (every existing entry omits it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->