### PR TITLE
chore(roadmap): v11 — MCP spec 2026-07-28 / mcp 2.x fleet migration

### DIFF
--- a/plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md
+++ b/plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md
@@ -1,0 +1,116 @@
+# Detailed plan: port pmcp onto mcp 2.x (spec 2026-07-28) — Stage 1, runtime parity
+
+> **Plan Mode was NOT active when this was produced.** Planning artifact only — no implementation has begun.
+
+## Task
+
+Raise pmcp's `mcp<2.0.0` cap and get the gateway running on **mcp 2.x**, which is the only implementation of the current stable MCP spec (`2026-07-28`). mcp 1.29.0 tops out at `2025-11-25` and has no subscriptions support, so the cap added in #111 — correct as triage for a dead-on-arrival install — is now what pins pmcp to the previous protocol revision.
+
+**Stage 1 scope: run correctly on the mcp 2.x library while continuing to serve today's semantics.** New-spec *features* (`server/discover`, `subscriptions/listen`, retiring the HTTP GET endpoint) are explicitly out of scope — see "Why this is staged".
+
+## Research summary
+
+All facts below were verified in-session by installing the libraries and running the code, not by reading changelogs.
+
+- **mcp 2.0.0 is the 2026-07-28 implementation.** `LATEST_PROTOCOL_VERSION = 2026-07-28`; 1.29.0 reports `2025-11-25`. 2.0 adds `PROTOCOL_VERSION_META_KEY`, `UNSUPPORTED_PROTOCOL_VERSION`, and `UnsupportedProtocolVersionErrorData` — the primitives for per-request negotiation.
+- **The import surface is nearly intact.** Of pmcp's seven `mcp` imports, only `mcp.client.streamable_http.streamablehttp_client` is gone (renamed `streamable_http_client`). `sse_client`, `Server`, `StreamableHTTPSessionManager`, `SessionMessage`, and `Tool` all survive.
+- **The real break is the lowlevel `Server` decorators.** With the import aliased, every pmcp startup module imports, then the gateway dies at boot: `'Server' object has no attribute 'list_tools'`. All six registrations live in `src/pmcp/server.py` (`list_tools:203`, `call_tool:215`, `list_resources:369`, `read_resource:407`, `list_prompts:466`, `get_prompt:495`). The replacement is `Server.add_request_handler(method: str, params_type, handler)`; `mcp.server.mcpserver.MCPServer` uses exactly that internally, which is the migration recipe.
+- **`MCPServer` is the wrong target despite matching method names.** `StreamableHTTPSessionManager.__init__` takes `app: Server[Any]` — the lowlevel server — and `MCPServer.run(transport=...)` owns its own transport, which would displace pmcp's Starlette app in `src/pmcp/transport/http.py` (its own `/health`, `/metrics`, auth middleware, uvicorn wiring). Stay on lowlevel `Server`.
+- **Downstream bridging already exists and is the thing to extend, not invent.** `src/pmcp/client/manager.py` already negotiates and falls back: `PREFERRED_PROTOCOL_VERSION = "2025-11-25"` (`:187`), an accepted-version list including `"2025-06-18"` (around `:190`), `_is_protocol_version_initialize_error` (`:390`), and a retry at `"2024-11-05"` (around `:1876`). The gateway proxies 108 servers, nearly all on mcp 1.x, so this ladder is load-bearing.
+
+## Why this is staged
+
+The skill's bounded-plan threshold is ~8 files / ~3 distinct concerns. A full move to 2026-07-28 has at least five: (a) library port, (b) handler re-registration, (c) downstream version bridging, (d) `server/discover`, (e) `subscriptions/listen` replacing the HTTP GET endpoint. Bundling them would produce one oversized plan whose failure modes are entangled — and (d) and (e) are *protocol surface changes* that alter what clients see, whereas (a)–(c) are internal.
+
+Stage 1 is (a)–(c): pmcp runs on mcp 2.x, behaves identically to today, and every downstream server keeps working. Stages 2 and 3 get their own bounded plans:
+
+- **Stage 2 — `server/discover`.** New mandatory RPC. Additive; needs its own handler and capability reporting.
+- **Stage 3 — subscriptions and the GET endpoint.** The spec retires the HTTP GET endpoint in favour of `subscriptions/listen`. `transport/http.py` routes GET on `/mcp` (`:756`) and special-cases it (`:600`). This one changes observable client behaviour and deserves its own risk budget.
+
+Do **not** start Stage 2 or 3 until Stage 1 is merged and the gateway has run on it for a normal working day.
+
+## Changes
+
+### `pyproject.toml` (modify)
+- `dependencies` → `mcp` constraint — modify — raise `mcp>=1.0.0,<2.0.0` to `mcp>=2.0.0,<3.0.0`. Keep an upper bound: #111 shipped twice-broken because the bound was absent, and the cap comment there records that the bound is load-bearing. Rewrite that comment to describe the new floor rather than deleting it.
+
+### `src/pmcp/client/manager.py` (modify)
+- import of `streamablehttp_client` (`:22`) — modify — import `streamable_http_client`. Prefer renaming the two call sites (`:1366` is `sse_client`; the streamable call site is around `:1382`) over an `as` alias, so the codebase does not carry a name the library no longer has.
+- `PREFERRED_PROTOCOL_VERSION` (`:187`) — modify — raise to `"2026-07-28"`, keeping `"2025-11-25"`, `"2025-06-18"`, and `"2024-11-05"` in the fallback ladder. This is the single most important line in the plan: it is what lets a 2.x gateway keep talking to 1.x servers.
+- `_is_protocol_version_initialize_error` (`:390`) — modify — also recognise the new `UnsupportedProtocolVersionError` shape. 2.x servers reject with a typed error listing supported versions instead of failing the initialize handshake; without this the ladder will not trigger against a 2.x downstream server.
+
+### `src/pmcp/server.py` (modify)
+- Six handler registrations (`:203`, `:215`, `:369`, `:407`, `:466`, `:495`) — modify — replace each `@self._server.<name>()` decorator with `self._server.add_request_handler(<method-string>, <ParamsType>, <handler>)`. Keep the handler bodies unchanged; only registration moves. The method strings are the wire names (`tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`); resolve each `params_type` from `mcp.types` rather than guessing — `MCPServer`'s own registrations are the reference.
+- `Server(...)` construction (`:174`) — verify, likely unchanged — 2.0's `Server.__init__` still accepts `name` and `instructions`.
+
+### `.github/workflows/test.yml` (modify)
+- `install-smoke` job — modify — no structural change, but confirm it still resolves and imports against the new floor. This job is the regression guard from #111 and **must not be weakened**; if the port makes it fail, the port is wrong, not the job.
+
+### `tests/` (modify)
+- Add a test asserting the gateway registers all six handlers on the lowlevel server after construction (`get_request_handler(<method>) is not None` for each). The 2.x break was a *runtime* `AttributeError` at boot that no unit test caught — the suite passed while the gateway could not start.
+- Add a test asserting `PREFERRED_PROTOCOL_VERSION` is the newest entry in the fallback ladder, so the two cannot drift.
+
+## Documentation impact
+
+- `CHANGELOG.md` — modify — under `## [Unreleased]` / `### Changed`: pmcp now runs on mcp 2.x and negotiates `2026-07-28` with clients, retaining the fallback ladder for older downstream servers. State plainly that `server/discover` and `subscriptions/listen` are **not** yet implemented, so nobody reads "supports 2026-07-28" as full feature parity.
+- `README.md` — modify — if it names a supported protocol version, update it; otherwise none.
+- `plans/detailed-private-manifest-overlay-20260629-0841.md` — none. Unrelated.
+
+## Dependencies & order
+
+1. **`pyproject.toml` cap raise must land first** — nothing else can be tested against 2.x until it does.
+2. **Import rename before handler re-registration** — the module must import before its boot path can be exercised.
+3. **Handler re-registration before any runtime test** — the gateway cannot start without it.
+4. **`PREFERRED_PROTOCOL_VERSION` and `_is_protocol_version_initialize_error` together** — raising the preferred version without teaching the ladder to recognise the new rejection shape will strand downstream 1.x servers. Do not split these across commits.
+5. Blocking external dependency: none. mcp 2.0.0 is published.
+
+## Verification
+
+```bash
+# Gates
+uv sync --all-extras
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/pmcp/server.py src/pmcp/client/manager.py
+uv run pytest tests/ -q                      # expect 2276+ passed
+
+# The regression guard from #111 — must stay green
+uv build --wheel --out-dir dist
+uv venv /tmp/fresh && VIRTUAL_ENV=/tmp/fresh uv pip install dist/*.whl
+VIRTUAL_ENV=/tmp/fresh uv pip list | grep '^mcp '     # expect 2.x
+/tmp/fresh/bin/pmcp --version
+/tmp/fresh/bin/python -c "import pmcp.client.manager, pmcp.server, pmcp.config.loader"
+```
+
+The unit suite is **not sufficient** — it passed while the gateway could not boot. Two runtime checks are mandatory:
+
+```bash
+# 1. The gateway actually starts (this is what caught the decorator break)
+/tmp/fresh/bin/pmcp --transport http --host 127.0.0.1 --port 3355 -l info &
+sleep 15 && ss -ltn | grep 3355        # must be LISTENING, log must show no "Fatal error"
+
+# 2. Downstream bridging: a 1.x server still connects through a 2.x gateway
+#    firecrawl and playwright are the two currently online.
+python3 <mcp-client> gateway.connect_server '{"server_name":"firecrawl"}'
+python3 <mcp-client> gateway.invoke '{"tool_id":"firecrawl::firecrawl_scrape", ...}'
+```
+
+Edge cases to exercise: a downstream server that rejects `2026-07-28` (must fall back, not fail); a stdio server and a streamable-HTTP server (different client paths — `sse_client` vs `streamable_http_client`); and `gateway.health` reporting `protocol_version` per server, which should show a mix of `2026-07-28` and older after the port.
+
+## Acceptance criteria
+
+- [ ] A wheel built from this branch installs into a clean environment, resolves `mcp` 2.x, and `pmcp --version` succeeds — proven by the install-smoke block above
+- [ ] The gateway starts on HTTP and listens, with no `Fatal error` in the log — proven by runtime check 1
+- [ ] All six request handlers are registered on the lowlevel server after construction — proven by the new unit test
+- [ ] A downstream server still on mcp 1.x connects and serves a tool call through the 2.x gateway — proven by runtime check 2 against `firecrawl`
+- [ ] Full suite green and the #111 install-smoke job passes unmodified — proven by `uv run pytest tests/ -q` and CI
+
+## Out of scope (deliberate)
+
+- `server/discover` — Stage 2.
+- `subscriptions/listen` and retiring the HTTP GET endpoint — Stage 3.
+- **`pangram-mcp` ships separately.** Its port is genuinely small (`FastMCP` → `MCPServer`, `ToolAnnotations` still in `mcp.types`, `.tool()` still accepts `annotations`), but it is a different repo with its own release cadence, and coupling a three-line change to a gateway rewrite would gate the easy fix behind the hard one. Do it as its own PR once mcp 2.x is proven here.
+
+## Execution Policy
+
+- execute: effort=high, reason=protocol dispatch rewrite in a service 108 downstream servers depend on; the failure mode is a gateway that imports cleanly and then cannot boot

