### PR TITLE
feat(P1): release-guard hardening — min-version-smoke, schedule, drift test, honest mcp floor

### DIFF
--- a/.claude/docs-catalog.json
+++ b/.claude/docs-catalog.json
@@ -1,1 +1,322 @@
-[]
+{
+  "version": 1,
+  "last_updated": "2026-08-06T03:37:43+00:00",
+  "files": {
+    "README.md": {
+      "purpose": "root project README",
+      "touched_by_phases": []
+    },
+    "CHANGELOG.md": {
+      "purpose": "release changelog",
+      "touched_by_phases": [
+        "P1"
+      ]
+    },
+    "CONTRIBUTING.md": {
+      "purpose": "contribution guidelines",
+      "touched_by_phases": [
+        "P1"
+      ]
+    },
+    "SECURITY.md": {
+      "purpose": "security policy",
+      "touched_by_phases": []
+    },
+    ".claude/plans/ticklish-inventing-stearns.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "specs/README.md": {
+      "purpose": "root project README",
+      "touched_by_phases": []
+    },
+    "specs/active/pmcp-gateway-orchestration-plan.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v1.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v10.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v11.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": [
+        "P1"
+      ]
+    },
+    "specs/phase-plans-v2.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v3.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v4.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v5.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v6.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v7.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v8.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v9.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/tenant-code-mode-host-contract.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/HANDOFF-agent-board-mcp-registration.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/ROADMAP-pmcp-agent-board-mcp.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/codebase-review-2026-06-15.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/detailed-103-scoped-advisor-audit-20260726.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/detailed-describe-nested-schema-and-indexit-stdio-20260706-0920.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/detailed-idle-timeout-downstream-calls-20260628-0646.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/detailed-mcp-2x-spec-2026-07-28-stage1-20260805-1740.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/detailed-overlay-server-env-patch-20260801-1530.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/detailed-private-manifest-overlay-20260629-0841.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v1-config.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v1-observe.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v1-resolver.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v1-runtime.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v11-P1.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": [
+        "P1"
+      ]
+    },
+    "plans/phase-plan-v11-P5.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v11-P6CLEAN.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v11-PG.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v2-lifecycle.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v2-ops.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v2-refresh.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v2-serialize.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v2-soak.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v3-auth.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v3-config.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v3-conform.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v3-observe.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v3-proto.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v3-tasks.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v4-authobs.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v4-authsoak.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v4-elicit.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v4-remote.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v4-safeurl.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v4-store.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v5-catalogcli.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v5-clihint.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v5-climatch.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v5-clisoak.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v5-reqcli.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v6-hostcontract.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v6-hostmeta.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v6-hostpolicy.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v6-hostreg.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v6-hostsoak.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v7-AUTHRS.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v7-CONCURR.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v7-ENVFIX.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v7-MANIFEST.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v7-REDACT.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v7-REGISTRY.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v8-AUTHFIX.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v8-COMPLETE.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v8-MATCHFIX.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v8-REGFIX.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v8-RELEASE.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v9-SPECCURRENCY.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/v7-code-review-findings.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/v7-issue-tracker.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    }
+  }
+}

