### PR TITLE
chore: v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-08-01
+
 ### Added
 - **Non-secret server environment variables (`extra_env`).** A manifest server
   entry can now declare environment variables beyond its single credential —
@@ -14,7 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   way to reach a non-default endpoint was to start the whole gateway with the
   variable pre-exported, which is process-global and invisible to the manifest.
   Values are non-secret by design; credentials stay in `env_var`/`secret_key`
-  and always win over a colliding `extra_env` key. (#108)
+  and always win over a colliding `extra_env` key. Applied on **every** server
+  spawn path — install-and-run, restart, refresh, lazy reconnect, and lifecycle
+  connect — so a self-hosted endpoint survives a gateway restart rather than
+  silently reverting to the vendor default. A configured `.mcp.json` entry that
+  duplicates a manifest server inherits it too, with any value that config sets
+  explicitly winning as a genuine user override. (#108, #109)
 - **Per-host overlay patching (`server_env`).** A private overlay
   (`~/.pmcp/manifest.yaml`, `<project>/.pmcp/manifest.yaml`,
   `$PMCP_MANIFEST_PATH`) can patch `extra_env` on an existing server without
@@ -23,18 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a copy that would silently shadow later upstream fixes. `servers:` keeps its
   whole-entry-replace semantics unchanged; a patch naming an unknown server
   warns and is skipped rather than creating one. (#105)
-
-### Fixed
-- **`extra_env` is now applied on every server spawn path, not just
-  install-and-run.** `_manifest_server_to_config` built the runtime environment
-  from the credential alone, so a server picked up its declared non-secret
-  variables on first provision (which builds its own child environment) and then
-  silently lost them on every restart, refresh, lazy reconnect, and lifecycle
-  connect — falling back to the vendor default endpoint with no error. A
-  configured `.mcp.json` entry duplicating a manifest server likewise discarded
-  them; it now inherits `extra_env`, with any value the config sets explicitly
-  winning as a genuine user override. Credentials continue to take precedence
-  over a colliding `extra_env` key on both paths. (#109)
+- **`blacksmith` CLI alternative.** Agents now discover the Blacksmith CLI
+  (Testbox, job history, log search, CI usage) instead of looking for an MCP
+  server — Blacksmith publishes none, and its CLI is the supported agent
+  surface. (#106, #107)
 
 ## [1.20.0] - 2026-07-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.20.0"
+version = "1.21.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.20.0"
+__version__ = "1.21.0"

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.20.0"
+version = "1.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release PR. **Merging this does not publish** — the PyPI trusted-publish fires on the annotated `v1.21.0` tag, pushed after merge.

## What ships

| PR | Change |
|---|---|
| #108, #109 | `extra_env` — non-secret server env vars, applied on every spawn path |
| #105 (via #109) | `server_env` — per-host overlay patching without redeclaring an entry |
| #106, #107 | `blacksmith` CLI alternative |

## Why minor, not patch or major

Everything is additive and backward compatible. `extra_env` defaults empty, `server_env` is new syntax no existing overlay uses, and `_manifest_server_to_config` deliberately preserves its historical `env=None` shape when there is nothing to inject. No existing manifest entry declares either field, so no currently-installed server changes behavior on upgrade.

## Changelog editorial note

The #109 spawn-path work was originally written as a `### Fixed` entry. But the feature it fixed — `extra_env` (#108) — **has never shipped**; both land in this same release. Presenting it as a fix would send users hunting for a broken version that does not exist, so it is folded into the `extra_env` entry as the design guarantee it actually is ("applied on every server spawn path").

The `blacksmith` entry is listed even though this repo has no precedent for changelogging pure manifest additions (#102/pangram got none). Reason: unlike a new provisionable server, a new `cli_alternative` changes agent behavior on upgrade — agents start recommending the CLI — so an upgrading user should see it.

## Version bump verified consistent

```
pyproject.toml       1.21.0
src/pmcp/__init__.py 1.21.0
uv.lock              1.21.0
$ pmcp --version   → pmcp 1.21.0
```

## Post-merge

Push the annotated tag to trigger `release.yml` → PyPI trusted publishing:

```bash
git tag -a v1.21.0 -m "v1.21.0" && git push origin v1.21.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->