--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -869,6 +869,31 @@
       "task_summary": "Let a private overlay point a shipped manifest server at a non-default endpoint without redeclaring the whole entry (part 2 of #105).",
       "type": "detailed",
       "updated_at": "2026-08-01T15:30:00Z"
+    },
+    {
+      "acceptance_criteria_count": 5,
+      "created_at": "2026-08-05T17:40:00Z",
+      "file": "plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md",
+      "handoff_ref": null,
+      "lifecycle": [
+        {
+          "at": "2026-08-05T17:40:00Z",
+          "by": "claude-plan-detailed",
+          "metadata": {
+            "branch": "main",
+            "follows": "Consiliency/pmcp#111",
+            "spec": "2026-07-28",
+            "stage": "1 of 3"
+          },
+          "transition": "committed"
+        }
+      ],
+      "owner_skill": "claude-plan-detailed",
+      "slug": "mcp-2x-spec-2026-07-28-stage1",
+      "status": "committed",
+      "task_summary": "Port pmcp onto mcp 2.x (spec 2026-07-28), stage 1: runtime parity \u2014 raise the cap, re-register the six lowlevel handlers, extend the downstream version ladder. server/discover and subscriptions are stages 2-3.",
+      "type": "detailed",
+      "updated_at": "2026-08-05T17:40:00Z"
     }
   ],
   "schema_version": 1

--- a/specs/phase-plans-v10.md
+++ b/specs/phase-plans-v10.md
@@ -1,5 +1,38 @@
 # PMCP — Phase Plan v10 (Code-Review Remediation)
 