--- a/.github/probe/p1_probe_client.py
+++ b/.github/probe/p1_probe_client.py
@@ -1,0 +1,67 @@
+"""Drive a real downstream tool call through a running gateway.
+
+Usage: p1_probe_client.py <gateway streamable-http url>   (e.g. .../mcp)
+
+Used by the `min-version-smoke` CI job as the acceptance step for the declared
+`mcp` floor. It connects to the gateway over Streamable HTTP, brings the
+`p1probe` stdio fixture online via `gateway.connect_server`, invokes
+`p1probe::p1_echo` via `gateway.invoke`, and asserts the fixture's payload came
+back. That client -> gateway -> stdio downstream -> back round trip is the proof;
+a successful import and a green `/health` are preconditions only.
+
+Exits non-zero with an explanatory message on any failure so the CI step fails.
+"""
+
+import asyncio
+import sys
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+SENTINEL = "p1-floor-ok:"
+
+
+def _text_of(result: object) -> str:
+    """Flatten a CallToolResult's content blocks into one searchable string."""
+    parts = []
+    for block in getattr(result, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+async def main(url: str) -> None:
+    async with streamablehttp_client(url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            connected = await session.call_tool(
+                "gateway.connect_server", {"server_name": "p1probe"}
+            )
+            if connected.isError:
+                sys.exit(f"gateway.connect_server failed: {_text_of(connected)}")
+
+            invoked = await session.call_tool(
+                "gateway.invoke",
+                {
+                    "tool_id": "p1probe::p1_echo",
+                    "arguments": {"text": "floor"},
+                },
+            )
+            if invoked.isError:
+                sys.exit(f"gateway.invoke failed: {_text_of(invoked)}")
+
+            payload = _text_of(invoked)
+            if SENTINEL not in payload:
+                sys.exit(
+                    f"downstream tool call did not round-trip: "
+                    f"expected {SENTINEL!r} in {payload!r}"
+                )
+            print(f"OK: downstream tool call round-tripped: {payload}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <gateway streamable-http url>")
+    asyncio.run(main(sys.argv[1]))

--- a/.github/probe/p1_probe_client.py
+++ b/.github/probe/p1_probe_client.py
@@ -13,12 +13,20 @@ Exits non-zero with an explanatory message on any failure so the CI step fails.
 """
 
 import asyncio
+import json
 import sys
 
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 SENTINEL = "p1-floor-ok:"
+
+
+class ProbeFailure(Exception):
+    """A probe assertion failed. Raised, not sys.exit'ed, so the message
+    survives anyio's task groups: calling sys.exit() inside the ClientSession
+    context gets wrapped in a BaseExceptionGroup and the actual reason ends up
+    buried under ~40 lines of traceback. __main__ unwraps and prints it alone."""
 
 
 def _text_of(result: object) -> str:
@@ -31,16 +39,59 @@ def _text_of(result: object) -> str:
     return "\n".join(parts)
 
 
+def _check(label: str, result: object) -> dict:
+    """Assert a gateway tool call succeeded, and return its parsed body.
+
+    `isError` alone is NOT sufficient. Gateway tools return their outcome as an
+    ordinary JSON text block (`server.py:318` json.dumps'es the model_dump and
+    never sets isError), so a genuine failure — a server that could not start,
+    a missing credential — arrives as `{"ok": false, "message": "..."}` with
+    isError FALSE. Checking only isError sails straight past it.
+
+    That matters more than it looks: a failed explicit connect leaves the
+    fixture registered as *lazy*, so the following invoke silently reconnects
+    on demand and returns the sentinel anyway. The job would go green while
+    gateway.connect_server was broken — exactly the "passes while something
+    real is broken" failure this phase exists to prevent.
+
+    Both checks are kept: isError catches transport-level failures that never
+    produce a JSON body at all, and `ok` catches gateway-level ones.
+    """
+    payload = _text_of(result)
+    if getattr(result, "isError", False):
+        raise ProbeFailure(f"{label} failed at the transport level: {payload}")
+
+    try:
+        body = json.loads(payload)
+    except (TypeError, ValueError) as exc:
+        raise ProbeFailure(
+            f"{label} did not return a JSON body ({exc}): {payload!r}"
+        ) from exc
+
+    if not isinstance(body, dict):
+        raise ProbeFailure(f"{label} returned a non-object body: {payload!r}")
+
+    if body.get("ok") is not True:
+        detail = body.get("message") or body.get("errors") or payload
+        raise ProbeFailure(
+            f"{label} reported failure (ok={body.get('ok')!r}): {detail}"
+        )
+
+    return body
+
+
 async def main(url: str) -> None:
     async with streamablehttp_client(url) as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
 
-            connected = await session.call_tool(
-                "gateway.connect_server", {"server_name": "p1probe"}
+            connected = _check(
+                "gateway.connect_server",
+                await session.call_tool(
+                    "gateway.connect_server", {"server_name": "p1probe"}
+                ),
             )
-            if connected.isError:
-                sys.exit(f"gateway.connect_server failed: {_text_of(connected)}")
+            print(f"connected: {connected.get('new_status')!r}")
 
             invoked = await session.call_tool(
                 "gateway.invoke",
@@ -49,19 +100,41 @@ async def main(url: str) -> None:
                     "arguments": {"text": "floor"},
                 },
             )
-            if invoked.isError:
-                sys.exit(f"gateway.invoke failed: {_text_of(invoked)}")
+            # Same reasoning as the connect above: gateway.invoke reports its own
+            # outcome as `ok` in the body, so check it explicitly rather than
+            # inferring failure from the sentinel being absent.
+            _check("gateway.invoke", invoked)
 
             payload = _text_of(invoked)
             if SENTINEL not in payload:
-                sys.exit(
+                raise ProbeFailure(
                     f"downstream tool call did not round-trip: "
                     f"expected {SENTINEL!r} in {payload!r}"
                 )
             print(f"OK: downstream tool call round-tripped: {payload}")
 
 
+def _flatten(exc: BaseException) -> "list[BaseException]":
+    """Walk anyio's nested exception groups down to the real exceptions.
+
+    Duck-typed on `.exceptions` rather than `isinstance(exc, BaseExceptionGroup)`
+    because that builtin only exists on Python 3.11+, and this package declares
+    support from 3.10. The job itself runs 3.12, but a NameError here would only
+    surface on the failure path — the one path a guard must not break on.
+    """
+    nested = getattr(exc, "exceptions", None)
+    if nested is None:
+        return [exc]
+    return [sub for inner in nested for sub in _flatten(inner)]
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         sys.exit(f"usage: {sys.argv[0]} <gateway streamable-http url>")
-    asyncio.run(main(sys.argv[1]))
+    try:
+        asyncio.run(main(sys.argv[1]))
+    except BaseException as exc:  # noqa: BLE001 - re-raised unless it is ours
+        failures = [e for e in _flatten(exc) if isinstance(e, ProbeFailure)]
+        if not failures:
+            raise
+        sys.exit(f"PROBE FAILED: {failures[0]}")

--- a/.github/probe/p1_probe_server.py
+++ b/.github/probe/p1_probe_server.py
@@ -1,0 +1,33 @@
+"""Throwaway stdio MCP server used only by the `min-version-smoke` CI job.
+
+This is the downstream end of the floor proof. `min-version-smoke` installs pmcp
+pinned at exactly the `mcp` lower bound declared in `pyproject.toml`, boots the
+gateway, and drives a real tool call through it to this server. Importing the
+gateway's startup modules is NOT sufficient evidence for a floor — the mcp 2.x
+break that motivated these guards was invisible to imports — and neither is
+`/health`, which returns a hardcoded literal. Only a round trip through session
+initialization, tool discovery, and invocation exercises the code an `mcp`
+version bump actually lands on.
+
+Deliberately not under `tests/`: it must stay out of the shipped wheel and out
+of the pytest collection path.
+
+The gateway SIGKILLs orphaned downstream processes at startup, matching on
+`(Path(command).name, tuple(args))`. This file is therefore always launched as
+`<venv>/bin/python <absolute path under a throwaway temp dir>`, a pair no
+unrelated process on the runner can collide with.
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("p1probe")
+
+
+@mcp.tool()
+def p1_echo(text: str) -> str:
+    """Echo the supplied text back with a fixed, greppable prefix."""
+    return f"p1-floor-ok:{text}"
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # 1.21.0 could have broken with ZERO commits to this repo: mcp 2.0.0 was
+  # published after the last CI run and nothing re-ran to notice. Push/PR
+  # triggers cannot catch a dependency that moves underneath a released
+  # package, so run weekly against the released artifact.
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -75,6 +82,87 @@ jobs:
           # Import the modules a real startup touches, so a renamed or removed
           # upstream symbol fails here rather than in a user's service log.
           /tmp/fresh/bin/python -c "import pmcp.client.manager, pmcp.server, pmcp.config.loader"
+
+  # install-smoke proves the CEILING: the unpinned resolve still works. It says
+  # nothing about the FLOOR, because a fresh resolve always picks the newest
+  # allowed version. A declared lower bound that was never installed is a guess,
+  # and this repo shipped one: `mcp>=1.0.0` while mcp.client.streamable_http —
+  # imported by client/manager.py at module scope — first exists in mcp 1.8.0.
+  # This job installs pinned at exactly the declared floor and proves it works.
+  min-version-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Resolve the declared minimum mcp from pyproject
+        id: floor
+        run: |
+          FLOOR=$(python3 <<'PY'
+          import pathlib
+          import re
+
+          text = pathlib.Path("pyproject.toml").read_text()
+          match = re.search(r'"mcp>=([0-9.]+),<', text)
+          assert match, "could not parse the mcp lower bound from pyproject.toml"
+          print(match.group(1))
+          PY
+          )
+          echo "floor=$FLOOR" >> "$GITHUB_OUTPUT"
+          echo "declared mcp floor: $FLOOR"
+
+      - name: Install at the floor and import the startup modules
+        env:
+          FLOOR: ${{ steps.floor.outputs.floor }}
+        run: |
+          uv build --wheel --out-dir dist
+          uv venv /tmp/floor
+          VIRTUAL_ENV=/tmp/floor uv pip install dist/*.whl "mcp==${FLOOR}"
+          VIRTUAL_ENV=/tmp/floor uv pip list
+          /tmp/floor/bin/pmcp --version
+          /tmp/floor/bin/python -c "import pmcp.client.manager, pmcp.server, pmcp.config.loader"
+
+      # Imports are not acceptance for a gateway, and neither is /health —
+      # transport/http.py:435-436 returns "ok": True as a hardcoded literal.
+      # Only a real downstream tool call exercises session init, discovery,
+      # and invocation, which is where an mcp break actually lands.
+      - name: Serve a real downstream tool call at the floor
+        env:
+          FLOOR: ${{ steps.floor.outputs.floor }}
+        run: |
+          VIRTUAL_ENV=/tmp/floor uv pip install "$(ls dist/*.whl)[http]" "mcp==${FLOOR}"
+          mkdir -p /tmp/floorhome/lock /tmp/floorhome/xdg
+          cp .github/probe/p1_probe_server.py .github/probe/p1_probe_client.py /tmp/floorhome/
+          printf '{"mcpServers": {"p1probe": {"command": "/tmp/floor/bin/python", "args": ["/tmp/floorhome/p1_probe_server.py"]}}}\n' > /tmp/floorhome/mcp.json
+          printf 'servers:\n  allowlist: ["p1probe"]\n' > /tmp/floorhome/policy.yaml
+          HOME=/tmp/floorhome XDG_CONFIG_HOME=/tmp/floorhome/xdg /tmp/floor/bin/pmcp \
+            --transport http --host 127.0.0.1 --port 3399 \
+            --config /tmp/floorhome/mcp.json \
+            --project /tmp/floorhome \
+            --policy /tmp/floorhome/policy.yaml \
+            --lock-dir /tmp/floorhome/lock -l info > /tmp/floorboot.log 2>&1 &
+          PROBE_PID=$!
+          trap 'kill "$PROBE_PID" 2>/dev/null' EXIT
+          for _ in $(seq 1 30); do
+            curl -sf --max-time 2 http://127.0.0.1:3399/health > /dev/null && break
+            sleep 1
+          done
+          cat /tmp/floorboot.log
+          # Assert the RESOLVED set is exactly the one fixture. Do NOT tripwire on
+          # "a count in the hundreds" — the shipped manifest always contributes 106,
+          # so a correctly isolated run legitimately reports skipped=106 and
+          # policy_denied=106. Hundreds in those buckets is the CORRECT output; what
+          # proves isolation is that lazy+eager (the denominator here) is exactly 1.
+          grep -E 'Gateway initialized: [0-9]+/1 servers online' /tmp/floorboot.log
+          /tmp/floor/bin/python /tmp/floorhome/p1_probe_client.py http://127.0.0.1:3399/mcp
+          kill "$PROBE_PID" 2>/dev/null || true
 
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The declared `mcp` floor was corrected from `>=1.0.0` to `>=1.8.0`, because
+  `>=1.0.0` was never installable.** `client/manager.py` imports
+  `streamablehttp_client` from `mcp.client.streamable_http` at module scope, and
+  that module first exists in `mcp` 1.8.0 — pinning 1.0.0, 1.6.0, 1.7.0, or
+  1.7.1 fails the gateway's startup import with
+  `ModuleNotFoundError: No module named 'mcp.client.streamable_http'`. The bound
+  was set by installing at each candidate, not by reading source. The upper
+  bound is unchanged; supporting `mcp` 2.x is still tracked separately.
+- **CI now proves the declared minimum actually works.** `install-smoke` only
+  ever exercised the *ceiling* — a fresh resolve always picks the newest allowed
+  version, so a bogus lower bound is invisible to it. A new `min-version-smoke`
+  job parses the floor out of `pyproject.toml`, installs the built wheel pinned
+  at exactly that version, imports the gateway's startup modules, then boots the
+  gateway and drives a real tool call through it to a throwaway downstream
+  server. Imports alone are not acceptance for a gateway, and neither is
+  `/health` — it returns a hardcoded literal. Only the round trip exercises
+  session initialization, tool discovery, and invocation, which is where an
+  `mcp` break actually lands.
+- **The test workflow now runs on a schedule and on demand.** A weekly
+  `schedule:` (`0 8 * * 1`) plus `workflow_dispatch:` join the existing push and
+  pull-request triggers. 1.21.0 could have broken with zero commits to this
+  repo: `mcp` 2.0.0 was published after the last CI run and nothing re-ran to
+  notice. Push and PR triggers cannot catch a dependency that moves underneath
+  an already-released package.
+- **A drift test pins `pmcp.__version__` to the installed distribution's
+  metadata.** `tests/test_package_metadata.py` fails when the version in
+  `pyproject.toml` and the one in `src/pmcp/__init__.py` disagree. A release
+  that bumps one without the other makes everything reading `pmcp.__version__` —
+  the `/health` payload and the `pmcp/{version}` User-Agent among them — report
+  the wrong release.
+
 ## [1.21.1] - 2026-08-01
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,13 @@ Currently, only Playwright and Context7 are auto-start servers.
 - **Linting**: Use `ruff check` for linting
 - **Type hints**: Required for all public functions (mypy checked in CI)
 - **Tests**: Required for new features
+- **Dependency bounds**: Set them by installing, not by reading source. `uv.lock`
+  pins development checkouts, so the full suite can pass while a declared bound
+  is wrong in both directions. Two CI jobs cover this: `install-smoke` resolves
+  fresh with no lockfile (the ceiling), and `min-version-smoke` installs pinned
+  at exactly the declared floor and serves a real downstream tool call through
+  the booted gateway (the floor). If you change a bound in `pyproject.toml`, run
+  `uv lock` in the same commit.
 
 ```bash
 # Format code

--- a/plans/phase-plan-v11-P1.md
+++ b/plans/phase-plan-v11-P1.md
@@ -289,6 +289,29 @@ Implementation contract:
 - [ ] EC-P1-5 — proven by V5: `uv run pytest tests/ -q`, `uv run ruff check src/ tests/`, `uv run ruff format --check src/ tests/`, `uv run mypy src/pmcp --exclude baml_client` all green, and `rg -n '^### Changed' -A 20 CHANGELOG.md` showing the new entry under `## [Unreleased]`.
 - [ ] Plan-internal — the roadmap amendment narrowing P1's dependency-bound non-goal is present in the same merge as the `pyproject.toml` floor change, proven by `git show --stat HEAD` (or the phase merge commit) listing both `pyproject.toml` and `specs/phase-plans-v11.md`, and by `rg -n 'Post-execution amendments' -A 10 specs/phase-plans-v11.md`.
 
+## Post-execution amendments
+
+*Recorded pre-merge by SL-docs.3, in the same commit as the `pyproject.toml`
+floor change.* The roadmap's Phase 1 "Non-goals: changing any dependency bound"
+has been narrowed to the **ceiling** only; the matching
+`### Post-execution amendments` block is in `specs/phase-plans-v11.md`. P1
+changed `mcp>=1.0.0,<2.0.0` to `mcp>=1.8.0,<2.0.0` and regenerated `uv.lock`
+(one line: the `[package.metadata] requires-dist` entry). The floor was set by
+installing the built wheel pinned at each candidate — 1.0.0/1.6.0/1.7.0/1.7.1
+all fail the startup import with
+`ModuleNotFoundError: No module named 'mcp.client.streamable_http'`, and 1.8.0
+both imports and serves a real downstream tool call through the booted gateway.
+P2 is unaffected: it still raises the cap and re-derives the floor for `mcp` 2.x.
+
+`roadmap_sha256` in this file's frontmatter is deliberately left at its
+plan-time value (`2f03c6f3…`). It records the roadmap state this plan was
+derived from, which is the pre-amendment state; it is read only by
+`claude-plan-phase`'s planning-time validator, never by an execution gate.
+
+SL-docs.5's post-merge evidence (the correlated `workflow_dispatch` run for
+EC-P1-2 and #112's refreshed head for EC-P1-4) is **not** included — by
+construction it cannot exist before the merge.
+
 ## Verification
 
 Run from the merged branch. `/tmp/p1*` are throwaway paths. **V2b and V2c start a gateway on port `3388`** — read `## Execution Notes > Boot-check isolation` first and prefer a CI runner or container over the operator's host. No step may bind `3344`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,16 @@ dependencies = [
     # which client/manager.py imports at module scope. Without the cap a fresh
     # install resolves to 2.x and the gateway dies on startup with an ImportError.
     # Raising this requires porting that import (and auditing the rest of 2.x).
-    "mcp>=1.0.0,<2.0.0",
+    #
+    # The lower bound is load-bearing too, and was set by INSTALLING, not by
+    # reading source. client/manager.py imports streamablehttp_client from
+    # mcp.client.streamable_http at module scope, and that module first exists
+    # in mcp 1.8.0: the previously declared >=1.0.0 was never installable, and
+    # 1.0.0/1.6.0/1.7.0/1.7.1 all die with
+    # `ModuleNotFoundError: No module named 'mcp.client.streamable_http'`.
+    # At 1.8.0 the gateway boots, listens, and serves a real downstream tool
+    # call. The min-version-smoke CI job re-proves this floor on every run.
+    "mcp>=1.8.0,<2.0.0",
     "pydantic>=2.0",
     "pyjwt[crypto]>=2.10.0",
     "pyyaml>=6.0",

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -139,10 +139,61 @@ Level `pmcp`'s CI up to the four guards already proven in `pangram-mcp`, so the 
 
 **Spec closeout policy**
 - schema: `spec_delta_closeout.v1`
-- decision: `no_spec_delta`
-- target surfaces: `.github/workflows/test.yml`, `tests/`
-- evidence paths: `plans/phase-plan-v11-P1.md`
+- decision: `roadmap_amendment`
+- target surfaces: `.github/workflows/test.yml`, `pyproject.toml`, `uv.lock`, `tests/`
+- evidence paths: `plans/phase-plan-v11-P1.md`, `specs/phase-plans-v11.md`
 - redaction posture: `metadata_only`
+
+**Post-execution amendments**
+
+*P1's dependency-bound non-goal is narrowed to the ceiling.* The "Non-goals"
+above read "changing any dependency bound". Held literally, the phase is
+unmergeable: `min-version-smoke` installs pinned at the declared floor, and the
+declared floor of `mcp>=1.0.0` does not install. That would land a permanently
+red job on `main`, contradicting EC-P1-5 and undermining P2, whose premise is
+that these guards are trustworthy. Cross-Cutting Principle 2 forbids weakening
+the guard to make the phase pass; Principles 4 and 5 require both bounds be
+declared and set by installing. The reading that satisfies all three: **the
+non-goal reserves the ceiling raise for P2, while a floor that installation
+proves false is corrected here.** P1 therefore changed `mcp>=1.0.0,<2.0.0` to
+`mcp>=1.8.0,<2.0.0` and regenerated `uv.lock`. **P2 is unaffected** — it still
+raises the cap and re-derives the floor for `mcp` 2.x.
+
+Evidence for the 1.8.0 floor, gathered by installing the built wheel pinned at
+each candidate rather than by reading source:
+
+| pinned `mcp` | `import pmcp.client.manager, pmcp.server, pmcp.config.loader` |
+|---|---|
+| 1.0.0 / 1.6.0 / 1.7.0 / 1.7.1 | `ModuleNotFoundError: No module named 'mcp.client.streamable_http'` |
+| 1.8.0 | OK — and the gateway boots, listens, and serves a real downstream tool call |
+
+`client/manager.py:22` imports `streamablehttp_client` from
+`mcp.client.streamable_http`, a module that first exists in `mcp` 1.8.0. The
+functional half of that evidence is the acceptance step: at `mcp==1.8.0`, with
+the startup set bounded by `--policy` to a single throwaway stdio fixture, an
+MCP client over Streamable HTTP initialized against the gateway,
+`gateway.connect_server` brought the fixture online, and `gateway.invoke` on
+`p1probe::p1_echo` returned `p1-floor-ok:floor` with `isError: false`. Imports
+are not acceptance for a gateway, and `/health` is barely stronger — it returns
+`"ok": True` as a hardcoded literal — so both are retained as preconditions
+only.
+
+*EC-P1-1 was tightened, not weakened.* Its text asks only that the job "imports
+the gateway's startup modules". As shipped, `min-version-smoke` also boots the
+gateway and serves a real downstream tool call, per Cross-Cutting Principle 1.
+The `mcp` 2.x break this roadmap exists to fix was invisible to imports and
+would also have been invisible to `/health`. Strengthening a guard is always in
+scope; weakening one never is.
+
+*Post-merge operational evidence (EC-P1-2, EC-P1-4).* Pending. Neither is
+provable from a lane worktree: `workflow_dispatch` is only dispatchable once the
+workflow is on the default branch, and #112's checks are only meaningful when
+re-run against post-P1 `main`. Recorded here by the post-merge closeout, which
+gates nothing — the correlated `workflow_dispatch` run URL, conclusion, and
+`headSha`; and #112's old and refreshed head SHAs with the conclusion against
+the new one. After P1, #112 is expected to fail `install-smoke` **only**: it
+raises the cap but not the floor, so `min-version-smoke` still installs
+`mcp==1.8.0` and passes.
 
 ---
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,34 @@
+"""Guard `pmcp.__version__` against the installed distribution's metadata.
+
+The version lives in two places — `pyproject.toml`'s `[project] version` and
+`src/pmcp/__init__.py`'s `__version__` — and a release that bumps one without
+the other makes everything reading `pmcp.__version__` report the wrong release:
+the `/health` payload and the `pmcp/{version}` User-Agent both come from it, so
+the drift is invisible locally and misleading in production.
+"""
+
+import importlib.metadata
+
+import pytest
+
+import pmcp
+
+
+def test_dunder_version_matches_distribution_metadata() -> None:
+    try:
+        installed = importlib.metadata.version("pmcp")
+    except importlib.metadata.PackageNotFoundError:
+        # Not drift — the distribution simply is not installed, which is an
+        # environment fault. Fail loudly rather than skipping: a silent skip
+        # here would let real drift ship unnoticed on any machine where the
+        # metadata happened to be missing.
+        pytest.fail(
+            "the pmcp distribution is not installed, so __version__ cannot be "
+            "checked against its metadata; run `uv sync --all-extras`"
+        )
+
+    assert pmcp.__version__ == installed, (
+        f"pmcp.__version__ is {pmcp.__version__!r} but the installed "
+        f"distribution reports {installed!r}; bump both pyproject.toml and "
+        f"src/pmcp/__init__.py"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ http = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
+    { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pmcp", extras = ["dev", "http"], marker = "extra == 'all'" },
     { name = "prometheus-client", marker = "extra == 'http'", specifier = ">=0.20" },


### PR DESCRIPTION
Executes **v11 Phase 1 (P1)** per `plans/phase-plan-v11-P1.md`. First executed phase of the roadmap.

## What ships

Four release guards, ported from `Consiliency/pangram-mcp`:

| Guard | Status |
|---|---|
| `install-smoke` | **byte-for-byte unchanged** — verified programmatically |
| `min-version-smoke` | new |
| `schedule:` + `workflow_dispatch:` | new |
| `__version__` / metadata drift test | new |

Plus a correction to a **shipped dependency bound**.

## pmcp has been declaring a false `mcp` floor

`pyproject.toml` said `mcp>=1.0.0`. Established by installing each candidate, not by reading source:

| mcp | `import pmcp.client.manager` |
|---|---|
| 1.0.0 | ❌ `No module named 'mcp.client.streamable_http'` |
| 1.7.1 | ❌ same |
| 1.8.0 | ✅ |

`client/manager.py:22` imports from that module. Now `mcp>=1.8.0,<2.0.0`.

The roadmap listed "changing any dependency bound" as a P1 non-goal, but held literally that makes the phase unmergeable — `min-version-smoke` at `>=1.0.0` lands red on `main`, and cross-cutting principle 2 forbids weakening the job to make it pass. **The roadmap amendment ships in this same commit**, per the plan: `pyproject.toml`, `uv.lock`, and `specs/phase-plans-v11.md` are not separable.

This is the third instance of this bug class this session — pmcp's missing upper bound shipped broken twice (#111), and pangram-mcp's lower bound was wrong by twelve minor versions (0.1.3).

## `min-version-smoke` proves a real tool call, not an import

Imports are not acceptance for a gateway — 2276 tests once passed while it could not boot. Neither is `/health`, which returns `"ok": True` as a hardcoded literal (`transport/http.py:435-436`).

So the job boots at the declared floor and drives a **client → gateway → stdio downstream → back** round trip through `.github/probe/`.

Its isolation is the part that matters, because `_kill_orphan_processes` (`server.py:683-700`) SIGKILLs every `/proc` match among resolved configs:

- `HOME` + `XDG_CONFIG_HOME` redirected — load-bearing, since `--config` alone does not bound resolution (`load_manifest()` starts from the package-shipped manifest)
- `--policy` allowlisting only the probe — this is what actually bounds the kill set
- `--lock-dir`, `--config`, `--project`, port 3399, **never 3344**
- asserts `Gateway initialized: N/1 servers online`, with a comment recording that `skipped=106, policy_denied=106` is what a *correct* run looks like so the tripwire is not re-inverted
- `$!` captured, `trap`-cleaned

## Verification

```
install-smoke byte-identical to main:  True   (job block extracted and compared)
pytest                                 2277 passed, 3 skipped   (baseline 2276)
ruff check / format                    clean
mypy src/                              clean, 41 files
actionlint                             clean
FLOOR reaches the shell via env:       yes, never inlined into run:
live gateway on :3344                  healthy throughout
```

Reviewed by three advisor-board rounds at the plan stage before any code was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->