### PR TITLE
fix: cap mcp below 2.0 — a fresh install was dead on arrival (v1.21.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,45 @@ jobs:
       - name: Check coverage threshold
         run: uv run coverage report --fail-under=60
 
+  # Every other job installs via `uv sync`, which uses uv.lock — so they only
+  # ever exercise the PINNED dependency versions. That hid a shipped break: an
+  # unbounded `mcp>=1.0.0` let a real install resolve to mcp 2.0.0, which had
+  # renamed a symbol the gateway imports at startup. The whole suite passed
+  # while `pip install pmcp` was dead on arrival.
+  #
+  # This job resolves dependencies FRESH, exactly as a user does, and smoke-tests
+  # the installed console script. It is the only job that can catch a bad or
+  # missing version constraint.
+  install-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Build and install from the wheel, ignoring uv.lock
+        run: |
+          uv build --wheel --out-dir dist
+          uv venv /tmp/fresh
+          # No --frozen / no uv.lock: resolve from pyproject constraints alone.
+          VIRTUAL_ENV=/tmp/fresh uv pip install dist/*.whl
+
+      - name: Report the resolved versions (so a bad bump is visible in the log)
+        run: VIRTUAL_ENV=/tmp/fresh uv pip list
+
+      - name: Smoke-test the installed entry point
+        run: |
+          /tmp/fresh/bin/pmcp --version
+          # Import the modules a real startup touches, so a renamed or removed
+          # upstream symbol fails here rather than in a user's service log.
+          /tmp/fresh/bin/python -c "import pmcp.client.manager, pmcp.server, pmcp.config.loader"
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.1] - 2026-08-01
+
+### Fixed
+- **A fresh install was dead on arrival.** The `mcp` dependency was declared as
+  `mcp>=1.0.0` with no upper bound. `mcp` 2.0.0 renamed
+  `mcp.client.streamable_http.streamablehttp_client` to
+  `streamable_http_client`, which `client/manager.py` imports at module scope,
+  so any clean `pip install pmcp` / `uv tool install pmcp` resolved to 2.x and
+  the gateway died at startup with
+  `ImportError: cannot import name 'streamablehttp_client'`. Existing installs
+  and development checkouts were unaffected — `uv.lock` pins a 1.x `mcp`, which
+  is precisely why the entire test suite passed while the published artifact was
+  broken. Now capped at `mcp>=1.0.0,<2.0.0`. Supporting `mcp` 2.x is tracked
+  separately; raising the cap requires porting that import and auditing the rest
+  of the 2.x surface.
+
+### Changed
+- **CI now installs the built wheel with dependencies resolved from scratch.**
+  Every existing job installs via `uv sync`, which uses `uv.lock`, so nothing
+  ever exercised the version constraints an end user actually resolves against.
+  A new `install-smoke` job builds the wheel, installs it into a clean
+  environment with no lockfile, prints the resolved versions, and imports the
+  modules a real startup touches. Verified to fail on the previous unbounded
+  constraint and pass on the capped one — this class of break can no longer ship
+  green.
+
 ## [1.21.0] - 2026-08-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.21.0"
+version = "1.21.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"
@@ -31,7 +31,12 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    # Upper bound is load-bearing: mcp 2.0.0 renamed
+    # mcp.client.streamable_http.streamablehttp_client to streamable_http_client,
+    # which client/manager.py imports at module scope. Without the cap a fresh
+    # install resolves to 2.x and the gateway dies on startup with an ImportError.
+    # Raising this requires porting that import (and auditing the rest of 2.x).
+    "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0",
     "pyjwt[crypto]>=2.10.0",
     "pyyaml>=6.0",

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.21.0"
+__version__ = "1.21.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.21.0"
+version = "1.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1063,7 +1063,7 @@ http = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pmcp", extras = ["dev", "http"], marker = "extra == 'all'" },
     { name = "prometheus-client", marker = "extra == 'http'", specifier = ">=0.20" },


### PR DESCRIPTION
**Severity: the published package cannot start.** Affects 1.20.0 and 1.21.0.

## The bug

`mcp` was declared `mcp>=1.0.0` with no upper bound. `mcp` 2.0.0 renamed `mcp.client.streamable_http.streamablehttp_client` → `streamable_http_client`, and `src/pmcp/client/manager.py:22` imports the old name at module scope. So any clean install resolves to 2.x and dies immediately:

```
Fatal error: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'
```

Found while reinstalling from PyPI after the 1.21.0 release. Observed in the wild as a systemd unit in an auto-restart loop, **restart counter at 18003**.

## Why 2276 passing tests didn't catch it

Every CI job installs with `uv sync`, which uses `uv.lock` — and the lock pins `mcp` **1.25.0**. The suite only ever exercised *pinned* versions, never the constraints a user resolves against. The whole suite was green while `pip install pmcp` was dead on arrival.

This is structural: a lockfile makes bad version constraints invisible by construction. No amount of additional unit tests would have found it.

## Fix

**1. Cap the dependency** — `mcp>=1.0.0,<2.0.0`, with an inline comment recording that the bound is load-bearing and what raising it requires.

**2. Close the CI gap** — new `install-smoke` job that builds the wheel, installs it into a clean env with **no lockfile**, prints resolved versions, and imports the modules a real startup touches.

Verified in both directions locally, which is the part that matters:

| Constraint | Resolves | Smoke result |
|---|---|---|
| `mcp>=1.0.0` (old) | mcp **2.0.0** | ❌ `ImportError: cannot import name 'streamablehttp_client'` |
| `mcp>=1.0.0,<2.0.0` (new) | mcp **1.29.0** | ✅ `pmcp 1.21.1`, imports OK |

So the job demonstrably catches the exact break that shipped, rather than being a guard we hope works.

## Scope

Supporting `mcp` 2.x is **not** attempted here — that needs the import ported and the rest of the 2.x surface audited, which is not a patch-release change. The cap makes installs work now; a follow-up can raise it deliberately.

## Test plan

- [x] Full suite: 2276 passed, 3 skipped
- [x] `ruff check` / `ruff format --check` clean
- [x] Version consistent across `pyproject.toml`, `src/pmcp/__init__.py`, `uv.lock`, and `pmcp --version` → 1.21.1
- [x] New `install-smoke` job contains no `${{ }}` interpolation and no `ref:` — no workflow-injection surface

## Post-merge

```bash
git tag -a v1.21.1 -m "v1.21.1" && git push origin v1.21.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->