+> **STATUS: CLOSED — 2026-08-05. Do not plan or execute phases from this roadmap.**
+> The remediation shipped across the 1.19.x–1.20.0 line, but **not through this
+> pipeline**: no `plans/phase-plan-v10-*.md` lane plans were ever produced and no
+> `plans/manifest.json` entries exist for it. The work landed as ordinary PRs, so
+> the unchecked boxes below are stale paperwork, not outstanding work.
+>
+> Verified present in the tree on 2026-08-05 (file:line evidence, not release notes):
+>
+> | Phase | Evidence |
+> |---|---|
+> | P1 — Reconnect & failure-path recovery | `src/pmcp/client/manager.py:611,1974` current-task-safe cancellation; CHANGELOG 1.19.0 "Downstream servers now actually recover from failure" |
+> | P2 — Auth / Origin wiring | `src/pmcp/server.py:88-109` `auth_mode` / `allowed_origins` threaded through; CHANGELOG 1.19.0 |
+> | P3 — Agent-reachable code-exec validation | `src/pmcp/validation.py:17,30` `_PACKAGE_NAME_RE` |
+> | P4 — Local credential hardening | `src/pmcp/cli.py:633,637` `--stdin` + argv warning; `src/pmcp/env_store.py:98` `chmod 0o700` |
+> | P5A — Transport DoS hardening | `src/pmcp/transport/http.py:68` `_MAX_BODY_BYTES`; `:191` `_check_rate_limit` |
+> | P5B — SSRF & registry hardening | `src/pmcp/auth.py:246` `allow_redirects=False`; `src/pmcp/manifest/registry.py:675` atomic `os.replace` |
+> | P6 — Robustness & quality sweep | **PARTIAL** — overlay shadow warning, symlink containment, version-check URL quoting (`version_checker.py:52,94`), malformed-config surfacing (`config/loader.py:316-330`), and **task-registry eviction** all landed. One item did not; see below. |
+>
+> **One P6 item was not completed and is carried into
+> `specs/phase-plans-v11.md` Phase 6 (P6CLEAN)** — it is not dropped:
+>
+> 1. `tests/test_manifest.py:1775` still uses `asyncio.sleep(0.3)` instead of polling
+>    job state — the wall-clock race P6 intended to remove.
+>
+> **Correction (2026-08-05, from pre-execution review).** An earlier draft of this
+> header claimed `_tasks` registry eviction was missing. That was wrong: it searched
+> `src/pmcp/tools/handlers.py` because that is where v10's P6 text pointed, but the
+> registry lives in `src/pmcp/client/manager.py`. It is **done** — `_tasks` with
+> `_max_terminal_tasks = 100` and oldest-first pruning of terminal records
+> (`client/manager.py:507-512`), a done-callback `pop` (`:597`), and a regression
+> test `test_terminal_task_records_are_evicted_past_cap`
+> (`tests/test_client_manager.py:1588`). Do not re-plan it.
+
 > How to use this document: save to `specs/phase-plans-v10.md`, then run `/claude-plan-phase <ALIAS>` to produce the lane-level plan for each phase (→ `plans/phase-plan-v10-<alias>.md`), then `/claude-execute-phase <alias>` to build it.
 
 ---

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -1,0 +1,452 @@
+# PMCP — Phase Plan v11 (MCP spec 2026-07-28 / mcp 2.x fleet migration)
+
+> How to use this document: run `/claude-plan-phase <ALIAS>` to produce the lane-level plan for each phase (→ `plans/phase-plan-v11-<alias>.md`), then `/claude-execute-phase <alias>` to build it.
+
+---
+
+## Context
+
+**MCP spec `2026-07-28` is the current stable revision, and `mcp` 2.x is its only implementation.** `mcp` 1.29.0 tops out at `2025-11-25` with no subscriptions support. So the `mcp<2.0.0` caps in `pmcp` (from #111) and `pangram-mcp` — each correct as triage for a package that could not start on a fresh install — are now precisely what pin the fleet to the previous protocol revision.
+
+The migration is smaller than it first appears, and the hard part is already half-built. Six of pmcp's seven `mcp` imports survive 2.0 untouched, but the seventh is **not merely a rename**: `streamable_http_client` also dropped `headers`, `timeout`, `sse_read_timeout`, and `httpx_client_factory` in favour of a caller-built `http_client` — and it is an `httpx2` client, a different httpx major. `sse_client` is unchanged. The genuine break is invisible to imports: with that aliased, every module loads and the gateway then **dies at boot** with `'Server' object has no attribute 'list_tools'` — lowlevel `Server` dropped its decorators in favour of `add_request_handler(method, params_type, handler)`. All six registration sites live in one file. Meanwhile `client/manager.py` already carries a downstream version-negotiation ladder (`PREFERRED_PROTOCOL_VERSION`, an accepted-version list, an initialize-error detector, and a `2024-11-05` retry), so bridging 108 mostly-1.x downstream servers is an **extension of existing machinery, not a new subsystem**.
+
+Two traps are recorded here because both look like the obvious path. `MCPServer` (the FastMCP successor) exposes exactly the six method names pmcp registers — but `StreamableHTTPSessionManager` takes the *lowlevel* `Server`, and `MCPServer.run(transport=...)` owns its own transport, which would displace pmcp's Starlette app, `/health`, `/metrics`, and auth middleware. Stay lowlevel. And the unit suite is **not** valid acceptance: 2276 tests passed while the gateway could not boot.
+
+Sequencing is constrained by a live hazard. Dependabot PR **#112** already proposes raising the cap to `mcp<3.0.0`. Seven checks pass on it — three test-matrix jobs, lint, typecheck, build, notify — and **only `install-smoke` fails**, the guard added in #111 catching an unported cap raise in the wild. That PR must not merge before the port lands, and it is the reason P1 (guard hardening) precedes P2 (the port): the guards are what make the port safe to attempt.
+
+---
+
+## Architecture North Star
+
+```
+                    clients (Claude Code, Codex, …)
+                              │
+                    MODERN ERA │ 2026-07-28 only
+                    per-request _meta protocolVersion
+                    + server/discover  (NOT initialize)
+                              ▼
+        ┌─────────────────────────────────────────────┐
+        │  pmcp gateway  (mcp 2.x)                    │
+        │                                             │
+        │   server.py      6 handlers via             │
+        │                  add_request_handler(...)   │
+        │                  + ADAPTERS: 2.x calls      │
+        │                  handler(ctx, typed_params) │
+        │                  and validates typed results│
+        │   transport/     own Starlette app:         │
+        │     http.py      /mcp /health /metrics      │
+        │                  (delegates to              │
+        │                   handle_modern_request)    │
+        │                                             │
+        │   client/        HANDSHAKE ladder — ceiling │
+        │     manager.py   stays 2025-11-25:          │
+        │                  2025-11-25 → 2025-06-18    │
+        │                   → 2025-03-26 → 2024-11-05 │
+        └─────────────────────────────────────────────┘
+                              │
+                  HANDSHAKE ERA │ initialize
+             ┌────────────────┼────────────────┐
+             ▼                ▼                ▼
+      firecrawl (1.x)   playwright (1.x)   pangram-mcp
+       spec 2025-11-25   spec 2025-11-25    (→ 2.x in PG)
+
+  TWO ERAS, NOT ONE LADDER. `mcp_types.version` separates
+  HANDSHAKE_PROTOCOL_VERSIONS (2024-11-05 … 2025-11-25, reached via
+  `initialize`) from MODERN_PROTOCOL_VERSIONS (2026-07-28 only, reached via
+  per-request `_meta` + `server/discover`). 2026-07-28 CANNOT be requested
+  through `initialize`. The gateway serves the modern era upward and speaks
+  the handshake era downward — never raise the downstream ladder to 2026-07-28.
+```
+
+---
+
+## Assumptions (fail-loud if wrong)
+
+1. ~~`mcp` 2.x retains backward compatibility with handshake-based revisions on the client side.~~ **VERIFIED 2026-08-05, no longer an assumption.** A `mcp` 2.0.0 client initialized against a `mcp` 1.29.0 stdio server, negotiated `2025-11-25`, listed tools, and completed a `tools/call`. The downstream handshake path works unchanged from a 2.x gateway.
+1a. **The protocol has two eras and they are not interchangeable.** `mcp_types.version` defines `HANDSHAKE_PROTOCOL_VERSIONS = (2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25)` and `MODERN_PROTOCOL_VERSIONS = (2026-07-28,)`. `2026-07-28` is unreachable via `initialize`. Any plan that treats the version list as one ladder is wrong.
+2. ~~The six handler bodies are unaffected — only how they are attached moves.~~ **FALSE, corrected 2026-08-05 at review.** 2.x invokes `handler(ctx, typed_params)` and validates a typed result (`RequestHandler = Callable[[ServerRequestContext, _ParamsT], Awaitable[BaseModel | dict | None]]`), while today's bodies take zero or domain arguments and return bare lists. The removed decorators supplied argument adaptation, result wrapping, and tool-input-schema validation. P2 must write explicit adapters restoring all three; treating this as registration-only would raise `TypeError`, emit invalid results, or silently drop input validation.
+3. `StreamableHTTPSessionManager` in 2.x still accepts the lowlevel `Server` as `app`, so pmcp keeps owning its Starlette app and auth middleware.
+4. `release.yml` + PyPI trusted publishing keep working for both repos, and the `phase-loop` validator runtime stays installed.
+5. Downstream third-party servers are not required to move; the gateway absorbs the version difference. No downstream server is dropped by this roadmap.
+6. `pangram-mcp` can move to 2.x independently of the gateway, because a 2.x server still accepts an older client. **PG's exit criteria test this explicitly rather than assuming it** — if it fails, PG gains a dependency on P2.
+
+---
+
+## Non-Goals
+
+- Porting any third-party downstream server. The gateway bridges; they stay as they are.
+- Implementing MCP subscriptions *end-to-end through the gateway* (proxying downstream `notifications/*` up to clients). P3B lands the client-facing surface only; gateway-level fan-out of downstream notifications is a future roadmap.
+- Removing the version-fallback ladder. It stays for the foreseeable future — it is the compatibility contract with 108 servers.
+- Any change to the `gateway.*` tool schemas. Client-visible tool contracts are unchanged by this roadmap.
+- Re-litigating the `mcp<2` caps as a strategy. They were correct; this roadmap is how they get raised safely.
+
+---
+
+## Cross-Cutting Principles
+
+1. **The unit suite is never sufficient acceptance for a gateway phase.** Every phase touching `pmcp` must prove (a) the process starts and listens, and (b) a real downstream server serves a real tool call through it. 2276 green tests coexisted with a gateway that could not boot.
+2. **Never weaken a release guard to make a phase pass.** If `install-smoke` or `min-version-smoke` fails, the change is wrong, not the job.
+3. **Every phase leaves `127.0.0.1:3344` working.** The gateway is the operator's daily driver. Phases are independently revertable; no phase may depend on a later phase to restore service.
+4. **Dependency bounds stay two-sided.** Raising a floor or ceiling always leaves both ends declared and both ends tested — #111 shipped broken twice from a missing upper bound, and 0.1.2 shipped with a wrong lower bound.
+5. **Version floors and ceilings are set by installing, not by reading source.** A review leg derived a floor from when a symbol first appeared; installation proved that version still failed for a different reason.
+6. **Protocol vocabulary is frozen to what the spec defines.** No phase invents a method name, `_meta` key, or error shape not in `2026-07-28`.
+
+---
+
+## Top Interface-Freeze Gates
+
+- **IF-0-P1-1** — The four-guard CI contract for first-party Python packages: `install-smoke` (fresh resolve, no lockfile, import the **entry-point** module), `min-version-smoke` (install pinned at the declared floor), a `schedule:` trigger, and a `__version__`-vs-distribution-metadata drift test. P2 and PG both rely on these guards to detect a bad constraint.
+- **IF-0-P2-1** — `pmcp` runs on `mcp>=2.0.0,<3.0.0`, serves the MODERN era (`2026-07-28`) to clients via per-request `_meta` + `server/discover`, and speaks the HANDSHAKE era (ceiling `2025-11-25`) downstream. This is the protocol surface P3B extends.
+- **IF-0-P2-2** — Handler registration shape: `self._server.add_request_handler(<method-string>, <ParamsType>, <handler>)` on the lowlevel `Server`. P3B registers `subscriptions/listen` through this same call. (`server/discover` needs no registration — the 2.x lowlevel `Server` auto-registers it.)
+- **IF-0-PG-1** — `pangram-mcp` on `mcp` 2.x, reachable from both a 1.x and a 2.x gateway, published to PyPI.
+- **IF-0-P5-1** — A manifest field expressing "credential optional under condition X", replacing the placeholder-secret workaround.
+
+---
+
+## Phases
+
+### Phase 1 — Release-guard hardening (P1)
+
+**Objective**
+Level `pmcp`'s CI up to the four guards already proven in `pangram-mcp`, so the cap raise in P2 cannot ship a package that installs but cannot run.
+
+**Exit criteria**
+- [ ] EC-P1-1 — A `min-version-smoke` job parses the declared `mcp` floor out of `pyproject.toml`, installs the built wheel pinned at exactly that version, and imports the gateway's startup modules; it fails if the floor is unsatisfiable or non-functional.
+- [ ] EC-P1-2 — `.github/workflows/test.yml` gains a `schedule:` trigger and `workflow_dispatch`; a manually dispatched run passes on unchanged `main`.
+- [ ] EC-P1-3 — A test asserts `pmcp.__version__ == importlib.metadata.version("pmcp")`, failing if either drifts.
+- [ ] EC-P1-4 — The existing `install-smoke` job is unmodified and still passes, and PR #112 still fails only that job (the guard's behaviour is unchanged by this phase).
+- [ ] EC-P1-5 — Full suite, ruff, and mypy green; CHANGELOG entry under `### Changed`.
+
+**Scope notes**
+- Decompose into 2 lanes with disjoint files. `.github/workflows/test.yml` is a **single-writer file** — one lane owns it entirely; splitting the two job additions across lanes would serialize on conflicts.
+- Lane A owns `.github/workflows/test.yml`: adds `min-version-smoke` (floor parser + pinned install) and the `schedule`/`workflow_dispatch` triggers. Pass the parsed floor through `env:`, never inlined into `run:`.
+- Lane B owns `tests/`: the `__version__` drift test. Independent of Lane A and can start immediately.
+- Port the jobs from `pangram-mcp`'s `.github/workflows/test.yml`, which already runs all four guards — do not re-derive them.
+
+**Non-goals**
+- Changing any dependency bound. This phase only adds detection; P2 does the raising.
+
+**Key files**
+- .github/workflows/test.yml
+- tests/
+- CHANGELOG.md
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-P1-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `.github/workflows/test.yml`, `tests/`
+- evidence paths: `plans/phase-plan-v11-p1.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 2 — Gateway runtime parity on mcp 2.x (P2)
+
+**Objective**
+Raise `pmcp` onto `mcp` 2.x so it runs correctly on the new library and negotiates `2026-07-28` with clients, while continuing to serve every downstream server exactly as today. Behaviour-preserving: no new client-visible protocol features.
+
+**Exit criteria**
+- [ ] EC-P2-1 — A wheel built from this phase installs into a clean environment with no lockfile, resolves `mcp` 2.x, and `pmcp --version` succeeds — `install-smoke` and `min-version-smoke` both green.
+- [ ] EC-P2-2 — The gateway starts on HTTP and listens on its configured port with no `Fatal error` in the log (this is the check that catches the `'Server' object has no attribute 'list_tools'` class of break, which the unit suite cannot).
+- [ ] EC-P2-3 — Each of the six handlers is exercised **at the wire level** — a real request in, a validated typed result out — for `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`. Registry-presence assertions are explicitly **not** sufficient. `tools/call` is additionally tested with **invalid** arguments and must return a schema-validation error, proving the validation the removed decorators used to supply is still in place.
+- [ ] EC-P2-4 — A downstream server still on `mcp` 1.x connects through the 2.x gateway over the **handshake** path and serves a real tool call; the negotiated version for that server is a `HANDSHAKE_PROTOCOL_VERSIONS` member (≤ `2025-11-25`), not `2026-07-28`.
+- [ ] EC-P2-5 — A **modern-era** request carrying `io.modelcontextprotocol/protocolVersion: 2026-07-28` in `_meta` is accepted and answered, and the SDK's default `server/discover` returns correct `supported_versions` and `capabilities`. Validating the SDK default is sufficient — `DiscoverResult` carries only `supported_versions`, `capabilities`, and `instructions`, so there is no aggregated inventory to add.
+- [ ] EC-P2-6 — **The six proxied handlers work under a modern envelope, exercised over the deployed HTTP wire** — POSTed to the running gateway's `/mcp` on a spare port, not via stdio or direct dispatch: a modern `tools/list` returns the aggregated catalog, a modern `tools/call` succeeds, and a modern `tools/call` with invalid arguments returns a schema-validation error. The envelope must be complete (`_meta` carrying both `protocolVersion` and `clientCapabilities`) with matching HTTP routing headers, since the session manager selects the modern handler from the protocol-version header. A stdio-only or direct-dispatch test can pass while `/mcp` is broken.
+- [ ] EC-P2-7 — **An authenticated remote downstream over Streamable HTTP still connects and serves a tool call**, proving the rebuilt `http_client` carries headers. Additionally: a **redirected** downstream still resolves (proving `follow_redirects=True`), and repeated disconnect/reconnect cycles leak no httpx2 clients (proving exit-stack ownership). stdio-only verification does not satisfy this.
+- [ ] EC-P2-8 — Full suite green, ruff/mypy clean, CHANGELOG accurate about which eras are served, and PR #112 resolved per the Execution Notes.
+
+**Scope notes**
+- **The two eras are the design.** `mcp_types.version` splits them explicitly: `HANDSHAKE_PROTOCOL_VERSIONS = (2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25)` versus `MODERN_PROTOCOL_VERSIONS = (2026-07-28,)`. `2026-07-28` **cannot be requested through `initialize`** — it is reached via per-request `_meta` plus `server/discover`. Therefore: **do not raise `PREFERRED_PROTOCOL_VERSION` to `2026-07-28`.** That constant governs the downstream *handshake* ladder and its ceiling of `2025-11-25` is correct. Upstream (serving clients) and downstream (calling servers) are different eras and must be kept separate in both code and tests.
+- Verified in-session, so the plan does not rest on it: a `mcp` 2.0.0 client initializes against a `mcp` 1.29.0 server, negotiates `2025-11-25`, lists tools, and completes a `tools/call`. The downstream path works unchanged from a 2.x gateway.
+- Verified in-session: `StreamableHTTPSessionManager` delegates to `handle_modern_request`, so pmcp keeping its own Starlette app does **not** strand it on the old era.
+- Decompose into 4 lanes partitioned by disjoint files. Intra-phase freeze, publish day 1: Lane C raises the cap first so every other lane can develop and test against 2.x immediately.
+- Lane C owns `pyproject.toml` + `CHANGELOG.md`: raise to `mcp>=2.0.0,<3.0.0`, keeping a two-sided bound and rewriting (not deleting) the load-bearing-bound comment.
+- Lane A owns `src/pmcp/server.py`: convert the six decorator registrations to `add_request_handler`. **Handler bodies cannot be attached unchanged** — 2.x invokes `handler(ctx, typed_params)` and validates a typed result (`RequestHandler = Callable[[ServerRequestContext, _ParamsT], Awaitable[BaseModel | dict | None]]`), while today's bodies take zero or domain arguments and return bare lists. The removed decorators supplied argument adaptation, result wrapping, and tool-input-schema validation; this lane must write explicit adapters that restore all three. Note `Server.__init__` also accepts `on_list_tools` / `on_call_tool` callbacks — evaluate them against `add_request_handler` before choosing.
+- Lane B owns `src/pmcp/client/manager.py`: **this is not a rename.** 1.29's `streamablehttp_client(url, headers=..., timeout=..., sse_read_timeout=..., httpx_client_factory=...)` becomes 2.x's `streamable_http_client(url, *, http_client: httpx2.AsyncClient | None, terminate_on_close)`. Every one of those keyword arguments is gone; the caller now builds and owns an `httpx2.AsyncClient` carrying headers and timeouts. pmcp passes `headers=` today (around `:1382`), so the naive rename raises `TypeError` and **breaks every authenticated remote downstream**. Note `httpx2` is a different httpx major. **Two behaviours the old helper provided must be reproduced explicitly:** it followed redirects, and it owned and closed the client it created — 2.x sets `client_provided = http_client is not None` and deliberately does **not** close a caller-supplied client. So the rebuilt client needs `follow_redirects=True` and must be owned through the managed connection's exit stack, or redirected downstreams regress and every reconnect leaks a client. `sse_client` is UNCHANGED — do not touch it. Also audit `_read_*` paths: JSON-RPC error `code`/`data` appear to be discarded (around `:1506`), which would make typed-error handling impossible. Leave the handshake ladder ceiling at `2025-11-25`.
+- Lane B also owns the `httpx` fallout outside the client: `src/pmcp/cli.py` does a bare `import httpx` (around `:1844` and `:1867`) while never declaring `httpx` in `pyproject.toml` — it rides mcp's transitive dependency. mcp 2.x ships `httpx2` instead, so those imports fail after the bump. Either declare `httpx` explicitly or migrate those call sites to `httpx2`; decide which in the phase plan.
+- Lane D owns `tests/` and the runtime acceptance harness for EC-P2-2, EC-P2-4, and EC-P2-5.
+- Do **not** migrate to `MCPServer` (see Context). Test on a spare port; never disturb the live service.
+
+**Non-goals**
+- Subscriptions / GET retirement (P3B). This phase is library parity plus proof that both eras answer.
+
+**Key files**
+- pyproject.toml
+- src/pmcp/server.py
+- src/pmcp/client/manager.py
+- tests/
+- CHANGELOG.md
+
+**Depends on**
+- P1
+
+**Produces**
+- IF-0-P2-1
+- IF-0-P2-2
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `roadmap_amendment`
+- target surfaces: `src/pmcp/server.py`, `src/pmcp/client/manager.py`, `pyproject.toml`
+- evidence paths: `plans/phase-plan-v11-p2.md`, `plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md`
+- redaction posture: `metadata_only`
+- note: if Assumption 1a (the two-era split) proves wrong, this phase must raise a roadmap amendment before P3B is planned.
+
+---
+
+### Phase 3B — Subscriptions and GET retirement (P3B)
+
+**Objective**
+Implement `subscriptions/listen` and retire the HTTP GET endpoint it replaces, which is the one part of this migration that changes observable client behaviour.
+
+**Exit criteria**
+- [ ] EC-P3B-1 — `subscriptions/listen` is registered through the IF-0-P2-2 shape, honours the `notifications` filter, sends `notifications/subscriptions/acknowledged` as the first message carrying `io.modelcontextprotocol/subscriptionId` in `_meta`, and never sends a notification type the client did not request.
+- [ ] EC-P3B-2 — Cancellation works from both sides: a client closing the stream (HTTP) or sending `notifications/cancelled` (stdio) ends the subscription, and a server-initiated close sends the empty `subscriptions/listen` response before closing.
+- [ ] EC-P3B-3 — The HTTP GET path on `/mcp` is retired without breaking `/health` or `/metrics`, and a client using the old GET flow receives a defined error rather than a hang.
+- [ ] EC-P3B-4 — **A real catalog mutation delivers a notification end to end.** Calling `gateway.connect_server` / `disconnect_server` / `refresh` — which mutate the tool, resource, and prompt indexes in `ClientManager` — causes a subscribed client to receive the corresponding `notifications/*/list_changed`. A synthetic test that fires the publisher directly does **not** satisfy this criterion.
+- [ ] EC-P3B-5 — Gateway starts, a downstream tool call still succeeds, and a client with no subscription is unaffected; full suite, ruff, mypy green.
+- [ ] EC-P3B-6 — CHANGELOG documents the GET retirement as a breaking client-visible change, released as a **major version**.
+
+**Scope notes**
+- **A listener with no publishers is the failure mode to design against.** `subscriptions/listen` lives in `src/pmcp/server.py`, but the events that should drive it originate in `src/pmcp/client/manager.py`, where tools/resources/prompts are indexed and removed (around `:1099`). Without an explicit event path from those mutations to the subscription, handler-level tests pass while live `connect_server` / disconnect / refresh deliver nothing. Define the publisher interface **before** the listener.
+- Decompose into 4 lanes. Lane A owns `src/pmcp/transport/http.py` (GET retirement, route table, protocol-version header). Lane B owns `src/pmcp/server.py` (the `subscriptions/listen` handler). Lane C owns `src/pmcp/client/manager.py` (**the production event publishers** — the lane that was missing). Lane D owns `tests/`.
+- Lanes A, B, and C touch different files but share one contract: the subscription id, the event payload shape, and the stream lifecycle. Publish that contract as an intra-phase freeze on day 1 so Lane D can write tests against it immediately.
+- **Release as a major version.** "Explicitly flagged breaking minor" was rejected at review: retiring a documented endpoint is a compatibility break and semver should say so plainly.
+- Highest-risk phase in the roadmap — it is the only one that changes what existing clients see. Ship it alone.
+- Multiple concurrent subscriptions must demultiplex by `subscriptionId`; on stdio all subscriptions share one channel.
+
+**Non-goals**
+- Proxying downstream servers' `notifications/*` up to clients (future roadmap; see Non-Goals).
+
+**Key files**
+- src/pmcp/transport/http.py
+- src/pmcp/server.py
+- src/pmcp/client/manager.py
+- tests/
+- CHANGELOG.md
+
+**Depends on**
+- P2
+
+**Produces**
+- (none)
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `canonical_spec_update`
+- target surfaces: `src/pmcp/transport/http.py`, `src/pmcp/server.py`, `CHANGELOG.md`
+- evidence paths: `plans/phase-plan-v11-p3b.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 4 — pangram-mcp onto mcp 2.x (PG)
+
+**Objective**
+Move the first-party `pangram-mcp` server off the removed `FastMCP` API onto `MCPServer`, raising its `mcp` cap, and prove it is reachable from both a 1.x and a 2.x gateway.
+
+**Exit criteria**
+- [ ] EC-PG-1 — `src/pangram_mcp/server.py` uses `MCPServer` instead of `mcp.server.fastmcp.FastMCP`; the `analyze` tool keeps its `ToolAnnotations` and its input/output contract is byte-identical.
+- [ ] EC-PG-2 — `pyproject.toml` declares a two-sided `mcp` bound whose floor is verified by installing at exactly that floor (not by reading source), and all four guards from IF-0-P1-1 pass.
+- [ ] EC-PG-3 — The **currently published 1.x** `pmcp` gateway connects to the ported server and `pangram::analyze` returns a live classification — this is the test of Assumption 6; if it fails, PG gains a dependency on P2 and the roadmap is amended.
+- [ ] EC-PG-4 — After P2 lands, the 2.x gateway also connects and serves `pangram::analyze`.
+- [ ] EC-PG-5 — Published to PyPI; `uvx pangram-mcp` starts clean from a cold cache.
+
+**Scope notes**
+- Decompose into 2 lanes with disjoint files. Lane A owns `src/pangram_mcp/server.py` (the API port). Lane B owns `pyproject.toml` + `tests/` (bound raise, floor bisection, drift test).
+- Port surface is small: `MCPServer.tool()` still accepts `annotations`, and `ToolAnnotations` still lives in `mcp.types`. Verify both against the installed 2.x library before writing code.
+- Different repository (`Consiliency/pangram-mcp`) with its own release cadence — deliberately not coupled to the gateway port, so a three-line change is not gated behind a gateway rewrite.
+- EC-PG-4 can only be checked after P2; run EC-PG-1..3 and EC-PG-5 first and treat EC-PG-4 as a follow-up verification, not a blocker on publishing.
+
+**Non-goals**
+- Any change to the `analyze` tool's behaviour, schema, or the Pangram API integration.
+
+**Key files**
+- src/pangram_mcp/server.py
+- pyproject.toml
+- tests/test_server.py
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-PG-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pangram_mcp/server.py`, `pyproject.toml`
+- evidence paths: `plans/phase-plan-v11-pg.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 5 — Manifest credential optionality (P5)
+
+**Objective**
+Let a manifest entry express "credential required for the vendor endpoint, optional for a self-hosted one", removing the placeholder-secret workaround that #114 documents.
+
+**Exit criteria**
+- [ ] EC-P5-1 — A manifest entry can declare that its credential is optional under a named condition, and the requirement is evaluated by **one shared predicate** that every enforcement path calls — not re-implemented per call site.
+- [ ] EC-P5-2 — A server whose credential is genuinely required still fails closed at **every** gate; no server becomes reachable without auth that was not already.
+- [ ] EC-P5-3 — With the new field in use, an operator reaches a self-hosted endpoint with **no placeholder credential** anywhere, and it works through **all six consumers**: eager startup, provision/install, lifecycle connect, `pmcp secrets check` diagnostics, and capability discovery (`gateway.catalog_search` / `gateway.request_capability` must not report the server as key-missing or advise `auth_connect`). Passing only the connect path does not satisfy this.
+- [ ] EC-P5-4 — Existing manifest entries are unaffected (the field is optional and defaults to today's behaviour); full suite, ruff, mypy green.
+
+**Scope notes**
+- **`requires_api_key` is enforced in FIVE independent places** — eager startup (`src/pmcp/config/loader.py`, around `:1038`), install (`src/pmcp/manifest/installer.py` `check_api_key`, around `:541`), lifecycle connect (`src/pmcp/tools/handlers.py`, around `:3200`), provisioning (`src/pmcp/tools/handlers.py`, around `:4058`), **diagnostics** (`src/pmcp/cli_commands/secrets.py`, around `:93` — `pmcp secrets check`), and **capability discovery** (`_get_server_env_metadata`, `src/pmcp/tools/handlers.py:3355`, consumed at `:1403`, `:3643`, `:3730`, `:3840` — this is what makes `gateway.catalog_search` and `gateway.request_capability` report a server as key-missing and tell operators to run `gateway.auth_connect`) — spanning 6 files and ~26 references. Successive review rounds found this list at four, then five, then six; each time the omitted consumer would have kept demanding the placeholder while every other path was fixed. Patching a subset produces a server that connects manually but fails auto-start, provisioning, or diagnostics. **Centralize first, then consume — and enumerate by grepping, not from memory.**
+- This is the same shape as the credential-namespacing work in #95: a requirement evaluated on several independent axes, where fixing one member of the class looks like fixing the class. Enumerate every call site before writing code.
+- Decompose into 3 lanes. Lane A owns `src/pmcp/manifest/loader.py` (the field plus the shared predicate) and publishes its signature as a day-1 intra-phase freeze. Lane B owns **all six** consumers (`config/loader.py`, `manifest/installer.py`, `tools/handlers.py`, `cli_commands/secrets.py`) and converts every gate to the predicate. Lane C owns `tests/`, including a test that fails if a new `requires_api_key` check appears outside the predicate — that test is what keeps the count honest.
+- #114 lists three candidate designs and explicitly rejects inferring from a URL-shaped override as a heuristic. Pick an **explicit** signal.
+- Independent of the protocol migration — touches the manifest/config path, not the protocol path — so it can run concurrently with P2.
+- Security-sensitive: the failure mode is a server reachable without auth. Weight verification toward EC-P5-2.
+
+**Non-goals**
+- Changing how credentials are stored or namespaced.
+
+**Key files**
+- src/pmcp/manifest/loader.py
+- src/pmcp/manifest/installer.py
+- src/pmcp/config/loader.py
+- src/pmcp/tools/handlers.py
+- src/pmcp/cli_commands/secrets.py
+- tests/
+- CHANGELOG.md
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-P5-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/manifest/loader.py`, `tests/`
+- evidence paths: `plans/phase-plan-v11-p5.md`
+- redaction posture: `metadata_only`
+
+---
+
+### Phase 6 — Deferred v10 robustness remnants (P6CLEAN)
+
+**Objective**
+Finish the one item from `specs/phase-plans-v10.md` Phase 6 that never landed, so the closed v10 roadmap has no silent leftovers.
+
+**Exit criteria**
+- [ ] EC-P6CLEAN-1 — `tests/test_manifest.py:1775` polls job state instead of `asyncio.sleep(0.3)`; the test passes with no wall-clock dependency and does not regress under load.
+- [ ] EC-P6CLEAN-2 — Full suite, ruff, and mypy green; CHANGELOG entry recording that this closes out v10 P6.
+
+**Scope notes**
+- **Single lane, justified.** This is one test-file change; a second lane would contend on the same file for no benefit. This is the preamble/cleanup exception to the ≥2-lane rule, not an oversight.
+- **Task-registry eviction was REMOVED from this phase at review — it is already done.** An earlier draft claimed it was missing, having searched `src/pmcp/tools/handlers.py` because that is where v10's P6 text pointed. The registry is actually in `src/pmcp/client/manager.py` and already has bounded terminal-record eviction (`_max_terminal_tasks`, `:507-512`), the done-callback `pop` (`:597`), and a regression test (`tests/test_client_manager.py:1588`). **Do not re-plan it.** The lesson generalises: verify a "missing" item against the code, not against the roadmap prose that described it.
+- Fully disjoint from every other v11 phase, so it can run concurrently with all of them.
+
+**Non-goals**
+- Any other item from v10 P6 — the rest were verified as landed when v10 was closed on 2026-08-05.
+
+**Key files**
+- tests/test_manifest.py
+- CHANGELOG.md
+
+**Depends on**
+- (none)
+
+**Produces**
+- (none)
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/tools/handlers.py`, `tests/test_manifest.py`
+- evidence paths: `plans/phase-plan-v11-p6clean.md`, `specs/phase-plans-v10.md`
+- redaction posture: `metadata_only`
+
+---
+
+## Phase Dependency DAG
+
+```
+  P1 ──► P2 ──► P3B
+
+  PG        (root — parallel with P1/P2, EC-PG-4 verifies after P2)
+
+  P5        (root — parallel with everything, disjoint file set)
+
+  P6CLEAN   (root — parallel with everything; closes out v10 P6)
+
+
+  Critical path:  P1 → P2 → P3B         (P3B is the riskiest phase)
+  Concurrent:     P1, PG, P5, and P6CLEAN may all be planned and started at once.
+                  server/discover needs no phase — the SDK auto-registers it.
+```
+
+---
+
+## Execution Notes
+
+Plan and execute:
+
+```
+/claude-plan-phase P1     &&  /claude-execute-phase p1
+/claude-plan-phase PG     &&  /claude-execute-phase pg     # concurrent with P1
+/claude-plan-phase P5     &&  /claude-execute-phase p5     # concurrent with P1
+/claude-plan-phase P2     &&  /claude-execute-phase p2     # after P1
+/claude-plan-phase P3B    &&  /claude-execute-phase p3b    # after P2
+/claude-plan-phase P6CLEAN && /claude-execute-phase p6clean # concurrent with anything
+```
+
+**P1, PG, P5, and P6CLEAN can be planned concurrently** — they share no DAG ancestor and touch disjoint file sets across two repositories.
+
+**Relationship to v10.** `specs/phase-plans-v10.md` was closed on 2026-08-05 with a status header recording file:line evidence that six of its seven phases shipped across the 1.19.x–1.20.0 line — outside this pipeline, as ordinary PRs, which is why it has no lane plans or manifest entries. P6CLEAN carries its two unfinished items so nothing is silently dropped. Do not plan or execute any phase from v10.
+
+**Disposition of Dependabot PR #112.** Leave it **open and unmerged** through P1. It is currently the best live evidence that `install-smoke` works: seven checks green, only that one red, on a real unported cap raise. Treat it as a standing canary. When P2 lands and raises the cap deliberately, close #112 as superseded with a comment pointing at this roadmap — do not merge it, because its cap raise carries none of the port. If Dependabot reopens it before P2, re-close it; do not disable the update.
+
+**Release cadence.** P1 is a patch. P2 is a minor (`1.22.0`) — new library, same client-visible behaviour. **P3B is a MAJOR version** — retiring a documented endpoint is a compatibility break and semver should say so; "explicitly-flagged breaking minor" was proposed and rejected at review. PG is a patch on its own repo.
+
+**Review history.** This roadmap went through three advisor-board rounds before any phase was planned. Three legs responded; two returned DISAGREE with five blocking findings, all independently confirmed against the code and reconciled. A second board on the reconciled draft found more: the Streamable HTTP client lost `headers`/`timeout` (not a rename), `DiscoverResult` cannot carry proxied inventory (so P3A was DELETED), the modern envelope was never proven against the six proxied handlers, and credential enforcement has FIVE consumers, not four. All are reconciled here. A third round was **not a usable board** — only 2 of 4 seats returned (gemini EMPTY, claude UNAVAILABLE), below the independence floor — so its verdict is not a pass. Its one substantive leg still found three real defects, all confirmed against the code and reconciled: a SIXTH credential consumer (capability discovery via `_get_server_env_metadata`), modern-envelope criteria that could pass over stdio while `/mcp` stayed broken, and the old HTTP client's redirect-following and client-ownership behaviour that 2.x hands back to the caller.
+
+**Read the trend before trusting this document.** Round 1 found 5 defects, round 2 found 5 more on the reconciled draft, round 3 found 3 more. The findings shrank in structural severity — round 2 deleted a phase, round 3 only tightened criteria — but they have not stopped. The credential-consumer count alone went four → five → six across rounds. Treat any 'complete' enumeration here as a floor, not a ceiling, and grep before trusting a list.
+
+**Service safety.** The gateway runs as a live systemd user service on `127.0.0.1:3344`. Every phase must leave it working; test on a spare port. After each phase merges, reinstall from PyPI and restart the unit before starting the next phase, so no phase is validated against a stale build.
+
+---
+
+## Verification
+
+End-to-end, after the last phase merges:
+
+```bash
+# 1. Both first-party packages install clean from PyPI and start
+uv venv /tmp/v11 && VIRTUAL_ENV=/tmp/v11 uv pip install pmcp pangram-mcp
+VIRTUAL_ENV=/tmp/v11 uv pip list | grep '^mcp '        # expect 2.x
+/tmp/v11/bin/pmcp --version
+/tmp/v11/bin/python -c "import pmcp.server, pmcp.client.manager, pangram_mcp.server"
+
+# 2. The gateway starts and serves (the check the unit suite cannot make)
+/tmp/v11/bin/pmcp --transport http --host 127.0.0.1 --port 3399 -l info &
+sleep 15 && ss -ltn | grep 3399                         # must be LISTENING
+
+# 3. Version negotiation is real, per era
+#    Downstream servers are reached via `initialize`, whose ceiling is
+#    2025-11-25 — NO downstream server should ever report 2026-07-28.
+#    gateway.health must show handshake-era values only (<= 2025-11-25).
+#    The 2026-07-28 era is proven separately, upward, by EC-P2-5/EC-P2-7.
+
+# 4. A downstream 1.x server still works through the 2.x gateway
+#    gateway.connect_server firecrawl  → online
+#    gateway.invoke firecrawl::firecrawl_scrape → returns content
+
+# 5. server/discover advertises what the gateway actually accepts (verified in P2)
+# 6. subscriptions/listen delivers a filtered notification and cancels cleanly (P3B)
+
+# 7. Guards still green on both repos, unmodified
+uv run pytest tests/ -q
+```
+
+The roadmap has delivered when: both packages run on `mcp` 2.x, clients negotiate `2026-07-28`, **every downstream server that worked before still works**, and no placeholder credential is required to reach a self-hosted endpoint.


### PR DESCRIPTION
Planning artifact only — no code changes, nothing executed. Adds `specs/phase-plans-v11.md` (6 phases, validator clean) and closes out `specs/phase-plans-v10.md`.

## Why now

**`mcp` 2.x is the only implementation of the current stable spec (`2026-07-28`).** So the `mcp<2.0.0` caps in both first-party packages — each correct as triage for a package that couldn't start on a fresh install — are now exactly what pin the fleet to the previous protocol revision.

Dependabot **#112** is already proposing the unported cap raise: 7 checks green, only `install-smoke` red. That PR is held as a canary and closed as superseded when P2 lands — never merged.

## v10 closure

Six of v10's seven phases had already shipped across the 1.19.x–1.20.0 line **as ordinary PRs, outside the phase pipeline** — which is why it had no lane plans, no manifest entries, and seven phases of security work still reading as open. The header now records file:line evidence per phase. Its one genuinely unfinished item (a sleep-based test) is carried into v11 P6CLEAN.

## Three review rounds, every finding verified against the code

| Round | Verdicts | Findings |
|---|---|---|
| 1 | 1 AGREE, 2 DISAGREE | 5 blocking — all confirmed |
| 2 | 3 DISAGREE | 5 more — all confirmed, **P3A deleted** |
| 3 | **Not a usable board** (2/4 seats: gemini EMPTY, claude UNAVAILABLE) | 3 more — all confirmed |

The two findings that would have wrecked execution:

**The protocol has two eras, not one ladder.** `mcp_types.version` separates `HANDSHAKE_PROTOCOL_VERSIONS` (`2024-11-05…2025-11-25`, via `initialize`) from `MODERN_PROTOCOL_VERSIONS` (`2026-07-28` only, via per-request `_meta` + `server/discover`). The original P2 planned to raise the *downstream handshake ladder* to `2026-07-28` — a version `initialize` cannot carry.

**`streamable_http_client` wasn't renamed, it was reshaped.** `headers`, `timeout`, `sse_read_timeout`, `httpx_client_factory` are gone in favour of a caller-built `httpx2` client that 2.x deliberately does **not** close. pmcp passes `headers=`, so the planned rename would `TypeError` on every authenticated remote downstream — and the fix leaks a client per reconnect without exit-stack ownership.

**P3A was deleted**: the SDK auto-registers `server/discover`, and `DiscoverResult` carries only `supported_versions`/`capabilities`/`instructions` — no proxied inventory — so the phase's premise was impossible.

**The v10 closeout itself had to be corrected mid-review.** It claimed task-registry eviction was missing, having trusted v10's prose (`tools/handlers.py`) over the code (`client/manager.py:507`, where it is done and tested).

## Verified independently, not assumed

- A `mcp` 2.0.0 client initializes against a `mcp` 1.29.0 stdio server, negotiates `2025-11-25`, lists tools, completes a `tools/call` — Assumption 1 is now a tested fact.
- `StreamableHTTPSessionManager` delegates to `handle_modern_request`, so keeping pmcp's own Starlette app doesn't strand it on the old era.
- `cli.py` does a bare `import httpx` while `httpx` is undeclared in `pyproject.toml` — it rides mcp's transitive dep, and 2.x ships `httpx2`. Found outside the board; folded into P2.

## Honest caveat, recorded in the document itself

The credential-consumer count went **four → five → six** across rounds. The roadmap states that any "complete" enumeration in it is a floor, not a ceiling, and to grep before trusting a list.

## Structure

```
P1 ──► P2 ──► P3B        Critical path
PG        (root, pangram-mcp — other repo)
P5        (root, #114)
P6CLEAN   (root, v10 leftover)
```

`P1`, `PG`, `P5`, `P6CLEAN` share no DAG ancestor and can be planned concurrently.

Validator: `validate_roadmap: OK — 6 phase(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->