### PR TITLE
fix(P6CLEAN): de-flake the startup-pattern monitor test; close out v10 Phase 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `/health` payload and the `pmcp/{version}` User-Agent among them — report
   the wrong release.
 
+### Fixed
+- **The last outstanding item from `specs/phase-plans-v10.md` Phase 6 is closed
+  out.** `test_monitor_server_ready_on_startup_pattern`
+  (`tests/test_manifest.py`) asserted `job.status == "server_ready"` after a
+  fixed `await asyncio.sleep(0.3)`, racing the install monitor's pattern match
+  against the wall clock. It now `await`s `job._monitor_task` directly — the
+  monitor task returns as soon as it detects the startup pattern, so this is a
+  deterministic, event-driven wait with no timing dependency, matching the
+  idiom its sibling tests in the same class already use.
+
 ## [1.21.1] - 2026-08-01
 
 ### Fixed

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1771,11 +1771,14 @@ class TestMonitorInstall:
         manager = JobManager.get_instance()
         job_id = await manager.start_install(server_config, "linux")
 
-        # Wait for pattern detection
-        await asyncio.sleep(0.3)
-
+        # Wait deterministically for the monitor to detect the startup pattern
+        # and return, rather than racing a fixed wall-clock sleep against the
+        # subprocess. The monitor returns as soon as it matches, deliberately
+        # leaving the process alive for handoff.
         job = manager.get_job(job_id)
         assert job is not None
+        assert job._monitor_task is not None
+        await asyncio.wait_for(job._monitor_task, timeout=5.0)
         assert job.status == "server_ready"
 
         # Clean up - kill the process


### PR DESCRIPTION
Executes **v11 Phase 6 (P6CLEAN)** per `plans/phase-plan-v11-P6CLEAN.md`. Smallest phase in the roadmap.

## Change

`tests/test_manifest.py::test_monitor_server_ready_on_startup_pattern` raced a fixed `await asyncio.sleep(0.3)` against a subprocess. Replaced with the event-driven await:

```python
assert job._monitor_task is not None
await asyncio.wait_for(job._monitor_task, timeout=5.0)
```

This is **not a poll**. The monitor *returns* as soon as it matches the startup pattern (`manifest/installer.py:331-341`), deliberately leaving the process alive for handoff — so the `5.0` is a failure ceiling, not a wait. Three sibling tests already use this idiom (`:1679`, `:1708`, `:1730`); this matches them.

Measured: 0.3s floor → **0.05–0.06s**, five consecutive runs.

## What this closes

v10's Phase 6 is now fully closed out. Worth recording why this took a plan at all: **v10 named the wrong tests.** It listed `test_monitor_reads_stderr` and `test_monitor_keeps_last_20_lines` — both already fixed. The surviving racing sleep was in a third test v10 never mentioned. v11's line pointer was what was real.

The other v10 P6 item, `_tasks` registry eviction, was **already done** and correctly excluded from scope: `client/manager.py:507-512` (`_max_terminal_tasks`, oldest-first pruning), `:597` (done-callback `pop`), `tests/test_client_manager.py:1588` (regression test). An earlier draft claimed it was missing, having searched `tools/handlers.py` because that is where v10's *prose* pointed rather than where the code lives.

## Gateway acceptance

The plan required a real boot plus downstream call rather than taking the "too small to break" exemption — that reasoning is what shipped #111 dead on arrival, and `pyproject.toml:81` (`-m 'not live'`) means the suite baseline covers no live integration.

Run under full isolation (redirected `HOME`/`XDG_CONFIG_HOME`, `--policy` allowlisting only the fixture, `--lock-dir`, `--config`, spare port, fingerprint that cannot collide):

```
eager=0 lazy=1                     (fixture only)
gateway.invoke round trip          p6clean-pong:p6clean, ok:true
live gateway :3344                 healthy before and after
live child PID set                 unchanged
```

## Two plan assumptions that had gone stale

Both handled by falling back rather than forcing, and both are artifacts of this plan being written before P1 landed:

- `.claude/docs-catalog.json` is no longer `[]` — it carries content from the earlier plan merges, and no rescan helper exists at `.claude/skills/_shared/scaffold_docs_catalog.py`. Left untouched per the plan's own fallback.
- `## [Unreleased]` was not empty — P1 added a `### Changed` section. Appended `### Fixed` rather than assuming an empty section.

## Verification

```
asyncio.sleep in target function:  0
asyncio.wait_for in target function: 1
-k test_monitor:                   7/7 passed
target test x5:                    5/5, 0.05-0.06s each
pytest tests/ -q:                  2277 passed, 3 skipped
ruff check / format:               clean
mypy src/:                         clean, 41 files
```

Baseline is 2277 rather than 2276 because P1's drift test is already on this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->