### PR TITLE
fix(roadmap): uppercase phase-plan paths; repair invalid manifest statuses

### DIFF
--- a/plans/manifest.json
+++ b/plans/manifest.json
@@ -729,7 +729,7 @@
       ],
       "owner_skill": "claude-plan-detailed",
       "slug": "detailed-idle-timeout-downstream-calls",
-      "status": "staged",
+      "status": "committed",
       "task_summary": "Convert downstream-call timeout to inactivity (idle) timeout with absolute ceiling (#79 symptom 1a)",
       "type": "detailed",
       "updated_at": "2026-06-28T06:46:00Z"
@@ -751,7 +751,7 @@
       ],
       "owner_skill": "claude-plan-detailed",
       "slug": "detailed-private-manifest-overlay",
-      "status": "staged",
+      "status": "committed",
       "task_summary": "Private/custom MCP manifest overlay merged in load_manifest (user/project/PMCP_MANIFEST_PATH); ship v1.18.0",
       "type": "detailed",
       "updated_at": "2026-06-29T08:41:00Z"
@@ -773,7 +773,7 @@
       ],
       "owner_skill": "claude-plan-detailed",
       "slug": "detailed-describe-nested-schema-indexit-stdio",
-      "status": "staged",
+      "status": "committed",
       "task_summary": "gateway.describe nested-schema fidelity (#87) + index-it-mcp stdio transport & pilot docs (#89); ship v1.19.1",
       "type": "detailed",
       "updated_at": "2026-07-06T09:20:00Z"

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -1,6 +1,6 @@
 # PMCP — Phase Plan v11 (MCP spec 2026-07-28 / mcp 2.x fleet migration)
 
-> How to use this document: run `/claude-plan-phase <ALIAS>` to produce the lane-level plan for each phase (→ `plans/phase-plan-v11-<alias>.md`), then `/claude-execute-phase <alias>` to build it.
+> How to use this document: run `/claude-plan-phase <ALIAS>` to produce the lane-level plan for each phase (→ `plans/phase-plan-v11-<ALIAS>.md` — the alias is UPPERCASE; `PLAN_RE` in `phase_loop_runtime.plan_manifest` requires an uppercase first character and will not match a lowercase filename), then `/claude-execute-phase <alias>` to build it.
 
 ---
 
@@ -141,7 +141,7 @@ Level `pmcp`'s CI up to the four guards already proven in `pangram-mcp`, so the 
 - schema: `spec_delta_closeout.v1`
 - decision: `no_spec_delta`
 - target surfaces: `.github/workflows/test.yml`, `tests/`
-- evidence paths: `plans/phase-plan-v11-p1.md`
+- evidence paths: `plans/phase-plan-v11-P1.md`
 - redaction posture: `metadata_only`
 
 ---
@@ -194,7 +194,7 @@ Raise `pmcp` onto `mcp` 2.x so it runs correctly on the new library and negotiat
 - schema: `spec_delta_closeout.v1`
 - decision: `roadmap_amendment`
 - target surfaces: `src/pmcp/server.py`, `src/pmcp/client/manager.py`, `pyproject.toml`
-- evidence paths: `plans/phase-plan-v11-p2.md`, `plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md`
+- evidence paths: `plans/phase-plan-v11-P2.md`, `plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md`
 - redaction posture: `metadata_only`
 - note: if Assumption 1a (the two-era split) proves wrong, this phase must raise a roadmap amendment before P3B is planned.
 
@@ -241,7 +241,7 @@ Implement `subscriptions/listen` and retire the HTTP GET endpoint it replaces, w
 - schema: `spec_delta_closeout.v1`
 - decision: `canonical_spec_update`
 - target surfaces: `src/pmcp/transport/http.py`, `src/pmcp/server.py`, `CHANGELOG.md`
-- evidence paths: `plans/phase-plan-v11-p3b.md`
+- evidence paths: `plans/phase-plan-v11-P3B.md`
 - redaction posture: `metadata_only`
 
 ---
@@ -282,7 +282,7 @@ Move the first-party `pangram-mcp` server off the removed `FastMCP` API onto `MC
 - schema: `spec_delta_closeout.v1`
 - decision: `no_spec_delta`
 - target surfaces: `src/pangram_mcp/server.py`, `pyproject.toml`
-- evidence paths: `plans/phase-plan-v11-pg.md`
+- evidence paths: `plans/phase-plan-v11-PG.md`
 - redaction posture: `metadata_only`
 
 ---
@@ -328,7 +328,7 @@ Let a manifest entry express "credential required for the vendor endpoint, optio
 - schema: `spec_delta_closeout.v1`
 - decision: `no_spec_delta`
 - target surfaces: `src/pmcp/manifest/loader.py`, `tests/`
-- evidence paths: `plans/phase-plan-v11-p5.md`
+- evidence paths: `plans/phase-plan-v11-P5.md`
 - redaction posture: `metadata_only`
 
 ---
@@ -364,7 +364,7 @@ Finish the one item from `specs/phase-plans-v10.md` Phase 6 that never landed, s
 - schema: `spec_delta_closeout.v1`
 - decision: `no_spec_delta`
 - target surfaces: `src/pmcp/tools/handlers.py`, `tests/test_manifest.py`
-- evidence paths: `plans/phase-plan-v11-p6clean.md`, `specs/phase-plans-v10.md`
+- evidence paths: `plans/phase-plan-v11-P6CLEAN.md`, `specs/phase-plans-v10.md`
 - redaction posture: `metadata_only`
 
 ---


### PR DESCRIPTION
Two defects found while preparing the v11 lane plans for merge. Both confirmed mechanically; **one is my own error**, caught by a planning agent.

## 1. The roadmap declared its own plan paths in lowercase

`PLAN_RE` in `phase_loop_runtime.plan_manifest` is:

```
phase-plan-(v[\w.-]+?)-([A-Z][A-Za-z0-9._-]*?)\.md$
```

The alias group requires an **uppercase first character**, so a lowercase filename is invisible to the regex discovery path:

| filename | `PLAN_RE.match` |
|---|---|
| `phase-plan-v11-p6clean.md` | `False` |
| `phase-plan-v11-P6CLEAN.md` | `True` |

All six evidence paths in `specs/phase-plans-v11.md` corrected, and the how-to line now states the rule explicitly so the next reader doesn't repeat it.

**This was my error.** A planning agent flagged it early — "the skill mandates `P1`, you said `p1`; if the runner globs uppercase it won't find the file." I checked only the `phase-plan-v*-*.md` glob, saw it matched either case, and told them the frontmatter covered it. The glob does match; the regex fallback does not. All four lane plans were written lowercase on my instruction and have since been renamed.

## 2. `plans[19..21]` carried an invalid status

`status: "staged"` has never been a member of `PLAN_STATUSES` (`{committed, completed, executing, failed, imported, orphaned}`), so `validate_manifest` returned **globally invalid** regardless of what anyone appended. Pre-existing, predating this session.

Set to `committed` — these are plan documents committed to the repo.

**Judgment call worth reviewing:** their last lifecycle transition reads `planned`, and there is no corresponding status in the enum. `committed` is the closest true statement, but if `imported` is preferred it's a one-line change.

## Verification

```
validate_manifest → structural_valid=True, invalid entries: NONE
phase-loop validate-roadmap → OK, 6 phase(s)
```

Prerequisite for merging the four v11 lane plans, all of which now carry uppercase filenames and validating manifest entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt