### PR TITLE
chore(plan): stage-1 plan for the mcp 2.x / spec 2026-07-28 port

### DIFF
--- a/plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md
+++ b/plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md
@@ -1,0 +1,116 @@
+# Detailed plan: port pmcp onto mcp 2.x (spec 2026-07-28) — Stage 1, runtime parity
+
+> **Plan Mode was NOT active when this was produced.** Planning artifact only — no implementation has begun.
+
+## Task
+
+Raise pmcp's `mcp<2.0.0` cap and get the gateway running on **mcp 2.x**, which is the only implementation of the current stable MCP spec (`2026-07-28`). mcp 1.29.0 tops out at `2025-11-25` and has no subscriptions support, so the cap added in #111 — correct as triage for a dead-on-arrival install — is now what pins pmcp to the previous protocol revision.
+
+**Stage 1 scope: run correctly on the mcp 2.x library while continuing to serve today's semantics.** New-spec *features* (`server/discover`, `subscriptions/listen`, retiring the HTTP GET endpoint) are explicitly out of scope — see "Why this is staged".
+
+## Research summary
+
+All facts below were verified in-session by installing the libraries and running the code, not by reading changelogs.
+
+- **mcp 2.0.0 is the 2026-07-28 implementation.** `LATEST_PROTOCOL_VERSION = 2026-07-28`; 1.29.0 reports `2025-11-25`. 2.0 adds `PROTOCOL_VERSION_META_KEY`, `UNSUPPORTED_PROTOCOL_VERSION`, and `UnsupportedProtocolVersionErrorData` — the primitives for per-request negotiation.
+- **The import surface is nearly intact.** Of pmcp's seven `mcp` imports, only `mcp.client.streamable_http.streamablehttp_client` is gone (renamed `streamable_http_client`). `sse_client`, `Server`, `StreamableHTTPSessionManager`, `SessionMessage`, and `Tool` all survive.
+- **The real break is the lowlevel `Server` decorators.** With the import aliased, every pmcp startup module imports, then the gateway dies at boot: `'Server' object has no attribute 'list_tools'`. All six registrations live in `src/pmcp/server.py` (`list_tools:203`, `call_tool:215`, `list_resources:369`, `read_resource:407`, `list_prompts:466`, `get_prompt:495`). The replacement is `Server.add_request_handler(method: str, params_type, handler)`; `mcp.server.mcpserver.MCPServer` uses exactly that internally, which is the migration recipe.
+- **`MCPServer` is the wrong target despite matching method names.** `StreamableHTTPSessionManager.__init__` takes `app: Server[Any]` — the lowlevel server — and `MCPServer.run(transport=...)` owns its own transport, which would displace pmcp's Starlette app in `src/pmcp/transport/http.py` (its own `/health`, `/metrics`, auth middleware, uvicorn wiring). Stay on lowlevel `Server`.
+- **Downstream bridging already exists and is the thing to extend, not invent.** `src/pmcp/client/manager.py` already negotiates and falls back: `PREFERRED_PROTOCOL_VERSION = "2025-11-25"` (`:187`), an accepted-version list including `"2025-06-18"` (around `:190`), `_is_protocol_version_initialize_error` (`:390`), and a retry at `"2024-11-05"` (around `:1876`). The gateway proxies 108 servers, nearly all on mcp 1.x, so this ladder is load-bearing.
+
+## Why this is staged
+
+The skill's bounded-plan threshold is ~8 files / ~3 distinct concerns. A full move to 2026-07-28 has at least five: (a) library port, (b) handler re-registration, (c) downstream version bridging, (d) `server/discover`, (e) `subscriptions/listen` replacing the HTTP GET endpoint. Bundling them would produce one oversized plan whose failure modes are entangled — and (d) and (e) are *protocol surface changes* that alter what clients see, whereas (a)–(c) are internal.
+
+Stage 1 is (a)–(c): pmcp runs on mcp 2.x, behaves identically to today, and every downstream server keeps working. Stages 2 and 3 get their own bounded plans:
+
+- **Stage 2 — `server/discover`.** New mandatory RPC. Additive; needs its own handler and capability reporting.
+- **Stage 3 — subscriptions and the GET endpoint.** The spec retires the HTTP GET endpoint in favour of `subscriptions/listen`. `transport/http.py` routes GET on `/mcp` (`:756`) and special-cases it (`:600`). This one changes observable client behaviour and deserves its own risk budget.
+
+Do **not** start Stage 2 or 3 until Stage 1 is merged and the gateway has run on it for a normal working day.
+
+## Changes
+
+### `pyproject.toml` (modify)
+- `dependencies` → `mcp` constraint — modify — raise `mcp>=1.0.0,<2.0.0` to `mcp>=2.0.0,<3.0.0`. Keep an upper bound: #111 shipped twice-broken because the bound was absent, and the cap comment there records that the bound is load-bearing. Rewrite that comment to describe the new floor rather than deleting it.
+
+### `src/pmcp/client/manager.py` (modify)
+- import of `streamablehttp_client` (`:22`) — modify — import `streamable_http_client`. Prefer renaming the two call sites (`:1366` is `sse_client`; the streamable call site is around `:1382`) over an `as` alias, so the codebase does not carry a name the library no longer has.
+- `PREFERRED_PROTOCOL_VERSION` (`:187`) — modify — raise to `"2026-07-28"`, keeping `"2025-11-25"`, `"2025-06-18"`, and `"2024-11-05"` in the fallback ladder. This is the single most important line in the plan: it is what lets a 2.x gateway keep talking to 1.x servers.
+- `_is_protocol_version_initialize_error` (`:390`) — modify — also recognise the new `UnsupportedProtocolVersionError` shape. 2.x servers reject with a typed error listing supported versions instead of failing the initialize handshake; without this the ladder will not trigger against a 2.x downstream server.
+
+### `src/pmcp/server.py` (modify)
+- Six handler registrations (`:203`, `:215`, `:369`, `:407`, `:466`, `:495`) — modify — replace each `@self._server.<name>()` decorator with `self._server.add_request_handler(<method-string>, <ParamsType>, <handler>)`. Keep the handler bodies unchanged; only registration moves. The method strings are the wire names (`tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`); resolve each `params_type` from `mcp.types` rather than guessing — `MCPServer`'s own registrations are the reference.
+- `Server(...)` construction (`:174`) — verify, likely unchanged — 2.0's `Server.__init__` still accepts `name` and `instructions`.
+
+### `.github/workflows/test.yml` (modify)
+- `install-smoke` job — modify — no structural change, but confirm it still resolves and imports against the new floor. This job is the regression guard from #111 and **must not be weakened**; if the port makes it fail, the port is wrong, not the job.
+
+### `tests/` (modify)
+- Add a test asserting the gateway registers all six handlers on the lowlevel server after construction (`get_request_handler(<method>) is not None` for each). The 2.x break was a *runtime* `AttributeError` at boot that no unit test caught — the suite passed while the gateway could not start.
+- Add a test asserting `PREFERRED_PROTOCOL_VERSION` is the newest entry in the fallback ladder, so the two cannot drift.
+
+## Documentation impact
+
+- `CHANGELOG.md` — modify — under `## [Unreleased]` / `### Changed`: pmcp now runs on mcp 2.x and negotiates `2026-07-28` with clients, retaining the fallback ladder for older downstream servers. State plainly that `server/discover` and `subscriptions/listen` are **not** yet implemented, so nobody reads "supports 2026-07-28" as full feature parity.
+- `README.md` — modify — if it names a supported protocol version, update it; otherwise none.
+- `plans/detailed-private-manifest-overlay-20260629-0841.md` — none. Unrelated.
+
+## Dependencies & order
+
+1. **`pyproject.toml` cap raise must land first** — nothing else can be tested against 2.x until it does.
+2. **Import rename before handler re-registration** — the module must import before its boot path can be exercised.
+3. **Handler re-registration before any runtime test** — the gateway cannot start without it.
+4. **`PREFERRED_PROTOCOL_VERSION` and `_is_protocol_version_initialize_error` together** — raising the preferred version without teaching the ladder to recognise the new rejection shape will strand downstream 1.x servers. Do not split these across commits.
+5. Blocking external dependency: none. mcp 2.0.0 is published.
+
+## Verification
+
+```bash
+# Gates
+uv sync --all-extras
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/pmcp/server.py src/pmcp/client/manager.py
+uv run pytest tests/ -q                      # expect 2276+ passed
+
+# The regression guard from #111 — must stay green
+uv build --wheel --out-dir dist
+uv venv /tmp/fresh && VIRTUAL_ENV=/tmp/fresh uv pip install dist/*.whl
+VIRTUAL_ENV=/tmp/fresh uv pip list | grep '^mcp '     # expect 2.x
+/tmp/fresh/bin/pmcp --version
+/tmp/fresh/bin/python -c "import pmcp.client.manager, pmcp.server, pmcp.config.loader"
+```
+
+The unit suite is **not sufficient** — it passed while the gateway could not boot. Two runtime checks are mandatory:
+
+```bash
+# 1. The gateway actually starts (this is what caught the decorator break)
+/tmp/fresh/bin/pmcp --transport http --host 127.0.0.1 --port 3355 -l info &
+sleep 15 && ss -ltn | grep 3355        # must be LISTENING, log must show no "Fatal error"
+
+# 2. Downstream bridging: a 1.x server still connects through a 2.x gateway
+#    firecrawl and playwright are the two currently online.
+python3 <mcp-client> gateway.connect_server '{"server_name":"firecrawl"}'
+python3 <mcp-client> gateway.invoke '{"tool_id":"firecrawl::firecrawl_scrape", ...}'
+```
+
+Edge cases to exercise: a downstream server that rejects `2026-07-28` (must fall back, not fail); a stdio server and a streamable-HTTP server (different client paths — `sse_client` vs `streamable_http_client`); and `gateway.health` reporting `protocol_version` per server, which should show a mix of `2026-07-28` and older after the port.
+
+## Acceptance criteria
+
+- [ ] A wheel built from this branch installs into a clean environment, resolves `mcp` 2.x, and `pmcp --version` succeeds — proven by the install-smoke block above
+- [ ] The gateway starts on HTTP and listens, with no `Fatal error` in the log — proven by runtime check 1
+- [ ] All six request handlers are registered on the lowlevel server after construction — proven by the new unit test
+- [ ] A downstream server still on mcp 1.x connects and serves a tool call through the 2.x gateway — proven by runtime check 2 against `firecrawl`
+- [ ] Full suite green and the #111 install-smoke job passes unmodified — proven by `uv run pytest tests/ -q` and CI
+
+## Out of scope (deliberate)
+
+- `server/discover` — Stage 2.
+- `subscriptions/listen` and retiring the HTTP GET endpoint — Stage 3.
+- **`pangram-mcp` ships separately.** Its port is genuinely small (`FastMCP` → `MCPServer`, `ToolAnnotations` still in `mcp.types`, `.tool()` still accepts `annotations`), but it is a different repo with its own release cadence, and coupling a three-line change to a gateway rewrite would gate the easy fix behind the hard one. Do it as its own PR once mcp 2.x is proven here.
+
+## Execution Policy
+
+- execute: effort=high, reason=protocol dispatch rewrite in a service 108 downstream servers depend on; the failure mode is a gateway that imports cleanly and then cannot boot

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -869,6 +869,31 @@
       "task_summary": "Let a private overlay point a shipped manifest server at a non-default endpoint without redeclaring the whole entry (part 2 of #105).",
       "type": "detailed",
       "updated_at": "2026-08-01T15:30:00Z"
+    },
+    {
+      "acceptance_criteria_count": 5,
+      "created_at": "2026-08-05T17:40:00Z",
+      "file": "plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md",
+      "handoff_ref": null,
+      "lifecycle": [
+        {
+          "at": "2026-08-05T17:40:00Z",
+          "by": "claude-plan-detailed",
+          "metadata": {
+            "branch": "main",
+            "follows": "Consiliency/pmcp#111",
+            "spec": "2026-07-28",
+            "stage": "1 of 3"
+          },
+          "transition": "committed"
+        }
+      ],
+      "owner_skill": "claude-plan-detailed",
+      "slug": "mcp-2x-spec-2026-07-28-stage1",
+      "status": "committed",
+      "task_summary": "Port pmcp onto mcp 2.x (spec 2026-07-28), stage 1: runtime parity \u2014 raise the cap, re-register the six lowlevel handlers, extend the downstream version ladder. server/discover and subscriptions are stages 2-3.",
+      "type": "detailed",
+      "updated_at": "2026-08-05T17:40:00Z"
     }
   ],
   "schema_version": 1


### PR DESCRIPTION
Planning artifact only — no code changes. Adds `plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md` and its manifest entry.

## Why this exists

**mcp 2.0 is the only implementation of the current stable MCP spec (`2026-07-28`).** So the `mcp<2.0.0` cap from #111 — correct triage for a dead-on-arrival install — is now what pins pmcp to the previous protocol revision.

| | LATEST_PROTOCOL_VERSION | subscriptions |
|---|---|---|
| mcp 1.29.0 (current pin) | `2025-11-25` | ✗ |
| mcp 2.0.0 | **`2026-07-28`** | ✓ |

## Split into three stages

A full move has five distinct concerns, well past the bounded-plan threshold. Bundling them entangles the failure modes, and two of them change *observable client behaviour* while the rest are internal.

- **Stage 1 (this plan)** — runtime parity. Raise the cap, re-register handlers, extend the downstream version ladder. The gateway runs on mcp 2.x and behaves exactly as today.
- **Stage 2** — `server/discover` (new mandatory RPC). Additive.
- **Stage 3** — `subscriptions/listen` replacing the retired HTTP GET endpoint. Changes what clients see.

Stage 2/3 don't begin until Stage 1 has run for a normal working day.

## What the research turned up

Everything was verified by installing the libraries and running the code:

- **The import surface is nearly intact** — 6 of 7 `mcp` imports survive; only `streamablehttp_client` → `streamable_http_client`.
- **The real break is invisible to imports.** With that aliased, every module imports and the gateway then dies at boot: `'Server' object has no attribute 'list_tools'`. All six registrations are in one file.
- **`MCPServer` is a trap.** It has matching method names, so it looks like the migration target — but `StreamableHTTPSessionManager` takes the *lowlevel* `Server`, and `MCPServer.run()` owns its own transport, which would displace pmcp's Starlette app, `/health`, `/metrics`, and auth middleware. Stay lowlevel.
- **The hard part is already half-built.** `client/manager.py` already negotiates downstream with a fallback ladder (`PREFERRED_PROTOCOL_VERSION` `:187`, accepted list around `:190`, `_is_protocol_version_initialize_error` `:390`, retry at `2024-11-05` around `:1876`). Bridging 108 mostly-1.x servers is an extension of that, not a new subsystem.

## The verification lesson from #111, applied

The plan states explicitly that **the unit suite is not sufficient** — 2276 tests passed while the gateway could not boot. Stage 1's acceptance requires two runtime checks: the gateway actually listens, and a downstream 1.x server still serves a tool call through the 2.x gateway.

The `install-smoke` job from #111 must pass **unmodified**; if the port breaks it, the port is wrong, not the job.

## pangram-mcp ships separately

Its port is genuinely ~3 lines (`FastMCP` → `MCPServer`; `ToolAnnotations` still in `mcp.types`; `.tool()` still takes `annotations`). Deliberately not coupled — gating a three-line fix behind a gateway rewrite helps nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->