### PR TITLE
feat(P5): manifest credential optionality — one predicate, seven gates

### DIFF
--- a/.claude/docs-catalog.json
+++ b/.claude/docs-catalog.json
@@ -1,26 +1,32 @@
 {
   "version": 1,
-  "last_updated": "2026-08-06T03:37:43+00:00",
+  "last_updated": "2026-08-06T06:22:47+00:00",
   "files": {
     "README.md": {
       "purpose": "root project README",
-      "touched_by_phases": []
+      "touched_by_phases": [
+        "P5"
+      ]
     },
     "CHANGELOG.md": {
       "purpose": "release changelog",
       "touched_by_phases": [
-        "P1"
+        "P1",
+        "P5"
       ]
     },
     "CONTRIBUTING.md": {
       "purpose": "contribution guidelines",
       "touched_by_phases": [
-        "P1"
+        "P1",
+        "P5"
       ]
     },
     "SECURITY.md": {
       "purpose": "security policy",
-      "touched_by_phases": []
+      "touched_by_phases": [
+        "P5"
+      ]
     },
     ".claude/plans/ticklish-inventing-stearns.md": {
       "purpose": "markdown document",

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ code_index.db
 
 # index-it-mcp local index cache
 .mcp-index/
+
+# claude-execute-phase orchestrator worktrees
+.claude/worktrees/
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Manifest credential optionality (`api_key_optional_when`).** A manifest
+  server entry can now name the `extra_env` variable (e.g. a self-hosted base
+  URL) whose presence makes its declared credential unnecessary, so reaching
+  a self-hosted endpoint no longer requires planting a placeholder secret like
+  `FIRECRAWL_API_KEY=self-hosted-no-auth` — which previously read as a real
+  credential to whoever found it. The field alone changes nothing: an operator
+  must separately supply the named variable via `extra_env` or a `server_env`
+  overlay patch before the credential relaxes, and a server cannot name its
+  own credential as its relaxer. Every one of the seven places that gate on
+  `requires_api_key` — eager startup, install/provision preflight, lifecycle
+  connect, provisioning, `pmcp secrets check`, capability discovery
+  (`gateway.catalog_search`/`gateway.request_capability`), and `pmcp init` —
+  now reads the effective requirement through one shared predicate, and every
+  unset, malformed, self-referencing, or placeholder (`${VAR}`) relaxer value
+  fails closed. Ships `firecrawl`'s `api_key_optional_when: ["FIRECRAWL_API_URL"]`
+  as the first entry using it — inert on its own for every existing install.
+  (Consiliency/pmcp#114)
+
 ### Changed
 - **The declared `mcp` floor was corrected from `>=1.0.0` to `>=1.8.0`, because
   `>=1.0.0` was never installable.** `client/manager.py` imports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,13 @@ my-server:
   requires_api_key: true          # Set to false if no API key needed
   env_var: "MY_SERVER_API_KEY"    # Required if requires_api_key is true
   env_instructions: "Get your API key from https://..."
+  # Optional: names of extra_env variables whose presence (e.g. a self-hosted
+  # base URL) makes the credential above unnecessary. Both parties must act —
+  # you declare the field here, and an operator must separately supply the
+  # named variable via extra_env or an overlay server_env patch — so the field
+  # alone never relaxes anything. An unset, self-referencing, or placeholder
+  # value fails closed and the credential stays required.
+  api_key_optional_when: ["MY_SERVER_BASE_URL"]
   auto_start: false               # Set to true for essential servers only
 ```
 

--- a/README.md
+++ b/README.md
@@ -946,14 +946,14 @@ servers:
 A server that supports a self-hosted, keyless deployment can declare which
 `extra_env` variable makes its credential optional via
 `api_key_optional_when`. Declaring the field alone changes nothing — an
-operator must separately supply that variable, either inline or via a
-`server_env` patch on a shipped entry:
+operator must separately supply that variable. The shipped `firecrawl` entry
+already declares `api_key_optional_when: ["FIRECRAWL_API_URL"]`, so supplying
+the URL is all an overlay needs to do — via a `server_env` patch, **not** a
+`servers:` block (`servers:` is whole-entry replace: a partial `firecrawl:`
+entry here would erase its command/install metadata and reset
+`requires_api_key` to its unset default, turning the credential gate off):
 
 ```yaml
-servers:
-  firecrawl:
-    api_key_optional_when: ["FIRECRAWL_API_URL"]
-
 server_env:
   firecrawl:
     FIRECRAWL_API_URL: "http://localhost:3002"

--- a/README.md
+++ b/README.md
@@ -672,6 +672,13 @@ Returns (if not already configured):
 }
 ```
 
+`requires_api_key` here reflects the **effective** requirement, not merely
+whether the entry declares one — a server whose manifest entry carries
+`api_key_optional_when` and whose named variable is set reports
+`requires_api_key: false` and no `auth_connect` recommendation, even though
+the underlying entry still has `requires_api_key: true`. See
+[Private manifest overlay](#private-manifest-overlay) below.
+
 ### Provisioning
 
 ```bash
@@ -935,6 +942,28 @@ servers:
     headers:
       Authorization: "Bearer ${MY_REMOTE_TOKEN}"
 ```
+
+A server that supports a self-hosted, keyless deployment can declare which
+`extra_env` variable makes its credential optional via
+`api_key_optional_when`. Declaring the field alone changes nothing — an
+operator must separately supply that variable, either inline or via a
+`server_env` patch on a shipped entry:
+
+```yaml
+servers:
+  firecrawl:
+    api_key_optional_when: ["FIRECRAWL_API_URL"]
+
+server_env:
+  firecrawl:
+    FIRECRAWL_API_URL: "http://localhost:3002"
+```
+
+Both parties must act — the manifest entry names the variable, and the
+operator supplies it — so no overlay can unilaterally relax a credential the
+entry never declared relaxable. A server naming its own credential as its own
+relaxer is ignored, and an unset, empty, or unexpanded `${VAR}` value fails
+closed: the credential stays required.
 
 Overlay loading is **fail-soft**: a missing file is skipped silently, and a
 malformed file or a single bad entry logs a warning and is skipped without

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,14 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
 - Hanging downstream tools consuming connections indefinitely (60 s request timeout)
 - Multiple gateway instances fighting over resources (fcntl singleton lock)
 - Reconnect storms from crashing downstream servers (per-server reconnect flag)
+- **Unilateral credential relaxation**: a manifest server's `requires_api_key`
+  can only be relaxed by a variable the entry itself names in
+  `api_key_optional_when` — an operator's overlay can supply that variable's
+  value, but cannot make a server's credential optional unless the manifest
+  entry already declared it relaxable. A server also cannot name its own
+  credential as its relaxer. Every unset, malformed, self-referencing, or
+  placeholder (`${VAR}`) relaxer value fails closed and the credential stays
+  required (Consiliency/pmcp#114).
 
 ### Known limitations
 

--- a/plans/phase-plan-v11-P5.md
+++ b/plans/phase-plan-v11-P5.md
@@ -657,8 +657,23 @@ uv run pytest tests/test_credential_child_env.py -v
 
 # 5. No pre-existing test moved — EXIT-STATUS BEARING (EC-P5-4).
 #    `git diff | grep -v` always exits 0 and proves nothing; this fails the build.
+#    RECORDED EXCEPTION (post-execution, board review finding 4):
+#    tests/test_manifest_provision.py is intentionally in this allowlist.
+#    Its module-level `load_manifest()` call had no HOME isolation and picked
+#    up this machine's real ~/.pmcp/manifest.yaml overlay (which independently
+#    patches firecrawl's extra_env with a real self-hosted URL). That overlay
+#    was always inert for gating purposes pre-P5 (requires_api_key never read
+#    extra_env), so the gap was invisible; once requires_api_key gating became
+#    extra_env-sensitive, test_provision_missing_api_key[firecrawl] started
+#    failing for reasons unrelated to the shipped manifest's own default
+#    behaviour (test_credential_optionality_e2e.py's shipped-manifest tests
+#    prove that default is unaffected). Fixed by loading via an explicit
+#    manifest_path, which applies no overlays — the officially documented
+#    no-overlay mode of load_manifest(). This is the ONLY pre-existing test
+#    file this phase modifies; the exception is scoped to this one file, not
+#    a general weakening of the filter.
 test "$(git diff --name-only main -- tests/ \
-  | grep -vcE '^tests/test_credential_(requirement|gates_startup|gates_handlers|predicate_guard|optionality_e2e|child_env|boot)\.py$')" -eq 0
+  | grep -vcE '^tests/test_credential_(requirement|gates_startup|gates_handlers|predicate_guard|optionality_e2e|child_env|boot)\.py$|^tests/test_manifest_provision\.py$')" -eq 0
 
 # 6. Full suite, lint, types (EC-P5-4)
 uv run pytest

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -382,6 +382,42 @@ Let a manifest entry express "credential required for the vendor endpoint, optio
 - evidence paths: `plans/phase-plan-v11-P5.md`
 - redaction posture: `metadata_only`
 
+### Post-execution amendments
+
+- **Consumer count revised from six (above) to SEVEN.** Execution
+  (`plans/phase-plan-v11-P5.md`) independently re-derived the enforcement
+  surface with two sweeps rather than trusting this section's count, because
+  the count had already drifted 4 → 5 → 6 across planning rounds — each
+  omission would have left one path still demanding the placeholder while
+  every other gate was fixed. Sweep 1 (`rg -c requires_api_key src/**/*.py`,
+  AST-classified into reads/writes/definitions) found the six consumers
+  listed above. Sweep 2 (an AST walk of every `ast.If` whose test mentions
+  `env_var` but not `requires_api_key`) found the seventh: `pmcp init`
+  (`src/pmcp/cli.py:1528`, `run_init`) gates on `if server.env_var:` alone —
+  it contains no `requires_api_key` token at all, which is exactly why a
+  token-only sweep never found it across six review rounds. The counting
+  method is recorded here so it stops moving; see
+  `plans/phase-plan-v11-P5.md`'s "Sweep 1" / "Sweep 2" for the full
+  methodology and the four producer sites (keyword *writes*) deliberately
+  excluded from the consumer count.
+- **`Produces` was incomplete.** This section lists only `IF-0-P5-1`.
+  Execution additionally froze `IF-0-P5-2` (`ServerConfig.api_key_optional_when`
+  parsing), `IF-0-P5-3` (`_get_server_env_metadata`'s effective-value
+  contract, feeding the ninth downstream reporting sites unchanged), and
+  `IF-0-P5-4` (the child-environment consistency invariant — a relaxed gate
+  must imply the spawned child actually receives the relaxer, not merely that
+  the gate opened). `IF-0-P5-4` closes a distinct security gap found during
+  planning: a predicate that read `os.environ` instead of the manifest's
+  `extra_env` would relax a gate for a variable `sanitized_subprocess_env`
+  then strips before the child spawns, silently reaching the vendor endpoint
+  unauthenticated.
+- **EC-P5-3's "all six consumers" wording is stale.** The phase plan's
+  EC-P5-3 (`plans/phase-plan-v11-P5.md`) correctly enumerates and proves all
+  seven, including `pmcp init`.
+- No interface freeze in `plans/phase-plan-v11-P5.md` itself proved wrong
+  during execution — all four (`IF-0-P5-1` through `IF-0-P5-4`) shipped with
+  the signatures and semantics as frozen.
+
 ---
 
 ### Phase 6 — Deferred v10 robustness remnants (P6CLEAN)

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -1528,20 +1528,32 @@ async def run_init(args: argparse.Namespace) -> None:
             if server.env_var:
                 from pmcp.manifest.loader import (
                     credential_lookup_keys,
+                    credential_requirement,
                     credential_storage_key,
                 )
 
-                found_key = next(
-                    (k for k in credential_lookup_keys(server) if os.environ.get(k)),
-                    None,
-                )
-                storage_key = credential_storage_key(server) or server.env_var
-                if found_key:
-                    print(f"    Found {found_key} in environment")
+                requirement = credential_requirement(server)
+                if requirement.required:
+                    found_key = next(
+                        (
+                            k
+                            for k in credential_lookup_keys(server)
+                            if os.environ.get(k)
+                        ),
+                        None,
+                    )
+                    storage_key = credential_storage_key(server) or server.env_var
+                    if found_key:
+                        print(f"    Found {found_key} in environment")
+                    else:
+                        print(
+                            f"    Note: store the credential with "
+                            f"`pmcp secrets set {storage_key} <value>`"
+                        )
                 else:
                     print(
-                        f"    Note: store the credential with "
-                        f"`pmcp secrets set {storage_key} <value>`"
+                        f"    No credential needed — {requirement.relaxed_by} "
+                        f"selects a self-hosted endpoint"
                     )
 
             selected_servers[name] = config

--- a/src/pmcp/cli_commands/secrets.py
+++ b/src/pmcp/cli_commands/secrets.py
@@ -15,7 +15,11 @@ from pmcp.env_store import (
     validate_env_var_name,
     write_env_file,
 )
-from pmcp.manifest.loader import credential_storage_key, load_manifest
+from pmcp.manifest.loader import (
+    credential_storage_key,
+    load_manifest,
+    requires_credential,
+)
 from pmcp.remote_auth import collect_remote_header_env_vars
 from pmcp.types import LocalMcpServerConfig, RemoteMcpServerConfig
 
@@ -92,8 +96,8 @@ def _extract_required_keys(
         credential_var: str | None = None
         if (
             manifest_server
-            and manifest_server.requires_api_key
             and manifest_server.env_var
+            and requires_credential(manifest_server, child_env=cfg.config.env)
         ):
             credential_var = manifest_server.env_var
             storage_key = credential_storage_key(manifest_server) or credential_var
@@ -102,12 +106,28 @@ def _extract_required_keys(
             if storage_key != credential_var:
                 credential_fallbacks[storage_key] = credential_var
 
+        # Manifest-supplied non-secrets (e.g. a self-hosted base URL from
+        # extra_env) are not credentials the operator must store — reported
+        # missing here they'd flip `secrets check`'s ok to false for a value
+        # that is already present via the manifest, not the secret store.
+        # Skipped only when the configured env_map still carries the exact
+        # manifest literal; a `.mcp.json` override to a different value (or a
+        # genuine ${VAR} indirection, handled by the ENV_REF_PATTERN branch
+        # below) is not skipped.
+        manifest_extra_env = getattr(manifest_server, "extra_env", None) or {}
+
         for env_key, env_value in env_map.items():
             # The credential var is required via the manifest above; don't re-add
             # its bare runtime name (which would bypass the storage-key mapping).
-            if env_key != credential_var:
-                server_keys.add(env_key)
-                all_keys.add(env_key)
+            if env_key == credential_var:
+                continue
+            if (
+                env_key in manifest_extra_env
+                and manifest_extra_env[env_key] == env_value
+            ):
+                continue
+            server_keys.add(env_key)
+            all_keys.add(env_key)
 
             for pattern_match in ENV_REF_PATTERN.finditer(env_value):
                 var_name = pattern_match.group(1) or pattern_match.group(2)

--- a/src/pmcp/config/loader.py
+++ b/src/pmcp/config/loader.py
@@ -1014,8 +1014,22 @@ def _eager_requires_credential(
     Local import avoids a circular import: ``pmcp.manifest`` (via its
     ``__init__.py``) transitively imports ``pmcp.env_store``, which imports
     ``find_project_root`` from this module.
+
+    A *configured* entry that is itself remote never relaxes, regardless of
+    the manifest's own transport: extra_env is carried to a spawned local
+    subprocess's env, and a remote connection has no such subprocess. Without
+    this, ``_local_env`` returns ``None`` for a remote ``config``, falling
+    back to the manifest's own (possibly usable) ``extra_env`` and relaxing a
+    credential that can never actually reach the remote connection
+    (Consiliency/pmcp#114 board review finding 1, remote-configured-duplicate
+    variant — the same class as ``credential_requirement``'s own
+    manifest-``url`` clause, but keyed on the CONFIGURED entry's transport,
+    which the predicate cannot see).
     """
     from pmcp.manifest.loader import requires_credential
+
+    if isinstance(config.config, RemoteMcpServerConfig):
+        return bool(getattr(manifest_server, "requires_api_key", False))
 
     return requires_credential(manifest_server, child_env=_local_env(config))
 
@@ -1070,7 +1084,10 @@ def resolve_startup_configs(
             and manifest_server
             and _eager_requires_credential(manifest_server, config)
         ):
-            from pmcp.manifest.loader import credential_lookup_keys
+            from pmcp.manifest.loader import (
+                credential_lookup_keys,
+                is_usable_credential_value,
+            )
 
             env_var = manifest_server.env_var
             # Auth is available if the credential is present under any of the
@@ -1078,7 +1095,26 @@ def resolve_startup_configs(
             # checking only the runtime env_var would skip a namespaced-only
             # credential as MISSING_AUTH.
             lookup_keys = credential_lookup_keys(manifest_server)
-            if lookup_keys and not any(is_auth_available(key) for key in lookup_keys):
+            auth_available = lookup_keys and any(
+                is_auth_available(key) for key in lookup_keys
+            )
+            # is_auth_available only checks process env / PMCP secret stores
+            # BY NAME — it cannot see a concrete credential the user wrote
+            # directly into a *configured* (.mcp.json) entry's own env block.
+            # A usable (non-empty, non-placeholder) literal there satisfies it
+            # too (Consiliency/pmcp#114 board review finding 2). Scoped to
+            # source == "configured" only: a manifest-only config's env is
+            # ALSO populated from os.environ by _manifest_server_to_config
+            # (unconditionally, regardless of any is_auth_available mock), so
+            # checking it here for manifest-sourced entries would silently
+            # re-derive the same os.environ read through a second path and
+            # defeat a caller's deliberate is_auth_available override.
+            if not auth_available and source == "configured":
+                own_env = _local_env(config) or {}
+                auth_available = any(
+                    is_usable_credential_value(own_env.get(key)) for key in lookup_keys
+                )
+            if lookup_keys and not auth_available:
                 skipped.append(
                     StartupSkip(
                         name=config.name,

--- a/src/pmcp/config/loader.py
+++ b/src/pmcp/config/loader.py
@@ -1122,6 +1122,12 @@ def resolve_startup_configs(
             config,
             eager=config.name in enabled and config.name not in disabled,
             source="configured",
+            # A .mcp.json entry that duplicates a manifest server must still
+            # be credential-gated — omitting manifest_server here let a
+            # genuinely-required, credential-less configured duplicate reach
+            # eager_configs with no MISSING_AUTH check at all (Consiliency/pmcp#114
+            # board review finding 1).
+            manifest_server=manifest_by_name.get(config.name),
         )
 
     for name, server in manifest_by_name.items():

--- a/src/pmcp/config/loader.py
+++ b/src/pmcp/config/loader.py
@@ -990,6 +990,36 @@ def manifest_server_to_config(server: "ManifestServerConfig") -> ResolvedServerC
     return _manifest_server_to_config(server, os.environ.get)
 
 
+def _local_env(config: ResolvedServerConfig) -> dict[str, str] | None:
+    """The post-merge child environment for *config*, or ``None``.
+
+    Returns ``config.config.env`` for a local stdio server config — the value
+    the spawned child will actually receive after ``_merge_manifest_defaults``
+    — or ``None`` for a remote server or when no env is set. Passed as
+    ``credential_requirement``'s ``child_env`` so a configured duplicate that
+    overrides the manifest's ``extra_env`` (e.g. with an empty string or an
+    unexpanded placeholder) is judged on the value the child actually gets,
+    not on the manifest's declared default (Consiliency/pmcp#114).
+    """
+    if isinstance(config.config, LocalMcpServerConfig):
+        return config.config.env
+    return None
+
+
+def _eager_requires_credential(
+    manifest_server: "ManifestServerConfig", config: ResolvedServerConfig
+) -> bool:
+    """Whether *manifest_server* still needs a credential to start eagerly.
+
+    Local import avoids a circular import: ``pmcp.manifest`` (via its
+    ``__init__.py``) transitively imports ``pmcp.env_store``, which imports
+    ``find_project_root`` from this module.
+    """
+    from pmcp.manifest.loader import requires_credential
+
+    return requires_credential(manifest_server, child_env=_local_env(config))
+
+
 def resolve_startup_configs(
     configured_configs: Sequence[ResolvedServerConfig],
     manifest_servers: Mapping[str, "ManifestServerConfig"]
@@ -1035,7 +1065,11 @@ def resolve_startup_configs(
             classified_names.add(config.name)
             return
 
-        if eager and manifest_server and manifest_server.requires_api_key:
+        if (
+            eager
+            and manifest_server
+            and _eager_requires_credential(manifest_server, config)
+        ):
             from pmcp.manifest.loader import credential_lookup_keys
 
             env_var = manifest_server.env_var

--- a/src/pmcp/manifest/installer.py
+++ b/src/pmcp/manifest/installer.py
@@ -13,7 +13,11 @@ from typing import Literal
 
 from pmcp.env_store import resolve_scope_path, sanitized_subprocess_env
 from pmcp.manifest.environment import Platform
-from pmcp.manifest.loader import ServerConfig, credential_lookup_keys
+from pmcp.manifest.loader import (
+    ServerConfig,
+    credential_lookup_keys,
+    requires_credential,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -544,7 +548,7 @@ async def check_api_key(server_config: ServerConfig) -> None:
     Raises:
         MissingApiKeyError: If API key is required but not set
     """
-    if not server_config.requires_api_key:
+    if not requires_credential(server_config):
         return
 
     env_var = server_config.env_var

--- a/src/pmcp/manifest/loader.py
+++ b/src/pmcp/manifest/loader.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -59,6 +61,12 @@ class ServerConfig:
     # FIRECRAWL_API_URL). Secrets belong in env_var/secret_key, which are resolved
     # from the env store and always win over a colliding extra_env key.
     extra_env: dict[str, str] = field(default_factory=dict)
+    # Names of extra_env variables whose presence (with a usable value) relaxes
+    # requires_api_key for this server — e.g. a self-hosted base URL that makes
+    # the vendor credential unnecessary. See credential_requirement() below for
+    # the full contract (Consiliency/pmcp#114). Empty by default, which is
+    # today's behaviour byte-for-byte: requires_api_key alone still gates.
+    api_key_optional_when: list[str] = field(default_factory=list)
     auto_start: bool = False
     transport: ServerTransport = "local"
     url: str | None = None
@@ -110,6 +118,106 @@ def credential_lookup_keys(server: Any) -> list[str]:
         if key and key not in keys:
             keys.append(key)
     return keys
+
+
+_PLACEHOLDER_RE = re.compile(r"^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$")
+
+
+def _is_usable_relaxer_value(value: Any) -> bool:
+    """True when *value* is a real, expanded value — not empty and not an
+    unexpanded ``${VAR}``/``$VAR`` placeholder token.
+
+    Local stdio env is passed to child processes verbatim, with no shell
+    expansion (see config/loader.py's env-merge comments), so a literal
+    ``${FIRECRAWL_API_URL}`` reaching the child is a dead string, not a real
+    URL, and must not relax a credential gate.
+    """
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if _PLACEHOLDER_RE.match(stripped):
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class CredentialRequirement:
+    """Result of evaluating whether *server* still needs a credential.
+
+    Frozen per IF-0-P5-1 (plans/phase-plan-v11-P5.md) — every field name and
+    meaning below is depended on unchanged by all seven gate consumers.
+    """
+
+    required: bool  # effective requirement after relaxation
+    declared: bool  # server.requires_api_key as shipped
+    relaxed_by: str | None  # extra_env var name that relaxed it, else None
+
+
+def credential_requirement(
+    server: Any, *, child_env: Mapping[str, str] | None = None
+) -> CredentialRequirement:
+    """Evaluate the effective credential requirement for *server*.
+
+    ``server`` is duck-typed over ``requires_api_key``, ``env_var``,
+    ``secret_key``, ``extra_env``, and ``api_key_optional_when`` — this accepts
+    manifest ``ServerConfig``, discovered-server configs, and ``None`` (treated
+    as not-required).
+
+    This function **never reads ``os.environ``**, the secret store, per-request
+    arguments, or a URL's shape — see the env-strip inversion analysis in
+    plans/phase-plan-v11-P5.md. ``sanitized_subprocess_env`` strips managed
+    secret keys from ``os.environ`` before a child process is spawned, so a
+    predicate reading ``os.environ`` could relax a gate for a variable the
+    child never actually receives — silently redirecting a "self-hosted"
+    server to the vendor endpoint with no credential. Restricting the source to
+    ``extra_env`` (and the caller-supplied ``child_env``, which must itself
+    trace back to ``extra_env``, never to ``os.environ``) keeps "the gate
+    relaxed" and "the child receives the variable" a structural invariant.
+
+    ``child_env``, when given, must be the post-merge environment the child
+    process will actually receive (e.g. ``ResolvedServerConfig.config.env``
+    after ``_merge_manifest_defaults``) — **never** ``os.environ`` or a copy of
+    it. Passing ``os.environ`` is a contract violation (guarded against in
+    ``tests/test_credential_predicate_guard.py``). When ``child_env`` is
+    ``None``, the source is ``server.extra_env``, which is correct for every
+    manifest-only call site because the two are identical by construction
+    there.
+    """
+    declared = bool(getattr(server, "requires_api_key", False)) if server else False
+    if not declared:
+        return CredentialRequirement(required=False, declared=False, relaxed_by=None)
+
+    own_env_var = getattr(server, "env_var", None)
+    own_secret_key = getattr(server, "secret_key", None)
+    optional_when = getattr(server, "api_key_optional_when", None) or []
+
+    if child_env is not None:
+        source: Mapping[str, str] = child_env
+    else:
+        source = getattr(server, "extra_env", None) or {}
+
+    for candidate in optional_when:
+        if candidate == own_env_var or candidate == own_secret_key:
+            # Self-relaxation is impossible — also enforced at parse time, but
+            # a duck-typed non-ServerConfig object may not have gone through
+            # that parse step.
+            continue
+        value = source.get(candidate) if hasattr(source, "get") else None
+        if _is_usable_relaxer_value(value):
+            return CredentialRequirement(
+                required=False, declared=True, relaxed_by=candidate
+            )
+
+    return CredentialRequirement(required=True, declared=True, relaxed_by=None)
+
+
+def requires_credential(
+    server: Any, *, child_env: Mapping[str, str] | None = None
+) -> bool:
+    """Convenience wrapper: ``credential_requirement(server, ...).required``."""
+    return credential_requirement(server, child_env=child_env).required
 
 
 # Category taxonomy used by Manifest.get_category_summary() and get_servers_in_category()
@@ -390,6 +498,43 @@ def _parse_extra_env(
     return parsed
 
 
+def _parse_api_key_optional_when(
+    name: str, raw: Any, env_var: str | None, secret_key: str | None
+) -> list[str]:
+    """Parse the ``api_key_optional_when`` list, fail-soft and fail-closed.
+
+    Absent key -> ``[]`` (today's behaviour unchanged). A non-list value drops
+    to ``[]`` with a warning. Non-string members are dropped. A member equal to
+    the server's own ``env_var`` or ``secret_key`` is dropped with a warning —
+    self-relaxation is impossible by construction (a server cannot declare its
+    own credential as the thing that makes the credential unnecessary).
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        logger.warning(
+            f"Ignoring 'api_key_optional_when' for server '{name}': not a list"
+        )
+        return []
+
+    parsed: list[str] = []
+    for item in raw:
+        if not isinstance(item, str) or not item:
+            logger.warning(
+                f"Skipping non-string 'api_key_optional_when' entry for server '{name}'"
+            )
+            continue
+        if item == env_var or item == secret_key:
+            logger.warning(
+                f"Server '{name}' names its own credential variable "
+                f"('{item}') in 'api_key_optional_when'; ignoring — a "
+                f"credential cannot relax itself"
+            )
+            continue
+        parsed.append(item)
+    return parsed
+
+
 def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
     """Parse a server config from raw YAML data."""
     install_data = data.get("install", {})
@@ -405,6 +550,11 @@ def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
     )
 
     extra_env = _parse_extra_env(name, data.get("extra_env"))
+    env_var = data.get("env_var")
+    secret_key = data.get("secret_key")
+    api_key_optional_when = _parse_api_key_optional_when(
+        name, data.get("api_key_optional_when"), env_var, secret_key
+    )
 
     raw_discovery_metadata = data.get("discovery_metadata", {})
     if not isinstance(raw_discovery_metadata, dict):
@@ -421,10 +571,11 @@ def _parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
         command=data.get("command", ""),
         args=data.get("args", []),
         requires_api_key=data.get("requires_api_key", False),
-        env_var=data.get("env_var"),
-        secret_key=data.get("secret_key"),
+        env_var=env_var,
+        secret_key=secret_key,
         env_instructions=data.get("env_instructions"),
         extra_env=extra_env,
+        api_key_optional_when=api_key_optional_when,
         auto_start=data.get("auto_start", False),
         transport=transport,
         url=data.get("url"),

--- a/src/pmcp/manifest/loader.py
+++ b/src/pmcp/manifest/loader.py
@@ -123,14 +123,18 @@ def credential_lookup_keys(server: Any) -> list[str]:
 _PLACEHOLDER_RE = re.compile(r"^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$")
 
 
-def _is_usable_relaxer_value(value: Any) -> bool:
+def is_usable_credential_value(value: Any) -> bool:
     """True when *value* is a real, expanded value — not empty and not an
     unexpanded ``${VAR}``/``$VAR`` placeholder token.
 
     Local stdio env is passed to child processes verbatim, with no shell
     expansion (see config/loader.py's env-merge comments), so a literal
     ``${FIRECRAWL_API_URL}`` reaching the child is a dead string, not a real
-    URL, and must not relax a credential gate.
+    URL, and must not relax a credential gate. Public (not underscore-
+    prefixed) because it is also used to recognize a concrete credential
+    literal placed directly in a configured entry's own env block
+    (Consiliency/pmcp#114 board review finding 2) — the same "is this a real
+    value" rule applies to both a relaxer and a credential.
     """
     if not isinstance(value, str):
         return False
@@ -217,7 +221,7 @@ def credential_requirement(
             # that parse step.
             continue
         value = source.get(candidate) if hasattr(source, "get") else None
-        if _is_usable_relaxer_value(value):
+        if is_usable_credential_value(value):
             return CredentialRequirement(
                 required=False, declared=True, relaxed_by=candidate
             )

--- a/src/pmcp/manifest/loader.py
+++ b/src/pmcp/manifest/loader.py
@@ -184,10 +184,22 @@ def credential_requirement(
     ``None``, the source is ``server.extra_env``, which is correct for every
     manifest-only call site because the two are identical by construction
     there.
+
+    A server with a ``url`` (remote/HTTP transport) is never relaxed, even if
+    ``api_key_optional_when`` names a variable present in ``extra_env``.
+    ``extra_env`` is carried to a spawned local subprocess's environment; a
+    remote connection has no such subprocess and authenticates via headers,
+    so a relaxer set there can never actually reach the connection. Without
+    this, a remote entry with a declared relaxer would be classified
+    not-required and connected to the vendor URL with no Authorization
+    header (Consiliency/pmcp#114 board review finding 2).
     """
     declared = bool(getattr(server, "requires_api_key", False)) if server else False
     if not declared:
         return CredentialRequirement(required=False, declared=False, relaxed_by=None)
+
+    if getattr(server, "url", None):
+        return CredentialRequirement(required=True, declared=True, relaxed_by=None)
 
     own_env_var = getattr(server, "env_var", None)
     own_secret_key = getattr(server, "secret_key", None)

--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -603,6 +603,12 @@ servers:
     requires_api_key: true
     env_var: "FIRECRAWL_API_KEY"
     env_instructions: "Set FIRECRAWL_API_KEY from https://www.firecrawl.dev"
+    # A self-hosted firecrawl deployment needs no vendor credential. Declaring
+    # FIRECRAWL_API_URL as the relaxer requires the operator to also supply it
+    # (via extra_env or an overlay server_env patch) before the gate relaxes —
+    # shipping this line alone changes nothing for an existing install.
+    # Consiliency/pmcp#114
+    api_key_optional_when: ["FIRECRAWL_API_URL"]
 
   tavily:
     description: "Tavily MCP - live web search and extraction tuned for AI workflows"

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -159,6 +159,7 @@ from pmcp.manifest.loader import (
     ServerConfig,
     credential_lookup_keys,
     credential_storage_key,
+    requires_credential,
 )
 
 logger = logging.getLogger(__name__)
@@ -3197,7 +3198,7 @@ class GatewayTools:
                     ),
                 )
 
-            if server_config.requires_api_key and server_config.env_var:
+            if requires_credential(server_config) and server_config.env_var:
                 auth_env_options = self._auth_env_options(
                     server_name, server_config.env_var
                 )
@@ -3358,11 +3359,19 @@ class GatewayTools:
         manifest: Manifest,
         configured_servers: dict[str, ResolvedServerConfig],
     ) -> tuple[bool, str | None, str | None]:
-        """Get API-key metadata for a server candidate."""
+        """Get API-key metadata for a server candidate.
+
+        The first element is the *effective* requirement
+        (``requires_credential``), not the raw declared ``requires_api_key`` —
+        a relaxed server reports no key required here even though it still
+        carries ``env_var``/``env_instructions`` unchanged, so
+        ``gateway.auth_connect`` still works for an operator who later wants a
+        real key (IF-0-P5-3).
+        """
         manifest_server = manifest.get_server(server_name)
         if manifest_server:
             return (
-                manifest_server.requires_api_key,
+                requires_credential(manifest_server),
                 manifest_server.env_var,
                 manifest_server.env_instructions,
             )
@@ -4055,7 +4064,7 @@ class GatewayTools:
             )
 
         # Check API key if required
-        if server_config.requires_api_key and server_config.env_var:
+        if requires_credential(server_config) and server_config.env_var:
             auth_env_options = self._auth_env_options(
                 server_name, server_config.env_var
             )

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -159,6 +159,7 @@ from pmcp.manifest.loader import (
     ServerConfig,
     credential_lookup_keys,
     credential_storage_key,
+    is_usable_credential_value,
     requires_credential,
 )
 
@@ -2905,25 +2906,54 @@ class GatewayTools:
         never credential-checked at all here — `manifest_server` was always
         `None` for this path, so a genuinely-required server with no
         credential reached `ensure_connected`/`connect_server` unauthenticated
-        (Consiliency/pmcp#114 board review finding 1). Judges the manifest
-        server's requirement against *configured*'s actual child env (a
-        `.mcp.json` override wins over the manifest default, same as every
-        other consumer). Returns `(manifest_server, auth_env_options)` when
-        the credential is still required and unavailable, else `None`.
+        (Consiliency/pmcp#114 board review finding 1). Returns
+        `(manifest_server, auth_env_options)` when the credential is still
+        required and unavailable, else `None`.
         """
         manifest_server = load_manifest().get_server(server_name)
         if not manifest_server or not manifest_server.env_var:
             return None
-        child_env = (
-            configured.config.env
-            if isinstance(configured.config, LocalMcpServerConfig)
-            else None
-        )
-        if not requires_credential(manifest_server, child_env=child_env):
+
+        if isinstance(configured.config, RemoteMcpServerConfig):
+            # extra_env is carried to a spawned local subprocess's env; a
+            # remote connection has no such subprocess, so a relaxer can
+            # never actually reach it no matter what the manifest declares
+            # (board review finding 1, remote-configured-duplicate variant:
+            # loader.py's "never relax a remote server" clause checks the
+            # MANIFEST server's url, which can be None while the CONFIGURED
+            # duplicate is itself remote — that combination must still fail
+            # closed). Judge only the declared requirement, ignoring any
+            # relaxer.
+            required = bool(manifest_server.requires_api_key)
+        else:
+            child_env = (
+                configured.config.env
+                if isinstance(configured.config, LocalMcpServerConfig)
+                else None
+            )
+            required = requires_credential(manifest_server, child_env=child_env)
+
+        if not required:
             return None
+
         auth_env_options = self._auth_env_options(server_name, manifest_server.env_var)
         if self._check_any_api_key_available(auth_env_options):
             return None
+
+        # _check_any_api_key_available only checks process env and the PMCP
+        # secret stores BY VARIABLE NAME — it cannot see a concrete
+        # credential the user wrote directly into the configured entry's own
+        # `env` block (board review finding 2). An empty string or
+        # unexpanded `${VAR}` placeholder does NOT satisfy it — same
+        # usability rule as a relaxer value.
+        if (
+            isinstance(configured.config, LocalMcpServerConfig)
+            and configured.config.env
+        ):
+            for key in auth_env_options:
+                if is_usable_credential_value(configured.config.env.get(key)):
+                    return None
+
         return (manifest_server, auth_env_options)
 
     def _write_secret(self, scope: str, key: str, value: str) -> Path:
@@ -3436,19 +3466,31 @@ class GatewayTools:
         ``config.env``, not the manifest's bare ``extra_env`` — passed as
         ``child_env`` so an override (e.g. an empty or placeholder value in
         ``.mcp.json``) is judged correctly instead of always reading the
-        manifest default (Consiliency/pmcp#114 board review finding 1).
+        manifest default (Consiliency/pmcp#114 board review finding 1). A
+        configured duplicate that is itself REMOTE never relaxes, regardless
+        of the manifest's own transport — extra_env cannot reach an HTTP
+        connection, so relaxation is judged on the declared requirement only
+        (board review finding 1, remote variant).
         """
         manifest_server = manifest.get_server(server_name)
         if manifest_server:
             configured = configured_servers.get(server_name)
-            child_env = (
-                configured.config.env
-                if configured is not None
-                and isinstance(configured.config, LocalMcpServerConfig)
-                else None
-            )
+            if configured is not None and isinstance(
+                configured.config, RemoteMcpServerConfig
+            ):
+                requires_api_key = bool(manifest_server.requires_api_key)
+            else:
+                child_env = (
+                    configured.config.env
+                    if configured is not None
+                    and isinstance(configured.config, LocalMcpServerConfig)
+                    else None
+                )
+                requires_api_key = requires_credential(
+                    manifest_server, child_env=child_env
+                )
             return (
-                requires_credential(manifest_server, child_env=child_env),
+                requires_api_key,
                 manifest_server.env_var,
                 manifest_server.env_instructions,
             )

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -2895,6 +2895,37 @@ class GatewayTools:
             return ["api_key", "subscription_token"]
         return ["api_key"]
 
+    def _configured_duplicate_missing_credential(
+        self, server_name: str, configured: ResolvedServerConfig
+    ) -> tuple[ServerConfig, list[str]] | None:
+        """Credential gate for a *configured* (.mcp.json) entry that also
+        matches a manifest server.
+
+        A `.mcp.json` entry duplicating a manifest server was previously
+        never credential-checked at all here — `manifest_server` was always
+        `None` for this path, so a genuinely-required server with no
+        credential reached `ensure_connected`/`connect_server` unauthenticated
+        (Consiliency/pmcp#114 board review finding 1). Judges the manifest
+        server's requirement against *configured*'s actual child env (a
+        `.mcp.json` override wins over the manifest default, same as every
+        other consumer). Returns `(manifest_server, auth_env_options)` when
+        the credential is still required and unavailable, else `None`.
+        """
+        manifest_server = load_manifest().get_server(server_name)
+        if not manifest_server or not manifest_server.env_var:
+            return None
+        child_env = (
+            configured.config.env
+            if isinstance(configured.config, LocalMcpServerConfig)
+            else None
+        )
+        if not requires_credential(manifest_server, child_env=child_env):
+            return None
+        auth_env_options = self._auth_env_options(server_name, manifest_server.env_var)
+        if self._check_any_api_key_available(auth_env_options):
+            return None
+        return (manifest_server, auth_env_options)
+
     def _write_secret(self, scope: str, key: str, value: str) -> Path:
         """Persist a secret in PMCP env storage."""
         return set_env_value(scope, key, value, self._project_root)
@@ -3176,6 +3207,38 @@ class GatewayTools:
                         missing_env_vars=missing_env_vars,
                     ),
                 )
+            # Same class of bug as the provision() and startup-resolution
+            # fixes (Consiliency/pmcp#114 board review finding 1): a
+            # configured duplicate of a manifest server was never
+            # credential-gated here at all.
+            credential_gap = self._configured_duplicate_missing_credential(
+                server_name, configured
+            )
+            if credential_gap:
+                manifest_server, auth_env_options = credential_gap
+                env_names = ", ".join(auth_env_options)
+                return (
+                    None,
+                    self._lifecycle_output(
+                        ok=False,
+                        server=server_name,
+                        action=action,
+                        prior_status=prior_status,
+                        message=(
+                            f"Server '{server_name}' requires authentication. "
+                            f"Set one of: {env_names}"
+                        ),
+                        errors=[
+                            f"Missing authentication environment variable for '{server_name}': {env_names}"
+                        ],
+                        missing_env_vars=auth_env_options,
+                        auth_state="missing_auth",
+                        auth_event="missing_credential",
+                        auth_methods=self._auth_methods_for_server(server_name),
+                        auth_metadata=self._auth_metadata_for_server(manifest_server),
+                        next_step=f"gateway.auth_connect(server_name='{server_name}')",
+                    ),
+                )
             return (configured, None)
 
         manifest = load_manifest()
@@ -3367,11 +3430,25 @@ class GatewayTools:
         carries ``env_var``/``env_instructions`` unchanged, so
         ``gateway.auth_connect`` still works for an operator who later wants a
         real key (IF-0-P5-3).
+
+        A server name present in *configured_servers* is a configured
+        duplicate: the child env it will actually receive is that entry's
+        ``config.env``, not the manifest's bare ``extra_env`` — passed as
+        ``child_env`` so an override (e.g. an empty or placeholder value in
+        ``.mcp.json``) is judged correctly instead of always reading the
+        manifest default (Consiliency/pmcp#114 board review finding 1).
         """
         manifest_server = manifest.get_server(server_name)
         if manifest_server:
+            configured = configured_servers.get(server_name)
+            child_env = (
+                configured.config.env
+                if configured is not None
+                and isinstance(configured.config, LocalMcpServerConfig)
+                else None
+            )
             return (
-                requires_credential(manifest_server),
+                requires_credential(manifest_server, child_env=child_env),
                 manifest_server.env_var,
                 manifest_server.env_instructions,
             )
@@ -3977,6 +4054,33 @@ class GatewayTools:
                     missing_env_vars=missing_env_vars,
                     auth_state="missing_auth",
                     auth_methods=self._auth_methods_for_server(server_name),
+                    next_step=f"gateway.auth_connect(server_name='{server_name}')",
+                    update_warning=update_warning,
+                    feedback_hint=self._feedback_hint(),
+                )
+            credential_gap = self._configured_duplicate_missing_credential(
+                server_name, configured
+            )
+            if credential_gap:
+                manifest_server, auth_env_options = credential_gap
+                return ProvisionOutput(
+                    ok=False,
+                    server=server_name,
+                    status="failed",
+                    message=(
+                        f"Server '{server_name}' requires authentication. "
+                        f"Set one of: {', '.join(auth_env_options)}"
+                    ),
+                    needs_api_key=True,
+                    env_var=manifest_server.env_var,
+                    env_instructions=manifest_server.env_instructions,
+                    auth_required=True,
+                    auth_mode="api_key",
+                    auth_methods=self._auth_methods_for_server(server_name),
+                    alternative_env_vars=auth_env_options,
+                    missing_env_vars=auth_env_options,
+                    auth_state="missing_auth",
+                    auth_metadata=self._auth_metadata_for_server(manifest_server),
                     next_step=f"gateway.auth_connect(server_name='{server_name}')",
                     update_warning=update_warning,
                     feedback_hint=self._feedback_hint(),

--- a/tests/test_credential_boot.py
+++ b/tests/test_credential_boot.py
@@ -1,0 +1,292 @@
+"""P5 SL-4.7: live spare-port boot proof for credential optionality.
+
+Boots a second, fully isolated PMCP gateway on a spare port (never :3344,
+where the operator's live gateway runs) and proves IF-0-P5-4 on a real
+spawned child process: a manifest-only server declaring
+`api_key_optional_when` starts EAGERLY with no credential set anywhere, and
+`/proc/<pid>/environ` shows the relaxer present and the credential var
+absent.
+
+Isolation recipe copied verbatim from P6CLEAN's verified fix (commit
+cbe98be, `plans/phase-plan-v11-p6clean.md`) — do not re-derive it. Two
+mistakes are baked in as regression guards below: `--config` alone does NOT
+bound resolution (the shipped manifest layers in additively), and redirected
+`HOME` alone is ALSO not sufficient on its own to prove isolation — the
+`--policy` allowlist is what actually narrows the kill set
+(`_kill_orphan_processes`, `src/pmcp/server.py:683-700`, fed by
+`resolution.lazy_configs + resolution.eager_configs`, `server.py:604`).
+
+Marked `@pytest.mark.live` — excluded from the default `-m 'not live'` run
+(`pyproject.toml`). Run explicitly:
+    uv run pytest -m live tests/test_credential_boot.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIVE_GATEWAY_PORT = 3344  # NEVER boot the test fixture on this port.
+SPARE_PORT = 38345  # Distinct from P6CLEAN's 38344 to avoid any collision.
+
+FIXTURE_SERVER_SRC = """\
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("p5-fixture")
+
+
+@mcp.tool()
+def ping(value: str) -> str:
+    return f"p5-pong:{value}"
+
+
+if __name__ == "__main__":
+    mcp.run()
+"""
+
+
+def _live_gateway_pid() -> str | None:
+    """PID listening on :3344, resolved from the socket — never by name-match
+    (pgrep -f self-matches the invoking shell's command line)."""
+    result = subprocess.run(
+        ["ss", "-ltnpH", f"sport = :{LIVE_GATEWAY_PORT}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    match = re.search(r"pid=(\d+)", result.stdout)
+    return match.group(1) if match else None
+
+
+def _children_of(pid: str) -> list[str]:
+    result = subprocess.run(
+        ["pgrep", "-P", pid], capture_output=True, text=True, check=False
+    )
+    # pgrep exits 1 on zero matches, which is a valid state, not a failure.
+    return sorted(line for line in result.stdout.splitlines() if line)
+
+
+def _live_health_ok() -> bool:
+    result = subprocess.run(
+        ["curl", "-sf", f"http://127.0.0.1:{LIVE_GATEWAY_PORT}/health"],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+@pytest.mark.live
+def test_relaxed_manifest_server_boots_eager_with_no_credential() -> None:
+    live_pid = _live_gateway_pid()
+    assert live_pid, "FAIL: could not resolve live gateway pid on :3344 — abort"
+    assert _live_health_ok(), "live gateway health check failed BEFORE boot — abort"
+    children_before = _children_of(live_pid)
+
+    with tempfile.TemporaryDirectory(prefix="pmcp-p5-boot-") as work_str:
+        work = Path(work_str)
+        fake_home = work / "home"
+        fake_home.mkdir()
+        project = work / "proj"
+        project.mkdir()
+        lock_dir = work / "lock"
+
+        # Fixture wrapper script — unique command basename + a fresh-mktemp
+        # arg, so _kill_orphan_processes' (Path(command).name, tuple(args))
+        # fingerprint (server.py:700) cannot collide with anything the live
+        # gateway is running.
+        fixture_py = work / "p5_fixture_server.py"
+        fixture_py.write_text(FIXTURE_SERVER_SRC)
+        wrapper = work / "p5-fixture-server"
+        wrapper.write_text(
+            f'#!/bin/sh\nexec {REPO_ROOT}/.venv/bin/python {fixture_py} "$@"\n'
+        )
+        wrapper.chmod(0o755)
+
+        # Manifest overlay: ONE server, declaring the relaxable credential.
+        # FIRECRAWL-style field, but a dedicated var name so this test never
+        # depends on (or collides with) the shipped firecrawl entry.
+        overlay = work / "manifest-overlay.yaml"
+        overlay.write_text(
+            f"""
+servers:
+  p5-fixture:
+    description: "P5 live-boot fixture"
+    keywords: [p5-fixture]
+    command: "{wrapper}"
+    args: ["--p5-run", "{work}"]
+    install: {{}}
+    requires_api_key: true
+    env_var: P5_FIXTURE_API_KEY
+    api_key_optional_when: ["P5_FIXTURE_URL"]
+    extra_env:
+      P5_FIXTURE_URL: "http://localhost:9999"
+"""
+        )
+
+        # Config: no mcpServers entries at all — autoStart names the manifest
+        # server directly, exercising the manifest-loop eager path (the one
+        # config/loader.py:1038 gates on).
+        config_path = work / "config.json"
+        config_path.write_text(
+            json.dumps({"mcpServers": {}, "autoStart": ["p5-fixture"]})
+        )
+
+        # Fixture-only policy — the real second isolation layer.
+        policy_path = work / "policy.yaml"
+        policy_path.write_text("servers:\n  allowlist:\n    - p5-fixture\n")
+
+        gw_log = work / "gw.log"
+        env = {
+            **os.environ,
+            "HOME": str(fake_home),
+            "XDG_CONFIG_HOME": str(fake_home / ".config"),
+            "PMCP_MANIFEST_PATH": str(overlay),
+        }
+        # Absent everywhere — the whole point of the test.
+        env.pop("P5_FIXTURE_API_KEY", None)
+
+        gw_proc = subprocess.Popen(
+            [
+                f"{REPO_ROOT}/.venv/bin/pmcp",
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(SPARE_PORT),
+                "--lock-dir",
+                str(lock_dir),
+                "--config",
+                str(config_path),
+                "--project",
+                str(project),
+                "--policy",
+                str(policy_path),
+            ],
+            stdout=open(gw_log, "w"),
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+        try:
+            _wait_for_health(gw_proc, gw_log)
+
+            log_text = gw_log.read_text()
+            summary_match = re.search(
+                r"Startup policy summary: eager=(\d+), lazy=(\d+), "
+                r"skipped=(\d+), policy_denied=(\d+)",
+                log_text,
+            )
+            assert summary_match, f"no startup summary found in log:\n{log_text}"
+            eager, lazy, skipped, policy_denied = (
+                int(g) for g in summary_match.groups()
+            )
+            # The fixture is the ONLY server that reaches eager+lazy — this is
+            # what actually proves isolation, NOT "server counts in the
+            # hundreds" (the shipped manifest's 106 entries always
+            # contribute, correctly, to skipped/policy_denied).
+            assert eager + lazy == 1, (
+                f"expected exactly 1 server in eager+lazy, got "
+                f"eager={eager} lazy={lazy} (isolation likely broken): "
+                f"{log_text}"
+            )
+            assert skipped >= 1 and policy_denied >= 1, (
+                "expected the shipped 106-server manifest to still "
+                f"contribute policy_denied entries: skipped={skipped} "
+                f"policy_denied={policy_denied}"
+            )
+
+            # gateway.invoke round-trip — the functional proof. /health only
+            # proves the HTTP server answers (transport/http.py hardcodes
+            # "ok": True); it is NOT proof the fixture is actually running.
+            asyncio.run(_invoke_fixture_ping())
+
+            # IF-0-P5-4 on a live process: the spawned child's real
+            # environment carries the relaxer and NOT the credential.
+            child_pid = _find_fixture_child_pid(str(work))
+            assert child_pid, "could not find spawned fixture child process"
+            child_environ = Path(f"/proc/{child_pid}/environ").read_bytes()
+            child_env = dict(
+                item.split("=", 1)
+                for item in child_environ.decode(errors="replace").split("\0")
+                if "=" in item
+            )
+            assert child_env.get("P5_FIXTURE_URL") == "http://localhost:9999"
+            assert "P5_FIXTURE_API_KEY" not in child_env
+        finally:
+            gw_proc.send_signal(signal.SIGTERM)
+            try:
+                gw_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                gw_proc.kill()
+                gw_proc.wait(timeout=10)
+
+    # Live gateway must be exactly as it was — before AND after.
+    assert _live_health_ok(), "FAIL: live gateway died during/after the boot test"
+    children_after = _children_of(live_pid)
+    assert children_before == children_after, (
+        "FAIL: live gateway's child set changed — "
+        f"before={children_before} after={children_after}"
+    )
+
+
+def _wait_for_health(gw_proc: subprocess.Popen, gw_log: Path) -> None:
+    for _ in range(60):
+        result = subprocess.run(
+            ["curl", "-sf", f"http://127.0.0.1:{SPARE_PORT}/health"],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        if gw_proc.poll() is not None:
+            pytest.fail(f"fixture gateway exited early:\n{gw_log.read_text()}")
+        time.sleep(0.5)
+    pytest.fail(f"fixture gateway never became healthy:\n{gw_log.read_text()}")
+
+
+async def _invoke_fixture_ping() -> None:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    url = f"http://127.0.0.1:{SPARE_PORT}/mcp"
+    async with streamablehttp_client(url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tool_names = {t.name for t in (await session.list_tools()).tools}
+            assert "gateway.invoke" in tool_names, sorted(tool_names)
+            result = await session.call_tool(
+                "gateway.invoke",
+                {
+                    "tool_id": "p5-fixture::ping",
+                    "arguments": {"value": "p5"},
+                },
+            )
+            body = "".join(getattr(c, "text", "") for c in result.content)
+            assert "p5-pong:p5" in body, f"downstream call failed: {body!r}"
+
+
+def _find_fixture_child_pid(work_dir: str) -> str | None:
+    """Resolve the spawned fixture's PID via /proc/*/cmdline containing the
+    unique work-dir path — safe from self-matching since this string never
+    appears in the pytest process's own argv."""
+    for proc_dir in Path("/proc").iterdir():
+        if not proc_dir.name.isdigit():
+            continue
+        cmdline_path = proc_dir / "cmdline"
+        try:
+            cmdline = cmdline_path.read_bytes()
+        except OSError:
+            continue
+        if work_dir.encode() in cmdline and b"p5_fixture_server.py" in cmdline:
+            return proc_dir.name
+    return None

--- a/tests/test_credential_child_env.py
+++ b/tests/test_credential_child_env.py
@@ -1,0 +1,161 @@
+"""P5 SL-4.6: IF-0-P5-4 child-environment consistency invariant.
+
+For any server, ``credential_requirement(server).relaxed_by is not None``
+implies that name is present with the same non-empty value in all three
+child-env constructions: path A (``build_install_child_env``), path B
+(``sanitized_subprocess_env(_manifest_server_to_config(...).config.env)``),
+and path C (the configured-duplicate merge, ``_merge_manifest_defaults``).
+
+Run under a configuration where the relaxer is ALSO a PMCP-managed secret
+key (registered in a tmp ``pmcp.env``) — that is the configuration
+``sanitized_subprocess_env`` strips from ``os.environ`` before applying
+``own_env``. This test fails on a predicate that reads ``os.environ`` and on
+any future refactor that reorders the ``managed_secret_keys`` strip after
+``own_env`` is applied.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from pmcp.config.loader import _manifest_server_to_config, _merge_manifest_defaults
+from pmcp.env_store import sanitized_subprocess_env
+from pmcp.manifest.installer import build_install_child_env
+from pmcp.manifest.loader import ServerConfig, credential_requirement
+from pmcp.types import LocalMcpServerConfig
+
+
+class TestRealSymbolsRealArity:
+    """A first assertion that imports all three symbols by name and calls each
+    with its real arity, so a rename or signature change breaks loudly
+    instead of the test silently testing nothing."""
+
+    def test_build_install_child_env_arity(self) -> None:
+        sig = inspect.signature(build_install_child_env)
+        assert list(sig.parameters) == ["server_config"]
+
+    def test_manifest_server_to_config_requires_two_args(self) -> None:
+        sig = inspect.signature(_manifest_server_to_config)
+        assert list(sig.parameters) == ["server", "env_lookup"]
+        server = _relaxed_server()
+        with pytest.raises(TypeError):
+            _manifest_server_to_config(server)  # type: ignore[call-arg]
+
+    def test_merge_manifest_defaults_arity(self) -> None:
+        sig = inspect.signature(_merge_manifest_defaults)
+        assert list(sig.parameters) == ["name", "config", "manifest_servers"]
+
+
+def _relaxed_server(**overrides: object) -> ServerConfig:
+    base: dict[str, object] = dict(
+        name="firecrawl",
+        description="firecrawl",
+        keywords=["firecrawl"],
+        install={},
+        command="npx",
+        args=["-y", "firecrawl-mcp"],
+        requires_api_key=True,
+        env_var="FIRECRAWL_API_KEY",
+        api_key_optional_when=["FIRECRAWL_API_URL"],
+        extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+    )
+    base.update(overrides)
+    return ServerConfig(**base)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _register_relaxer_as_managed_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Register FIRECRAWL_API_URL as a PMCP-managed secret key in a tmp
+    pmcp.env — the exact configuration sanitized_subprocess_env strips from
+    os.environ. Also puts a DIFFERENT value in os.environ directly, to prove
+    the predicate/child-env never derive their answer from os.environ."""
+    home = tmp_path / "home"
+    (home / ".config" / "pmcp").mkdir(parents=True)
+    (home / ".config" / "pmcp" / "pmcp.env").write_text(
+        "FIRECRAWL_API_URL=http://localhost:3002\n"
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+
+class TestChildEnvConsistencyAcrossPaths:
+    def test_relaxed_by_present_identically_in_paths_a_and_b(self) -> None:
+        server = _relaxed_server()
+        requirement = credential_requirement(server)
+        assert requirement.relaxed_by == "FIRECRAWL_API_URL"
+
+        # Path A — build_install_child_env already sanitizes; do not wrap.
+        path_a_env = build_install_child_env(server)
+
+        # Path B — sanitized_subprocess_env(_manifest_server_to_config(...).config.env)
+        # env_lookup intentionally resolves nothing ({}.get), isolating this
+        # assertion to the extra_env carriage, not credential resolution.
+        resolved = _manifest_server_to_config(server, {}.get)
+        assert isinstance(resolved.config, LocalMcpServerConfig)
+        path_b_env = sanitized_subprocess_env(resolved.config.env)
+
+        assert path_a_env.get("FIRECRAWL_API_URL") == "http://localhost:3002"
+        assert path_b_env.get("FIRECRAWL_API_URL") == "http://localhost:3002"
+
+        # The managed-secret-key strip must not have leaked into either path
+        # (own_env is applied AFTER the strip in both, per IF-0-P5-4).
+        assert path_a_env.get("FIRECRAWL_API_KEY") is None
+        assert path_b_env.get("FIRECRAWL_API_KEY") is None
+
+    def test_path_c_configured_duplicate_no_override_relaxes(self) -> None:
+        server = _relaxed_server()
+        config = LocalMcpServerConfig(command="npx", args=["-y", "firecrawl-mcp"])
+
+        merged = _merge_manifest_defaults("firecrawl", config, {"firecrawl": server})
+
+        assert merged is not None
+        assert merged.env is not None
+        assert merged.env.get("FIRECRAWL_API_URL") == "http://localhost:3002"
+        requirement = credential_requirement(server, child_env=merged.env)
+        assert requirement.required is False
+        assert requirement.relaxed_by == "FIRECRAWL_API_URL"
+
+    def test_path_c_empty_string_override_fails_closed(self) -> None:
+        """.mcp.json sets the relaxer to '' — the merge keeps the configured
+        value (a genuine override per _merge_manifest_defaults), the child
+        gets a dead literal, and the predicate must report required=True."""
+        server = _relaxed_server()
+        config = LocalMcpServerConfig(
+            command="npx",
+            args=["-y", "firecrawl-mcp"],
+            env={"FIRECRAWL_API_URL": ""},
+        )
+
+        merged = _merge_manifest_defaults("firecrawl", config, {"firecrawl": server})
+
+        assert merged is not None
+        assert merged.env == {"FIRECRAWL_API_URL": ""}
+        requirement = credential_requirement(server, child_env=merged.env)
+        assert requirement.required is True
+        assert requirement.relaxed_by is None
+
+    def test_path_c_unexpanded_placeholder_override_fails_closed(self) -> None:
+        """.mcp.json sets the relaxer to an unexpanded ${VAR} placeholder —
+        same fail-closed outcome as the empty-string case."""
+        server = _relaxed_server()
+        config = LocalMcpServerConfig(
+            command="npx",
+            args=["-y", "firecrawl-mcp"],
+            env={"FIRECRAWL_API_URL": "${FIRECRAWL_API_URL}"},
+        )
+
+        merged = _merge_manifest_defaults("firecrawl", config, {"firecrawl": server})
+
+        assert merged is not None
+        assert merged.env == {"FIRECRAWL_API_URL": "${FIRECRAWL_API_URL}"}
+        requirement = credential_requirement(server, child_env=merged.env)
+        assert requirement.required is True
+        assert requirement.relaxed_by is None

--- a/tests/test_credential_gates_handlers.py
+++ b/tests/test_credential_gates_handlers.py
@@ -1,0 +1,364 @@
+"""P5 gate tests: handler gates and capability discovery (consumers 3, 4, 6).
+
+Consumers 1, 2, 5, 7 live in tests/test_credential_gates_startup.py (SL-2); the
+seven-consumer end-to-end proof lives in tests/test_credential_optionality_e2e.py
+(SL-4). Also pins the producer invariants — the registry candidate, the
+synthesized `.mcp.json` entry, and `register_discovered_server` must report
+requires_api_key exactly as before; this lane does not touch producers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pmcp.manifest.loader import Manifest, ServerConfig
+from pmcp.manifest.registry import RegistryPackage, RegistryServerEntry
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig, ServerStatus
+
+
+class MockClientManager:
+    """Minimal client manager stub covering what connect_server/provision need."""
+
+    def __init__(self) -> None:
+        self._online: set[str] = set()
+        self.connected_configs: list[Any] = []
+
+    def is_server_online(self, name: str) -> bool:
+        return name in self._online
+
+    def is_lazy_server(self, name: str) -> bool:
+        return False
+
+    def get_server_status(self, name: str) -> ServerStatus | None:
+        return None
+
+    def get_all_server_statuses(self) -> list[ServerStatus]:
+        return []
+
+    def get_registry_meta(self) -> tuple[str, float]:
+        return ("test-rev", 0.0)
+
+    async def connect_server(self, config: Any) -> list[str]:
+        self.connected_configs.append(config)
+        return []
+
+
+def _relaxable_server(
+    *,
+    name: str = "firecrawl",
+    requires_api_key: bool = True,
+    env_var: str | None = "FIRECRAWL_API_KEY",
+    api_key_optional_when: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
+    keywords: list[str] | None = None,
+) -> ServerConfig:
+    return ServerConfig(
+        name=name,
+        description=f"{name} server",
+        keywords=keywords or [name],
+        install={},
+        command=f"{name}-mcp",
+        args=[],
+        requires_api_key=requires_api_key,
+        env_var=env_var,
+        api_key_optional_when=api_key_optional_when or [],
+        extra_env=extra_env or {},
+    )
+
+
+def _manifest(*servers: ServerConfig) -> Manifest:
+    return Manifest(
+        version="1.0",
+        cli_alternatives={},
+        servers={s.name: s for s in servers},
+        discovery_queue_path=".mcp-gateway/discovery_queue.json",
+    )
+
+
+def _gateway_tools(manifest: Manifest, monkeypatch: pytest.MonkeyPatch) -> GatewayTools:
+    client_manager = MockClientManager()
+    policy_manager = PolicyManager()
+    tools = GatewayTools(
+        client_manager=client_manager,  # type: ignore[arg-type]
+        policy_manager=policy_manager,
+    )
+    monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: manifest)
+    monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: [])
+    monkeypatch.setattr("pmcp.tools.handlers.load_dotenv", lambda *a, **kw: False)
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — lifecycle connect (gateway.connect_server)
+# ---------------------------------------------------------------------------
+
+
+class TestGate3ConnectServer:
+    @pytest.mark.asyncio
+    async def test_relaxed_server_does_not_report_missing_auth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.connect_server({"server_name": "firecrawl"})
+
+        assert result.auth_state != "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_required_server_still_reports_missing_auth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.connect_server({"server_name": "firecrawl"})
+
+        assert result.ok is False
+        assert result.auth_state == "missing_auth"
+        assert result.next_step == "gateway.auth_connect(server_name='firecrawl')"
+
+
+# ---------------------------------------------------------------------------
+# Gate 4 — provisioning (gateway.provision)
+# ---------------------------------------------------------------------------
+
+
+class TestGate4Provision:
+    @pytest.mark.asyncio
+    async def test_relaxed_server_does_not_need_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.provision({"server_name": "firecrawl"})
+
+        assert result.needs_api_key is not True
+        assert result.auth_state != "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_required_server_still_needs_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.provision({"server_name": "firecrawl"})
+
+        assert result.ok is False
+        assert result.needs_api_key is True
+        assert result.auth_state == "missing_auth"
+
+
+# ---------------------------------------------------------------------------
+# Gate 6 — capability discovery (_get_server_env_metadata and its consumers)
+# ---------------------------------------------------------------------------
+
+
+class TestGate6CapabilityDiscovery:
+    @pytest.mark.asyncio
+    async def test_catalog_search_candidate_reports_no_key_required(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                keywords=["firecrawl", "scrape", "crawl"],
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        # catalog_search's manifest-provision candidates are built by
+        # _manifest_candidates_for_query (consumer 6's other call site);
+        # exercise that builder directly to keep this gate test independent
+        # of unrelated tool/keyword ranking.
+        candidates = tools._manifest_candidates_for_query(
+            "firecrawl scrape",
+            manifest=manifest,
+            configured_servers={},
+            exclude_servers=set(),
+        )
+        assert candidates
+        assert candidates[0].requires_api_key is False
+
+    @pytest.mark.asyncio
+    async def test_request_capability_name_match_relaxed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.request_capability({"query": "firecrawl"})
+
+        assert result.status == "candidates"
+        assert result.candidates[0].requires_api_key is False
+        assert "No API key required" in result.message
+        assert "auth_connect" not in result.message
+        assert "auth_connect" not in (result.recommendation or "")
+
+    @pytest.mark.asyncio
+    async def test_request_capability_name_match_required(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.request_capability({"query": "firecrawl"})
+
+        assert result.status == "candidates"
+        assert result.candidates[0].requires_api_key is True
+        assert "Requires API key" in result.message
+        assert "gateway.auth_connect" in result.message
+
+    @pytest.mark.asyncio
+    async def test_request_capability_category_tiering_sorts_relaxed_first(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """firecrawl and tavily are both in the 'scraping/search' category
+        (manifest/loader.py's _CATEGORY_MAP). A relaxed firecrawl must sort
+        into the no-key-required tier ahead of a still-required tavily."""
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                keywords=["firecrawl", "scraping", "crawl"],
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            ),
+            _relaxable_server(
+                name="tavily",
+                env_var="TAVILY_API_KEY",
+                keywords=["tavily", "search"],
+                api_key_optional_when=[],
+            ),
+        )
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.request_capability({"query": "scraping search"})
+
+        assert result.status == "pick_from_category"
+        names_in_order = [c.name for c in result.candidates]
+        assert names_in_order.index("firecrawl") < names_in_order.index("tavily")
+        by_name = {c.name: c for c in result.candidates}
+        assert by_name["firecrawl"].requires_api_key is False
+        assert by_name["tavily"].requires_api_key is True
+        assert "No API key required: firecrawl." in result.message
+        assert "Requires API key (not set): tavily" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Producer invariants — untouched by this lane
+# ---------------------------------------------------------------------------
+
+
+class TestProducerInvariants:
+    """These construct requires_api_key rather than read a manifest server's
+    declared value; SL-3 must not have touched them (plans/phase-plan-v11-P5.md
+    Execution Notes: 'Do not edit :2977, :3336, :4954, or :4979')."""
+
+    @pytest.mark.asyncio
+    async def test_registry_candidate_reports_requires_api_key_from_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest = _manifest()
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        entry_with_key = RegistryServerEntry(
+            name="needs-key-registry",
+            description="test",
+            packages=[
+                RegistryPackage(identifier="@example/mcp", env_vars=["SOME_TOKEN"])
+            ],
+        )
+        entry_without_key = RegistryServerEntry(
+            name="no-key-registry",
+            description="test",
+            packages=[RegistryPackage(identifier="@example/other-mcp")],
+        )
+
+        candidate_with_key = tools._registry_candidate_for_entry(entry_with_key)
+        candidate_without_key = tools._registry_candidate_for_entry(entry_without_key)
+
+        assert candidate_with_key is not None
+        assert candidate_with_key.requires_api_key is True
+        assert candidate_without_key is not None
+        assert candidate_without_key.requires_api_key is False
+
+    @pytest.mark.asyncio
+    async def test_synthesized_configured_entry_is_always_no_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest = _manifest()
+        tools = _gateway_tools(manifest, monkeypatch)
+        configured = {
+            "plain-configured": ResolvedServerConfig(
+                name="plain-configured",
+                source="project",
+                config=LocalMcpServerConfig(command="plain-cmd"),
+            )
+        }
+
+        merged = tools._build_manifest_with_config_servers(manifest, configured)
+
+        assert merged.servers["plain-configured"].requires_api_key is False
+
+    @pytest.mark.asyncio
+    async def test_register_discovered_server_derives_from_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest = _manifest()
+        tools = _gateway_tools(manifest, monkeypatch)
+
+        result = await tools.register_discovered_server(
+            {
+                "server_name": "my-discovered",
+                "package": "@example/discovered-mcp",
+                "env_vars": ["DISCOVERED_TOKEN"],
+            }
+        )
+
+        assert result.ok is True
+        assert (
+            tools._discovered_server_configs["my-discovered"].requires_api_key is True
+        )
+
+        result_no_key = await tools.register_discovered_server(
+            {
+                "server_name": "my-discovered-no-key",
+                "package": "@example/discovered-mcp-nokey",
+                "env_vars": [],
+            }
+        )
+        assert result_no_key.ok is True
+        assert (
+            tools._discovered_server_configs["my-discovered-no-key"].requires_api_key
+            is False
+        )

--- a/tests/test_credential_gates_handlers.py
+++ b/tests/test_credential_gates_handlers.py
@@ -46,6 +46,13 @@ class MockClientManager:
         self.connected_configs.append(config)
         return []
 
+    def get_all_tools(self) -> list[Any]:
+        return []
+
+    async def ensure_connected(self, name: str) -> bool:
+        self._online.add(name)
+        return True
+
 
 def _relaxable_server(
     *,
@@ -80,6 +87,14 @@ def _manifest(*servers: ServerConfig) -> Manifest:
 
 
 def _gateway_tools(manifest: Manifest, monkeypatch: pytest.MonkeyPatch) -> GatewayTools:
+    return _gateway_tools_with_configured(manifest, [], monkeypatch)
+
+
+def _gateway_tools_with_configured(
+    manifest: Manifest,
+    configured_configs: list[ResolvedServerConfig],
+    monkeypatch: pytest.MonkeyPatch,
+) -> GatewayTools:
     client_manager = MockClientManager()
     policy_manager = PolicyManager()
     tools = GatewayTools(
@@ -87,7 +102,9 @@ def _gateway_tools(manifest: Manifest, monkeypatch: pytest.MonkeyPatch) -> Gatew
         policy_manager=policy_manager,
     )
     monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: manifest)
-    monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: [])
+    monkeypatch.setattr(
+        "pmcp.tools.handlers.load_configs", lambda **_: configured_configs
+    )
     monkeypatch.setattr("pmcp.tools.handlers.load_dotenv", lambda *a, **kw: False)
     return tools
 
@@ -272,6 +289,118 @@ class TestGate6CapabilityDiscovery:
         assert by_name["tavily"].requires_api_key is True
         assert "No API key required: firecrawl." in result.message
         assert "Requires API key (not set): tavily" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Configured-duplicate credential gate (board review finding 1)
+#
+# A .mcp.json entry duplicating a manifest server was previously never
+# credential-gated in connect_server (_resolve_lifecycle_config), provision,
+# or capability discovery (_get_server_env_metadata) — each of those code
+# paths branched on "is this name configured?" and never consulted the
+# manifest server's requires_api_key/api_key_optional_when at all for that
+# branch, regardless of what the predicate would say.
+# ---------------------------------------------------------------------------
+
+
+def _configured_local(
+    name: str, env: dict[str, str] | None = None
+) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="project",
+        config=LocalMcpServerConfig(command=f"{name}-mcp", env=env),
+    )
+
+
+class TestConfiguredDuplicateCredentialGate:
+    @pytest.mark.asyncio
+    async def test_connect_configured_duplicate_required_no_credential_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        configured = _configured_local("firecrawl")
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.connect_server({"server_name": "firecrawl"})
+
+        assert result.ok is False
+        assert result.auth_state == "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_connect_configured_duplicate_relaxed_via_own_env_proceeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(api_key_optional_when=["FIRECRAWL_API_URL"])
+        )
+        configured = _configured_local(
+            "firecrawl", env={"FIRECRAWL_API_URL": "http://localhost:3002"}
+        )
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.connect_server({"server_name": "firecrawl"})
+
+        assert result.auth_state != "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_provision_configured_duplicate_required_no_credential_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        configured = _configured_local("firecrawl")
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.provision({"server_name": "firecrawl"})
+
+        assert result.ok is False
+        assert result.needs_api_key is True
+        assert result.auth_state == "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_provision_configured_duplicate_relaxed_via_own_env_proceeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(api_key_optional_when=["FIRECRAWL_API_URL"])
+        )
+        configured = _configured_local(
+            "firecrawl", env={"FIRECRAWL_API_URL": "http://localhost:3002"}
+        )
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.provision({"server_name": "firecrawl"})
+
+        assert result.needs_api_key is not True
+        assert result.auth_state != "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_capability_discovery_judges_configured_child_env_not_manifest_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The manifest's own extra_env has a usable relaxer, but the
+        configured duplicate overrides it to an empty string — the child
+        gets a dead literal, so the effective requirement must be True."""
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        configured = _configured_local("firecrawl", env={"FIRECRAWL_API_URL": ""})
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+        configured_servers = {"firecrawl": configured}
+
+        requires_api_key, _env_var, _instructions = tools._get_server_env_metadata(
+            "firecrawl", manifest, configured_servers
+        )
+
+        assert requires_api_key is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_credential_gates_handlers.py
+++ b/tests/test_credential_gates_handlers.py
@@ -17,7 +17,12 @@ from pmcp.manifest.loader import Manifest, ServerConfig
 from pmcp.manifest.registry import RegistryPackage, RegistryServerEntry
 from pmcp.policy.policy import PolicyManager
 from pmcp.tools.handlers import GatewayTools
-from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig, ServerStatus
+from pmcp.types import (
+    LocalMcpServerConfig,
+    RemoteMcpServerConfig,
+    ResolvedServerConfig,
+    ServerStatus,
+)
 
 
 class MockClientManager:
@@ -313,6 +318,16 @@ def _configured_local(
     )
 
 
+def _configured_remote(
+    name: str, url: str = "https://vendor.example/mcp"
+) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="project",
+        config=RemoteMcpServerConfig(url=url),
+    )
+
+
 class TestConfiguredDuplicateCredentialGate:
     @pytest.mark.asyncio
     async def test_connect_configured_duplicate_required_no_credential_fails_closed(
@@ -401,6 +416,128 @@ class TestConfiguredDuplicateCredentialGate:
         )
 
         assert requires_api_key is True
+
+    # -- Board review round 2, finding 1 (remote configured duplicate) -----
+
+    @pytest.mark.asyncio
+    async def test_connect_remote_configured_duplicate_fails_closed_despite_manifest_relaxer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The manifest server is LOCAL with a usable relaxer, but the
+        CONFIGURED duplicate is itself REMOTE — extra_env cannot reach an
+        HTTP connection, so this must still fail closed."""
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        configured = _configured_remote("firecrawl")
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.connect_server({"server_name": "firecrawl"})
+
+        assert result.ok is False
+        assert result.auth_state == "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_provision_remote_configured_duplicate_fails_closed_despite_manifest_relaxer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        configured = _configured_remote("firecrawl")
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.provision({"server_name": "firecrawl"})
+
+        assert result.ok is False
+        assert result.needs_api_key is True
+        assert result.auth_state == "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_capability_discovery_remote_configured_duplicate_never_relaxes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(
+            _relaxable_server(
+                api_key_optional_when=["FIRECRAWL_API_URL"],
+                extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            )
+        )
+        configured = _configured_remote("firecrawl")
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+        configured_servers = {"firecrawl": configured}
+
+        requires_api_key, _env_var, _instructions = tools._get_server_env_metadata(
+            "firecrawl", manifest, configured_servers
+        )
+
+        assert requires_api_key is True
+
+    # -- Board review round 2, finding 2 (literal credential in .mcp.json) --
+
+    @pytest.mark.asyncio
+    async def test_connect_configured_duplicate_literal_credential_satisfies(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A concrete credential written directly into the configured
+        entry's own env block must satisfy the gate —
+        _check_any_api_key_available only checks process env / secret
+        stores by NAME and cannot see this literal."""
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        configured = _configured_local(
+            "firecrawl", env={"FIRECRAWL_API_KEY": "fc-real-key"}
+        )
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.connect_server({"server_name": "firecrawl"})
+
+        assert result.auth_state != "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_provision_configured_duplicate_literal_credential_satisfies(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        configured = _configured_local(
+            "firecrawl", env={"FIRECRAWL_API_KEY": "fc-real-key"}
+        )
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.provision({"server_name": "firecrawl"})
+
+        assert result.needs_api_key is not True
+        assert result.auth_state != "missing_auth"
+
+    @pytest.mark.asyncio
+    async def test_provision_configured_duplicate_placeholder_credential_does_not_satisfy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The literal-credential exception must not accept an empty string
+        or an unexpanded ${VAR} placeholder — same usability rule as a
+        relaxer value."""
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        manifest = _manifest(_relaxable_server(api_key_optional_when=[]))
+        configured = _configured_local(
+            "firecrawl", env={"FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"}
+        )
+        tools = _gateway_tools_with_configured(manifest, [configured], monkeypatch)
+
+        result = await tools.provision({"server_name": "firecrawl"})
+
+        assert result.ok is False
+        assert result.needs_api_key is True
+        assert result.auth_state == "missing_auth"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_credential_gates_startup.py
+++ b/tests/test_credential_gates_startup.py
@@ -19,7 +19,7 @@ import pytest
 from pmcp.config.loader import StartupSkipReason, resolve_startup_configs
 from pmcp.manifest.installer import MissingApiKeyError, check_api_key
 from pmcp.manifest.loader import ServerConfig
-from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig
+from pmcp.types import LocalMcpServerConfig, RemoteMcpServerConfig, ResolvedServerConfig
 
 
 def _relaxable_server(
@@ -154,6 +154,85 @@ class TestGate1ConfiguredDuplicate:
             config=LocalMcpServerConfig(
                 command="firecrawl-mcp",
                 env={"FIRECRAWL_API_URL": ""},
+            ),
+        )
+        result = resolve_startup_configs(
+            [configured],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert result.eager_configs == []
+        assert len(result.skipped) == 1
+        assert result.skipped[0].reason == StartupSkipReason.MISSING_AUTH
+
+    def test_configured_remote_duplicate_fails_closed_despite_manifest_relaxer(
+        self,
+    ) -> None:
+        """Board review finding 1 (remote variant): the manifest server is
+        LOCAL with a usable relaxer, but the CONFIGURED duplicate is itself
+        REMOTE. extra_env cannot reach an HTTP connection, so this must fail
+        closed regardless of what the manifest's own extra_env says —
+        _local_env(config) previously returned None for a remote config,
+        falling back to the (usable) manifest default and relaxing a
+        credential that could never actually reach the connection."""
+        server = _relaxable_server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        configured = ResolvedServerConfig(
+            name="firecrawl",
+            source="project",
+            config=RemoteMcpServerConfig(url="https://vendor.example/mcp"),
+        )
+        result = resolve_startup_configs(
+            [configured],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert result.eager_configs == []
+        assert len(result.skipped) == 1
+        assert result.skipped[0].reason == StartupSkipReason.MISSING_AUTH
+
+    def test_configured_duplicate_literal_credential_in_own_env_satisfies(
+        self,
+    ) -> None:
+        """Board review finding 2: a concrete credential written directly
+        into the configured entry's own env block must satisfy the gate —
+        is_auth_available only checks process env / PMCP secret stores by
+        variable NAME and cannot see this literal."""
+        server = _relaxable_server(api_key_optional_when=[])
+        configured = ResolvedServerConfig(
+            name="firecrawl",
+            source="project",
+            config=LocalMcpServerConfig(
+                command="firecrawl-mcp",
+                env={"FIRECRAWL_API_KEY": "fc-real-key"},
+            ),
+        )
+        result = resolve_startup_configs(
+            [configured],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert [c.name for c in result.eager_configs] == ["firecrawl"]
+        assert result.skipped == []
+
+    def test_configured_duplicate_placeholder_credential_does_not_satisfy(
+        self,
+    ) -> None:
+        """The literal-credential exception (finding 2) must not accept an
+        empty string or an unexpanded ${VAR} placeholder — same usability
+        rule as a relaxer value."""
+        server = _relaxable_server(api_key_optional_when=[])
+        configured = ResolvedServerConfig(
+            name="firecrawl",
+            source="project",
+            config=LocalMcpServerConfig(
+                command="firecrawl-mcp",
+                env={"FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"},
             ),
         )
         result = resolve_startup_configs(

--- a/tests/test_credential_gates_startup.py
+++ b/tests/test_credential_gates_startup.py
@@ -1,0 +1,326 @@
+"""P5 gate tests: startup, install, diagnostics, and `pmcp init` (consumers 1,
+2, 5, 7). Each gate is tested in both directions per plans/phase-plan-v11-P5.md:
+a relaxed server must pass, and a genuinely-required server must still fail
+closed. Consumers 3, 4, 6 live in tests/test_credential_gates_handlers.py
+(SL-3); the seven-consumer end-to-end proof lives in
+tests/test_credential_optionality_e2e.py (SL-4).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pmcp.config.loader import StartupSkipReason, resolve_startup_configs
+from pmcp.manifest.installer import MissingApiKeyError, check_api_key
+from pmcp.manifest.loader import ServerConfig
+
+
+def _relaxable_server(
+    *,
+    requires_api_key: bool = True,
+    env_var: str | None = "FIRECRAWL_API_KEY",
+    api_key_optional_when: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> ServerConfig:
+    return ServerConfig(
+        name="firecrawl",
+        description="firecrawl server",
+        keywords=["firecrawl"],
+        install={},
+        command="firecrawl-mcp",
+        args=[],
+        auto_start=True,
+        requires_api_key=requires_api_key,
+        env_var=env_var,
+        api_key_optional_when=api_key_optional_when or [],
+        extra_env=extra_env or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — eager startup (config/loader.py resolve_startup_configs)
+# ---------------------------------------------------------------------------
+
+
+class TestGate1EagerStartup:
+    def test_relaxed_server_becomes_eager(self) -> None:
+        server = _relaxable_server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        result = resolve_startup_configs(
+            [],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert [c.name for c in result.eager_configs] == ["firecrawl"]
+        assert result.skipped == []
+
+    def test_required_server_still_skipped_missing_auth(self) -> None:
+        server = _relaxable_server(api_key_optional_when=[])
+        result = resolve_startup_configs(
+            [],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert result.eager_configs == []
+        assert len(result.skipped) == 1
+        assert result.skipped[0].reason == StartupSkipReason.MISSING_AUTH
+        assert result.skipped[0].name == "firecrawl"
+
+    def test_required_server_with_credential_still_eager(self) -> None:
+        server = _relaxable_server(api_key_optional_when=[])
+        result = resolve_startup_configs(
+            [],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda key: key == "FIRECRAWL_API_KEY",
+        )
+        assert [c.name for c in result.eager_configs] == ["firecrawl"]
+        assert result.skipped == []
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — install/provision preflight (installer.check_api_key)
+# ---------------------------------------------------------------------------
+
+
+class TestGate2CheckApiKey:
+    @pytest.mark.asyncio
+    async def test_relaxed_server_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        server = _relaxable_server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        await check_api_key(server)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_required_server_without_credential_still_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        server = _relaxable_server(api_key_optional_when=[])
+        with pytest.raises(MissingApiKeyError):
+            await check_api_key(server)
+
+    @pytest.mark.asyncio
+    async def test_required_server_with_credential_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "sk-test")
+        server = _relaxable_server(api_key_optional_when=[])
+        await check_api_key(server)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Gate 5 — diagnostics (`pmcp secrets check` / run_secrets_check)
+# ---------------------------------------------------------------------------
+
+
+_OVERLAY_RELAXED = """
+servers:
+  cred-test:
+    description: "test relaxable server"
+    keywords: [cred-test]
+    command: "cred-test-mcp"
+    args: []
+    requires_api_key: true
+    env_var: CRED_TEST_API_KEY
+    api_key_optional_when: ["CRED_TEST_URL"]
+    extra_env:
+      CRED_TEST_URL: "http://localhost:9999"
+"""
+
+_OVERLAY_REQUIRED = """
+servers:
+  cred-test:
+    description: "test relaxable server"
+    keywords: [cred-test]
+    command: "cred-test-mcp"
+    args: []
+    requires_api_key: true
+    env_var: CRED_TEST_API_KEY
+    api_key_optional_when: ["CRED_TEST_URL"]
+"""
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+class TestGate5SecretsCheck:
+    @pytest.mark.asyncio
+    async def test_relaxed_server_reports_ok_with_no_missing_keys(
+        self, tmp_path: Path
+    ) -> None:
+        from pmcp.cli_commands.secrets import run_secrets_check
+
+        home = tmp_path / "home"
+        project = tmp_path / "project"
+        overlay = tmp_path / "overlay.yaml"
+        _write(home / ".config" / "pmcp" / "pmcp.env", "")
+        _write(project / ".env.pmcp", "")
+        _write(overlay, _OVERLAY_RELAXED)
+        _write(
+            project / ".mcp.json",
+            json.dumps(
+                {"mcpServers": {"cred-test": {"command": "cred-test-mcp", "args": []}}}
+            ),
+        )
+
+        with patch.dict(
+            "os.environ",
+            {"HOME": str(home), "PMCP_MANIFEST_PATH": str(overlay)},
+            clear=False,
+        ):
+            os.environ.pop("CRED_TEST_API_KEY", None)
+            output = await run_secrets_check(argparse.Namespace(project=project))
+
+        assert "CRED_TEST_API_KEY" not in output["required_keys"]
+        assert "CRED_TEST_URL" not in output["required_keys"]
+        assert output["missing_keys"] == []
+        assert output["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_required_server_still_reports_missing(self, tmp_path: Path) -> None:
+        from pmcp.cli_commands.secrets import run_secrets_check
+
+        home = tmp_path / "home"
+        project = tmp_path / "project"
+        overlay = tmp_path / "overlay.yaml"
+        _write(home / ".config" / "pmcp" / "pmcp.env", "")
+        _write(project / ".env.pmcp", "")
+        _write(overlay, _OVERLAY_REQUIRED)
+        _write(
+            project / ".mcp.json",
+            json.dumps(
+                {"mcpServers": {"cred-test": {"command": "cred-test-mcp", "args": []}}}
+            ),
+        )
+
+        with patch.dict(
+            "os.environ",
+            {"HOME": str(home), "PMCP_MANIFEST_PATH": str(overlay)},
+            clear=False,
+        ):
+            os.environ.pop("CRED_TEST_API_KEY", None)
+            output = await run_secrets_check(argparse.Namespace(project=project))
+
+        assert "CRED_TEST_API_KEY" in output["required_keys"]
+        assert "CRED_TEST_API_KEY" in output["missing_keys"]
+        assert output["ok"] is False
+
+    # `cli.py:2578` only prints `output["ok"]`, never maps it to process exit
+    # status, so a caller must assert on the returned mapping — never on a
+    # subprocess exit code — to detect gate 5 regressing.
+    @pytest.mark.asyncio
+    async def test_ok_is_returned_field_not_exit_status(self, tmp_path: Path) -> None:
+        from pmcp.cli_commands.secrets import run_secrets_check
+
+        home = tmp_path / "home"
+        project = tmp_path / "project"
+        _write(home / ".config" / "pmcp" / "pmcp.env", "")
+        _write(project / ".env.pmcp", "")
+        _write(project / ".mcp.json", json.dumps({"mcpServers": {}}))
+
+        with patch.dict("os.environ", {"HOME": str(home)}, clear=False):
+            output = await run_secrets_check(argparse.Namespace(project=project))
+
+        assert isinstance(output, dict)
+        assert "ok" in output
+
+
+# ---------------------------------------------------------------------------
+# Gate 7 — `pmcp init` (run_init)
+# ---------------------------------------------------------------------------
+
+
+class TestGate7RunInit:
+    @pytest.mark.asyncio
+    async def test_relaxed_server_prints_no_credential_needed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from pmcp.cli import run_init
+
+        home = tmp_path / "home"
+        overlay = tmp_path / "overlay.yaml"
+        home.mkdir()
+        _write(
+            overlay,
+            """
+servers:
+  firecrawl:
+    description: "Web scraping/crawling"
+    keywords: [firecrawl, scrape]
+    command: "firecrawl-mcp"
+    args: []
+    requires_api_key: true
+    env_var: FIRECRAWL_API_KEY
+    api_key_optional_when: ["FIRECRAWL_API_URL"]
+    extra_env:
+      FIRECRAWL_API_URL: "http://localhost:3002"
+""",
+        )
+        project = tmp_path / "project"
+        args = argparse.Namespace(command="init", project=project, force=False)
+
+        def _select_firecrawl(prompt: str) -> str:
+            return "y" if "firecrawl" in prompt else ""
+
+        with patch.dict(
+            "os.environ",
+            {"HOME": str(home), "PMCP_MANIFEST_PATH": str(overlay)},
+            clear=False,
+        ):
+            os.environ.pop("FIRECRAWL_API_KEY", None)
+            with patch("builtins.input", side_effect=_select_firecrawl):
+                await run_init(args)
+
+        content = (project / ".mcp.json").read_text()
+        assert '"firecrawl"' in content
+
+        captured = capsys.readouterr()
+        assert "No credential needed" in captured.out
+        assert "FIRECRAWL_API_URL" in captured.out
+        assert "pmcp secrets set" not in captured.out
+
+    @pytest.mark.asyncio
+    async def test_required_server_instruction_unchanged(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A server that still requires a credential keeps the exact
+        `pmcp secrets set` instruction — byte-for-byte unchanged."""
+        from pmcp.cli import run_init
+
+        home = tmp_path / "home"
+        home.mkdir()
+        project = tmp_path / "project"
+        args = argparse.Namespace(command="init", project=project, force=False)
+
+        def _select_firecrawl(prompt: str) -> str:
+            return "y" if "firecrawl" in prompt else ""
+
+        with patch.dict("os.environ", {"HOME": str(home)}, clear=False):
+            os.environ.pop("FIRECRAWL_API_KEY", None)
+            os.environ.pop("PMCP_MANIFEST_PATH", None)
+            with patch("builtins.input", side_effect=_select_firecrawl):
+                await run_init(args)
+
+        content = (project / ".mcp.json").read_text()
+        assert '"firecrawl"' in content
+
+        captured = capsys.readouterr()
+        assert "pmcp secrets set FIRECRAWL_API_KEY" in captured.out
+        assert "No credential needed" not in captured.out

--- a/tests/test_credential_gates_startup.py
+++ b/tests/test_credential_gates_startup.py
@@ -19,6 +19,7 @@ import pytest
 from pmcp.config.loader import StartupSkipReason, resolve_startup_configs
 from pmcp.manifest.installer import MissingApiKeyError, check_api_key
 from pmcp.manifest.loader import ServerConfig
+from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig
 
 
 def _relaxable_server(
@@ -86,6 +87,84 @@ class TestGate1EagerStartup:
         )
         assert [c.name for c in result.eager_configs] == ["firecrawl"]
         assert result.skipped == []
+
+
+class TestGate1ConfiguredDuplicate:
+    """Board review finding 1: a .mcp.json entry ("configured" source) whose
+    name duplicates a manifest server was previously never credential-gated
+    at all here — add_config's manifest_server param was always None for the
+    configured-entries loop, so a genuinely-required, credential-less
+    configured duplicate reached eager_configs unconditionally."""
+
+    def test_configured_duplicate_required_and_no_credential_is_skipped(
+        self,
+    ) -> None:
+        server = _relaxable_server(api_key_optional_when=[])
+        configured = ResolvedServerConfig(
+            name="firecrawl",
+            source="project",
+            config=LocalMcpServerConfig(command="firecrawl-mcp"),
+        )
+        result = resolve_startup_configs(
+            [configured],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert result.eager_configs == []
+        assert len(result.skipped) == 1
+        assert result.skipped[0].reason == StartupSkipReason.MISSING_AUTH
+        assert result.skipped[0].name == "firecrawl"
+
+    def test_configured_duplicate_relaxed_via_own_env_is_eager(self) -> None:
+        server = _relaxable_server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+        )
+        # The configured entry's OWN env supplies the relaxer — not the
+        # manifest's extra_env (which is empty here) — proving child_env,
+        # not the manifest default, is what's judged.
+        configured = ResolvedServerConfig(
+            name="firecrawl",
+            source="project",
+            config=LocalMcpServerConfig(
+                command="firecrawl-mcp",
+                env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+            ),
+        )
+        result = resolve_startup_configs(
+            [configured],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert [c.name for c in result.eager_configs] == ["firecrawl"]
+        assert result.skipped == []
+
+    def test_configured_duplicate_empty_string_override_fails_closed(self) -> None:
+        server = _relaxable_server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        # .mcp.json overrides the relaxer to an empty string — the child gets
+        # a dead literal, so this must still fail closed even though the
+        # manifest's own extra_env has a usable value.
+        configured = ResolvedServerConfig(
+            name="firecrawl",
+            source="project",
+            config=LocalMcpServerConfig(
+                command="firecrawl-mcp",
+                env={"FIRECRAWL_API_URL": ""},
+            ),
+        )
+        result = resolve_startup_configs(
+            [configured],
+            manifest_servers={"firecrawl": server},
+            enabled_auto_start={"firecrawl"},
+            is_auth_available=lambda _key: False,
+        )
+        assert result.eager_configs == []
+        assert len(result.skipped) == 1
+        assert result.skipped[0].reason == StartupSkipReason.MISSING_AUTH
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_credential_optionality_e2e.py
+++ b/tests/test_credential_optionality_e2e.py
@@ -86,6 +86,11 @@ servers:
   firecrawl:
     description: "Web scraping/crawling"
     keywords: [firecrawl, scraping, crawl, extract]
+    install:
+      mac: ["true"]
+      linux: ["true"]
+      wsl: ["true"]
+      windows: ["true"]
     command: "firecrawl-mcp"
     args: []
     requires_api_key: true
@@ -197,9 +202,14 @@ class TestRelaxedDirectionAllSevenGates:
         # Gate 3 — connect does not report missing_auth.
         assert outcomes["connect"].auth_state != "missing_auth"
 
-        # Gate 4 — provision does not need an api key.
+        # Gate 4 — provision actually succeeds (ok is True), not merely
+        # "didn't report needing a key". The fixture carries a real install
+        # command (`true`) so this exercises the full success path rather
+        # than accidentally passing via an unrelated InstallError.
         assert outcomes["provision"].needs_api_key is not True
         assert outcomes["provision"].auth_state != "missing_auth"
+        assert outcomes["provision"].ok is True, outcomes["provision"].message
+        assert outcomes["provision"].status == "started"
 
         # Gate 5 — ok is True; neither the credential nor the relaxer is
         # reported missing (read the returned field, never an exit code).

--- a/tests/test_credential_optionality_e2e.py
+++ b/tests/test_credential_optionality_e2e.py
@@ -1,0 +1,428 @@
+"""P5 SL-4.2/4.3: seven-consumer end-to-end proof (EC-P5-2, EC-P5-3).
+
+Each test in the "relaxed" class exercises all seven gates against ONE
+fixture whose `firecrawl` entry carries `api_key_optional_when:
+["FIRECRAWL_API_URL"]` and whose overlay supplies that URL, with
+FIRECRAWL_API_KEY absent everywhere — asserting POSITIVE outcomes, not
+merely the absence of error markers.
+
+Each test in the "fail closed" class runs a server that looks relaxable but
+isn't (four distinct reasons) through the same seven gates and asserts every
+one still demands the credential.
+
+"shipped" tests assert the manifest actually shipped in SL-4.4 carries the
+field and that shipping it alone relaxes nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pmcp.cli import run_init
+from pmcp.cli_commands.secrets import run_secrets_check
+from pmcp.config.loader import StartupSkipReason, resolve_startup_configs
+from pmcp.manifest.installer import MissingApiKeyError, check_api_key
+from pmcp.manifest.loader import load_manifest, requires_credential
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+from pmcp.types import ServerStatus
+
+
+class _MockClientManager:
+    """Minimal client manager stub covering connect_server/provision needs."""
+
+    def __init__(self) -> None:
+        self._online: set[str] = set()
+        self.connected_configs: list[Any] = []
+
+    def is_server_online(self, name: str) -> bool:
+        return name in self._online
+
+    def is_lazy_server(self, name: str) -> bool:
+        return False
+
+    def get_server_status(self, name: str) -> ServerStatus | None:
+        return None
+
+    def get_all_server_statuses(self) -> list[ServerStatus]:
+        return []
+
+    def get_registry_meta(self) -> tuple[str, float]:
+        return ("test-rev", 0.0)
+
+    async def connect_server(self, config: Any) -> list[str]:
+        self.connected_configs.append(config)
+        return []
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Isolate overlay/env-file discovery: fresh HOME, no project manifest, no
+    .mcp.json, no PMCP_MANIFEST_PATH by default. Returns (workdir, home)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("PMCP_MANIFEST_PATH", raising=False)
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    monkeypatch.chdir(workdir)
+    return workdir, home
+
+
+RELAXED_OVERLAY = """
+servers:
+  firecrawl:
+    description: "Web scraping/crawling"
+    keywords: [firecrawl, scraping, crawl, extract]
+    command: "firecrawl-mcp"
+    args: []
+    requires_api_key: true
+    env_var: FIRECRAWL_API_KEY
+    api_key_optional_when: ["FIRECRAWL_API_URL"]
+    extra_env:
+      FIRECRAWL_API_URL: "http://localhost:3002"
+"""
+
+
+async def _run_all_seven_gates(
+    workdir: Path,
+    home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> dict[str, Any]:
+    """Run every one of the seven consumers against the current overlay and
+    return their outcomes for the caller to assert on."""
+    manifest = load_manifest()
+    server = manifest.get_server("firecrawl")
+    assert server is not None
+
+    outcomes: dict[str, Any] = {}
+
+    # Gate 1 — eager startup.
+    startup = resolve_startup_configs(
+        [],
+        manifest_servers={"firecrawl": server},
+        enabled_auto_start={"firecrawl"},
+        is_auth_available=lambda _key: False,
+    )
+    outcomes["startup"] = startup
+
+    # Gate 2 — install/provision preflight.
+    try:
+        await check_api_key(server)
+        outcomes["check_api_key_raised"] = False
+    except MissingApiKeyError:
+        outcomes["check_api_key_raised"] = True
+
+    # Gates 3, 4, 6 — lifecycle connect, provisioning, capability discovery.
+    tools = GatewayTools(
+        client_manager=_MockClientManager(),  # type: ignore[arg-type]
+        policy_manager=PolicyManager(),
+    )
+    outcomes["connect"] = await tools.connect_server({"server_name": "firecrawl"})
+    outcomes["provision"] = await tools.provision({"server_name": "firecrawl"})
+    outcomes["request_capability"] = await tools.request_capability(
+        {"query": "firecrawl"}
+    )
+
+    # Gate 5 — diagnostics. run_secrets_check only reports on servers that
+    # appear in a configured .mcp.json (matches the existing behaviour
+    # test_run_secrets_check_reports_missing_namespaced_credential pins), so
+    # a bare configured entry for firecrawl is required for this gate to
+    # evaluate it at all.
+    _write(
+        workdir / ".mcp.json",
+        json.dumps({"mcpServers": {"firecrawl": {"command": "firecrawl-mcp"}}}),
+    )
+    outcomes["secrets_check"] = await run_secrets_check(
+        argparse.Namespace(project=workdir)
+    )
+
+    # Gate 7 — pmcp init.
+    init_project = workdir / "init"
+    init_project.mkdir()
+
+    def _select_firecrawl(prompt: str) -> str:
+        return "y" if "firecrawl" in prompt else ""
+
+    with patch("builtins.input", side_effect=_select_firecrawl):
+        await run_init(
+            argparse.Namespace(command="init", project=init_project, force=False)
+        )
+    outcomes["init_mcp_json"] = json.loads((init_project / ".mcp.json").read_text())
+    outcomes["init_stdout"] = capsys.readouterr().out
+
+    return outcomes
+
+
+class TestRelaxedDirectionAllSevenGates:
+    """EC-P5-3: FIRECRAWL_API_KEY absent everywhere; positive outcomes at
+    every gate."""
+
+    @pytest.mark.asyncio
+    async def test_all_seven_gates_pass_with_no_credential(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        workdir, home = _isolate(tmp_path, monkeypatch)
+        overlay = tmp_path / "overlay.yaml"
+        _write(overlay, RELAXED_OVERLAY)
+        monkeypatch.setenv("PMCP_MANIFEST_PATH", str(overlay))
+        _write(workdir / ".env.pmcp", "")
+        _write(home / ".config" / "pmcp" / "pmcp.env", "")
+
+        outcomes = await _run_all_seven_gates(workdir, home, monkeypatch, capsys)
+
+        # Gate 1 — present in eager_configs, absent from skipped.
+        assert [c.name for c in outcomes["startup"].eager_configs] == ["firecrawl"]
+        assert outcomes["startup"].skipped == []
+
+        # Gate 2 — did not raise.
+        assert outcomes["check_api_key_raised"] is False
+
+        # Gate 3 — connect does not report missing_auth.
+        assert outcomes["connect"].auth_state != "missing_auth"
+
+        # Gate 4 — provision does not need an api key.
+        assert outcomes["provision"].needs_api_key is not True
+        assert outcomes["provision"].auth_state != "missing_auth"
+
+        # Gate 5 — ok is True; neither the credential nor the relaxer is
+        # reported missing (read the returned field, never an exit code).
+        secrets_output = outcomes["secrets_check"]
+        assert secrets_output["ok"] is True
+        assert "FIRECRAWL_API_KEY" not in secrets_output["missing_keys"]
+        assert "FIRECRAWL_API_URL" not in secrets_output["missing_keys"]
+
+        # Gate 6 — catalog_search/request_capability candidate reports no key
+        # required and no auth_connect recommendation.
+        capability = outcomes["request_capability"]
+        assert capability.candidates[0].requires_api_key is False
+        assert "auth_connect" not in (capability.recommendation or "")
+
+        # Gate 7 — pmcp init did not need to prompt for a credential; the
+        # server made it into the generated config, and the printed guidance
+        # names the relaxer instead of instructing `pmcp secrets set`.
+        assert "firecrawl" in outcomes["init_mcp_json"]["mcpServers"]
+        assert "No credential needed" in outcomes["init_stdout"]
+        assert "pmcp secrets set" not in outcomes["init_stdout"]
+
+
+SHARED_SERVER_ENV_DECLARE = """
+servers:
+  firecrawl:
+    description: "Web scraping/crawling"
+    keywords: [firecrawl, scraping, crawl, extract]
+    command: "firecrawl-mcp"
+    args: []
+    requires_api_key: true
+    env_var: FIRECRAWL_API_KEY
+    api_key_optional_when: ["FIRECRAWL_API_URL"]
+"""
+
+
+class TestTwoPartyServerEnvPatchAlsoRelaxes:
+    """The relaxer may arrive via an overlay's `server_env:` patch (the
+    operator's action) layered onto a manifest entry that merely declares the
+    field (the author's action) — two independent parties, per the design
+    rationale in plans/phase-plan-v11-P5.md."""
+
+    @pytest.mark.asyncio
+    async def test_server_env_patch_relaxes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workdir, home = _isolate(tmp_path, monkeypatch)
+        # Author's declaration lives in the user overlay (lower precedence).
+        _write(home / ".pmcp" / "manifest.yaml", SHARED_SERVER_ENV_DECLARE)
+        # Operator's URL arrives via a project overlay's server_env patch
+        # (higher precedence than user, applied after).
+        _write(
+            workdir / ".pmcp" / "manifest.yaml",
+            """
+server_env:
+  firecrawl:
+    FIRECRAWL_API_URL: "http://localhost:3002"
+""",
+        )
+
+        manifest = load_manifest()
+        server = manifest.get_server("firecrawl")
+        assert server is not None
+        assert server.extra_env.get("FIRECRAWL_API_URL") == "http://localhost:3002"
+        assert requires_credential(server) is False
+
+
+FAIL_CLOSED_CASES: list[tuple[str, str]] = [
+    (
+        "no_api_key_optional_when",
+        """
+servers:
+  firecrawl:
+    description: "Web scraping/crawling"
+    keywords: [firecrawl, scraping, crawl, extract]
+    command: "firecrawl-mcp"
+    args: []
+    requires_api_key: true
+    env_var: FIRECRAWL_API_KEY
+""",
+    ),
+    (
+        "relaxer_declared_but_url_unset",
+        """
+servers:
+  firecrawl:
+    description: "Web scraping/crawling"
+    keywords: [firecrawl, scraping, crawl, extract]
+    command: "firecrawl-mcp"
+    args: []
+    requires_api_key: true
+    env_var: FIRECRAWL_API_KEY
+    api_key_optional_when: ["FIRECRAWL_API_URL"]
+""",
+    ),
+    (
+        "relaxer_names_its_own_credential",
+        """
+servers:
+  firecrawl:
+    description: "Web scraping/crawling"
+    keywords: [firecrawl, scraping, crawl, extract]
+    command: "firecrawl-mcp"
+    args: []
+    requires_api_key: true
+    env_var: FIRECRAWL_API_KEY
+    api_key_optional_when: ["FIRECRAWL_API_KEY"]
+""",
+    ),
+]
+
+
+class TestFailClosedDirectionAllSevenGates:
+    """EC-P5-2: four servers that look relaxable but aren't, each still
+    fail closed at all seven gates."""
+
+    @pytest.mark.parametrize("case_name,overlay_yaml", FAIL_CLOSED_CASES)
+    @pytest.mark.asyncio
+    async def test_fail_closed_at_all_seven_gates(
+        self,
+        case_name: str,
+        overlay_yaml: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        workdir, home = _isolate(tmp_path, monkeypatch)
+        overlay = tmp_path / "overlay.yaml"
+        _write(overlay, overlay_yaml)
+        monkeypatch.setenv("PMCP_MANIFEST_PATH", str(overlay))
+        _write(workdir / ".env.pmcp", "")
+        _write(home / ".config" / "pmcp" / "pmcp.env", "")
+
+        outcomes = await _run_all_seven_gates(workdir, home, monkeypatch, capsys)
+
+        assert outcomes["startup"].eager_configs == [], case_name
+        assert len(outcomes["startup"].skipped) == 1, case_name
+        assert (
+            outcomes["startup"].skipped[0].reason == StartupSkipReason.MISSING_AUTH
+        ), case_name
+
+        assert outcomes["check_api_key_raised"] is True, case_name
+
+        assert outcomes["connect"].auth_state == "missing_auth", case_name
+        assert outcomes["provision"].needs_api_key is True, case_name
+
+        secrets_output = outcomes["secrets_check"]
+        assert secrets_output["ok"] is False, case_name
+        assert "FIRECRAWL_API_KEY" in secrets_output["missing_keys"], case_name
+
+        capability = outcomes["request_capability"]
+        assert capability.candidates[0].requires_api_key is True, case_name
+
+        # Gate 7 — the credential is still genuinely required, so the
+        # existing `pmcp secrets set` instruction is unchanged.
+        assert "pmcp secrets set FIRECRAWL_API_KEY" in outcomes["init_stdout"], (
+            case_name
+        )
+        assert "No credential needed" not in outcomes["init_stdout"], case_name
+
+    @pytest.mark.asyncio
+    async def test_relaxer_present_only_in_os_environ_fails_closed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The fourth fail-closed reason: the relaxer is set only in
+        os.environ (e.g. a bare shell export), never in the manifest's
+        extra_env. This is the env-strip-inversion guard's e2e proof."""
+        workdir, home = _isolate(tmp_path, monkeypatch)
+        overlay = tmp_path / "overlay.yaml"
+        _write(
+            overlay,
+            """
+servers:
+  firecrawl:
+    description: "Web scraping/crawling"
+    keywords: [firecrawl, scraping, crawl, extract]
+    command: "firecrawl-mcp"
+    args: []
+    requires_api_key: true
+    env_var: FIRECRAWL_API_KEY
+    api_key_optional_when: ["FIRECRAWL_API_URL"]
+""",
+        )
+        monkeypatch.setenv("PMCP_MANIFEST_PATH", str(overlay))
+        monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
+        _write(workdir / ".env.pmcp", "")
+        _write(home / ".config" / "pmcp" / "pmcp.env", "")
+
+        outcomes = await _run_all_seven_gates(workdir, home, monkeypatch, capsys)
+
+        assert outcomes["startup"].eager_configs == []
+        assert outcomes["check_api_key_raised"] is True
+        assert outcomes["connect"].auth_state == "missing_auth"
+        assert outcomes["provision"].needs_api_key is True
+        assert outcomes["secrets_check"]["ok"] is False
+        assert outcomes["request_capability"].candidates[0].requires_api_key is True
+
+
+class TestShippedManifestCarriesTheField:
+    """SL-4.3: proves the shipped line exists, and that shipping it alone
+    relaxes nothing for an existing install."""
+
+    def test_shipped_firecrawl_declares_relaxer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)  # no overlay of any kind
+
+        manifest = load_manifest()
+        server = manifest.get_server("firecrawl")
+
+        assert server is not None
+        assert server.api_key_optional_when == ["FIRECRAWL_API_URL"]
+
+    def test_shipped_firecrawl_still_requires_credential_with_empty_extra_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+
+        manifest = load_manifest()
+        server = manifest.get_server("firecrawl")
+
+        assert server is not None
+        assert server.extra_env == {}
+        assert requires_credential(server) is True

--- a/tests/test_credential_predicate_guard.py
+++ b/tests/test_credential_predicate_guard.py
@@ -1,0 +1,229 @@
+"""Centralization guard for `requires_api_key` (P5, SL-4.1).
+
+This test is a tripwire, not a proof: it fails when a new gate reads
+`server.requires_api_key` (or its dynamic equivalents) directly instead of
+going through `credential_requirement`/`requires_credential`
+(src/pmcp/manifest/loader.py). A read reached through a variable alias (e.g.
+`f = operator.attrgetter("requires_api_key")`) evades all checks here — every
+gate also carries a behavioural fail-closed test in
+tests/test_credential_gates_startup.py / tests/test_credential_gates_handlers.py,
+which is what actually proves EC-P5-2.
+
+Four checks, per plans/phase-plan-v11-P5.md:
+
+1. Every `ast.Attribute` load of `requires_api_key` under src/pmcp/ must have
+   an enclosing function on the allowlist below (the CapabilityCandidate
+   wire-field consumers — a naive "only credential_requirement may read the
+   attribute" rule cannot pass, because these four reads are intentionally
+   preserved).
+1a. No call anywhere under src/pmcp/ passes `os.environ` (or
+   `os.environ.copy()`) as `child_env` to `credential_requirement` /
+   `requires_credential` — clause 2a of IF-0-P5-1 forbids it.
+2. No dynamic read (`getattr(x, "requires_api_key", ...)`, `x["requires_api_key"]`,
+   `x.get("requires_api_key")`) outside manifest/loader.py — this closes the
+   string-literal bypass that would defeat check 1.
+3. Every allowlisted (file, function) pair still exists and still contains a
+   matching attribute read, so a stale entry cannot silently widen the guard
+   after the code it named is deleted or renamed.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "pmcp"
+
+# (file path relative to src/pmcp, enclosing function name, why it's exempt)
+# These read CapabilityCandidate.requires_api_key — the *wire field* fed by
+# _get_server_env_metadata's effective value (IF-0-P5-3) — not a manifest
+# ServerConfig's declared value. AST cannot distinguish the two by type, so
+# the exemption is explicit and reviewed by hand.
+ALLOWLISTED_ATTRIBUTE_READS: set[tuple[str, str]] = {
+    ("tools/handlers.py", "_sort_key"),
+    ("tools/handlers.py", "request_capability"),
+}
+
+# Function that is allowed to read requires_api_key dynamically (via getattr)
+# because it duck-types over manifest ServerConfig, discovered-server configs,
+# and None. This IS the centralization point every other gate must route
+# through.
+DYNAMIC_READ_ALLOWED_FILE = "manifest/loader.py"
+
+
+def _iter_py_files() -> list[Path]:
+    return sorted(SRC_ROOT.rglob("*.py"))
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(SRC_ROOT))
+
+
+class _FuncStackVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.func_stack: list[str] = []
+        self.attribute_reads: list[tuple[int, str]] = []
+        self.dynamic_reads: list[tuple[int, str]] = []
+        self.child_env_os_environ_calls: list[int] = []
+
+    def _current_func(self) -> str:
+        return self.func_stack[-1] if self.func_stack else "<module>"
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.func_stack.append(node.name)
+        self.generic_visit(node)
+        self.func_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr == "requires_api_key" and isinstance(node.ctx, ast.Load):
+            self.attribute_reads.append((node.lineno, self._current_func()))
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        sl = node.slice
+        if isinstance(sl, ast.Constant) and sl.value == "requires_api_key":
+            self.dynamic_reads.append((node.lineno, self._current_func()))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # getattr(x, "requires_api_key", ...)
+        if isinstance(node.func, ast.Name) and node.func.id == "getattr":
+            if (
+                len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value == "requires_api_key"
+            ):
+                self.dynamic_reads.append((node.lineno, self._current_func()))
+        # x.get("requires_api_key")
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "requires_api_key"
+        ):
+            self.dynamic_reads.append((node.lineno, self._current_func()))
+
+        # child_env=os.environ / os.environ.copy() passed to
+        # credential_requirement / requires_credential
+        callee_name = None
+        if isinstance(node.func, ast.Name):
+            callee_name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            callee_name = node.func.attr
+        if callee_name in ("credential_requirement", "requires_credential"):
+            for kw in node.keywords:
+                if kw.arg != "child_env":
+                    continue
+                value = kw.value
+                if _is_os_environ_expr(value):
+                    self.child_env_os_environ_calls.append(node.lineno)
+
+        self.generic_visit(node)
+
+
+def _is_os_environ_expr(node: ast.expr) -> bool:
+    """True for `os.environ` or `os.environ.copy()`."""
+    target = node
+    if isinstance(target, ast.Call) and isinstance(target.func, ast.Attribute):
+        if target.func.attr == "copy":
+            target = target.func.value
+    return (
+        isinstance(target, ast.Attribute)
+        and target.attr == "environ"
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "os"
+    )
+
+
+def _scan_all_files() -> dict[str, _FuncStackVisitor]:
+    results: dict[str, _FuncStackVisitor] = {}
+    for path in _iter_py_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        visitor = _FuncStackVisitor()
+        visitor.visit(tree)
+        results[_rel(path)] = visitor
+    return results
+
+
+class TestManifestReadsAllowlist:
+    """Check 1: every ast.Attribute load of requires_api_key must be inside
+    an allowlisted (file, function)."""
+
+    def test_no_unallowlisted_attribute_reads(self) -> None:
+        scan = _scan_all_files()
+        violations: list[str] = []
+        for rel_path, visitor in scan.items():
+            for lineno, func_name in visitor.attribute_reads:
+                if (rel_path, func_name) not in ALLOWLISTED_ATTRIBUTE_READS:
+                    violations.append(f"{rel_path}:{lineno} in {func_name}()")
+        assert violations == [], (
+            "Found requires_api_key attribute read(s) outside the allowlist "
+            "— route through credential_requirement()/requires_credential() "
+            f"instead, or add a reviewed allowlist entry: {violations}"
+        )
+
+
+class TestChildEnvMisuse:
+    """Check 1a: no call passes os.environ (or a copy of it) as child_env."""
+
+    def test_no_os_environ_passed_as_child_env(self) -> None:
+        scan = _scan_all_files()
+        violations: list[str] = []
+        for rel_path, visitor in scan.items():
+            for lineno in visitor.child_env_os_environ_calls:
+                violations.append(f"{rel_path}:{lineno}")
+        assert violations == [], (
+            "child_env=os.environ (or a copy) reintroduces the env-strip "
+            f"inversion — see IF-0-P5-1 clause 2a: {violations}"
+        )
+
+
+class TestDynamicReads:
+    """Check 2: getattr/subscript/.get bypasses of the string literal are
+    only permitted inside manifest/loader.py."""
+
+    def test_no_dynamic_reads_outside_loader(self) -> None:
+        scan = _scan_all_files()
+        violations: list[str] = []
+        for rel_path, visitor in scan.items():
+            if rel_path == DYNAMIC_READ_ALLOWED_FILE:
+                continue
+            for lineno, func_name in visitor.dynamic_reads:
+                violations.append(f"{rel_path}:{lineno} in {func_name}()")
+        assert violations == [], (
+            "Found a dynamic ('requires_api_key' string-literal) read "
+            f"outside manifest/loader.py: {violations}"
+        )
+
+    def test_loader_dynamic_read_exists(self) -> None:
+        """Sanity check that the exemption isn't vacuous — loader.py really
+        does read requires_api_key dynamically (inside credential_requirement)."""
+        scan = _scan_all_files()
+        visitor = scan[DYNAMIC_READ_ALLOWED_FILE]
+        assert any(
+            func_name == "credential_requirement"
+            for _lineno, func_name in visitor.dynamic_reads
+        )
+
+
+class TestAllowlistLiveness:
+    """Check 3: every allowlisted entry still exists and still contains a
+    matching read, so it cannot silently widen the guard after the code it
+    named is deleted or renamed."""
+
+    def test_allowlisted_entries_still_present(self) -> None:
+        scan = _scan_all_files()
+        for rel_path, func_name in ALLOWLISTED_ATTRIBUTE_READS:
+            assert rel_path in scan, f"Allowlisted file {rel_path} no longer exists"
+            visitor = scan[rel_path]
+            matching = [
+                fn for _lineno, fn in visitor.attribute_reads if fn == func_name
+            ]
+            assert matching, (
+                f"Allowlist entry ({rel_path}, {func_name}) no longer "
+                "corresponds to any requires_api_key read — remove the stale "
+                "entry so the guard doesn't silently widen"
+            )

--- a/tests/test_credential_predicate_guard.py
+++ b/tests/test_credential_predicate_guard.py
@@ -39,16 +39,36 @@ SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "pmcp"
 # _get_server_env_metadata's effective value (IF-0-P5-3) — not a manifest
 # ServerConfig's declared value. AST cannot distinguish the two by type, so
 # the exemption is explicit and reviewed by hand.
+#
+# _configured_duplicate_missing_credential and _get_server_env_metadata each
+# additionally have ONE attribute read of manifest_server.requires_api_key in
+# their remote-configured-duplicate branch: extra_env cannot reach a remote
+# connection, so that branch deliberately reads the DECLARED requirement
+# only, bypassing credential_requirement()'s relaxation logic on purpose
+# (Consiliency/pmcp#114 board review finding 1, remote variant).
 ALLOWLISTED_ATTRIBUTE_READS: set[tuple[str, str]] = {
     ("tools/handlers.py", "_sort_key"),
     ("tools/handlers.py", "request_capability"),
+    ("tools/handlers.py", "_configured_duplicate_missing_credential"),
+    ("tools/handlers.py", "_get_server_env_metadata"),
 }
 
-# Function that is allowed to read requires_api_key dynamically (via getattr)
-# because it duck-types over manifest ServerConfig, discovered-server configs,
-# and None. This IS the centralization point every other gate must route
-# through.
+# File exempted from check 2 in full: the centralization point every other
+# gate routes through — duck-types over manifest ServerConfig,
+# discovered-server configs, and None, so it necessarily reads the string
+# literal dynamically.
 DYNAMIC_READ_ALLOWED_FILE = "manifest/loader.py"
+
+# (file path, enclosing function) pairs — OUTSIDE DYNAMIC_READ_ALLOWED_FILE —
+# individually allowed one dynamic read each, reviewed by hand.
+DYNAMIC_READ_ALLOWLIST: set[tuple[str, str]] = {
+    # Same remote-configured-duplicate exemption as the two attribute reads
+    # above: extra_env cannot reach a remote connection, so this branch
+    # deliberately reads the declared requirement only, via getattr since
+    # manifest_server is typed Any here (Consiliency/pmcp#114 board review
+    # finding 1, remote variant).
+    ("config/loader.py", "_eager_requires_credential"),
+}
 
 
 def _iter_py_files() -> list[Path]:
@@ -192,10 +212,13 @@ class TestDynamicReads:
             if rel_path == DYNAMIC_READ_ALLOWED_FILE:
                 continue
             for lineno, func_name in visitor.dynamic_reads:
+                if (rel_path, func_name) in DYNAMIC_READ_ALLOWLIST:
+                    continue
                 violations.append(f"{rel_path}:{lineno} in {func_name}()")
         assert violations == [], (
             "Found a dynamic ('requires_api_key' string-literal) read "
-            f"outside manifest/loader.py: {violations}"
+            f"outside manifest/loader.py and outside the reviewed "
+            f"allowlist: {violations}"
         )
 
     def test_loader_dynamic_read_exists(self) -> None:
@@ -226,4 +249,16 @@ class TestAllowlistLiveness:
                 f"Allowlist entry ({rel_path}, {func_name}) no longer "
                 "corresponds to any requires_api_key read — remove the stale "
                 "entry so the guard doesn't silently widen"
+            )
+
+    def test_dynamic_read_allowlist_entries_still_present(self) -> None:
+        scan = _scan_all_files()
+        for rel_path, func_name in DYNAMIC_READ_ALLOWLIST:
+            assert rel_path in scan, f"Allowlisted file {rel_path} no longer exists"
+            visitor = scan[rel_path]
+            matching = [fn for _lineno, fn in visitor.dynamic_reads if fn == func_name]
+            assert matching, (
+                f"Dynamic-read allowlist entry ({rel_path}, {func_name}) no "
+                "longer corresponds to any requires_api_key dynamic read — "
+                "remove the stale entry so the guard doesn't silently widen"
             )

--- a/tests/test_credential_requirement.py
+++ b/tests/test_credential_requirement.py
@@ -84,6 +84,43 @@ class TestExtraEnvRelaxation:
         assert result.relaxed_by is None
 
 
+class TestRemoteServersNeverRelax:
+    """Board review finding 2: extra_env is carried to a spawned local
+    subprocess's environment; a remote (url-based) server has no such
+    subprocess and authenticates via headers, so a relaxer set in extra_env
+    can never actually reach the connection. A remote entry must stay
+    required regardless of api_key_optional_when/extra_env."""
+
+    def test_remote_server_with_usable_relaxer_still_required(self) -> None:
+        server = _server(
+            url="https://mcp.example.com/sse",
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        result = credential_requirement(server)
+        assert result.required is True
+        assert result.relaxed_by is None
+
+    def test_remote_server_with_usable_relaxer_in_child_env_still_required(
+        self,
+    ) -> None:
+        server = _server(url="https://mcp.example.com/sse")
+        result = credential_requirement(
+            server, child_env={"FIRECRAWL_API_URL": "http://localhost:3002"}
+        )
+        assert result.required is True
+        assert result.relaxed_by is None
+
+    def test_local_server_unaffected_by_url_check(self) -> None:
+        # Sanity: a server with no url is unaffected by this clause.
+        server = _server(
+            url=None,
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        assert credential_requirement(server).required is False
+
+
 class TestOsEnvironInversionGuard:
     """Clause 2: the predicate must never read os.environ. This is the guard
     against the env-strip inversion documented in the plan: sanitized_subprocess_env

--- a/tests/test_credential_requirement.py
+++ b/tests/test_credential_requirement.py
@@ -1,0 +1,275 @@
+"""Tests for the shared credential-requirement predicate (P5, Consiliency/pmcp#114).
+
+Pins IF-0-P5-1 (CredentialRequirement / credential_requirement / requires_credential)
+and IF-0-P5-2 (ServerConfig.api_key_optional_when parsing) exactly as frozen in
+plans/phase-plan-v11-P5.md. Every clause here is load-bearing for the seven
+downstream gate consumers (SL-2, SL-3) — do not relax an assertion to make a
+call site convenient; fix the call site instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pmcp.manifest.loader import (
+    CredentialRequirement,
+    ServerConfig,
+    _parse_server_config,
+    credential_requirement,
+    requires_credential,
+)
+
+
+def _server(**overrides: object) -> ServerConfig:
+    base: dict[str, object] = dict(
+        name="firecrawl",
+        description="",
+        keywords=[],
+        install={},
+        command="firecrawl-mcp",
+        args=[],
+        requires_api_key=True,
+        env_var="FIRECRAWL_API_KEY",
+    )
+    base.update(overrides)
+    return ServerConfig(**base)  # type: ignore[arg-type]
+
+
+class TestDeclaredFalseShortCircuit:
+    def test_declared_false_never_required(self) -> None:
+        server = _server(requires_api_key=False, api_key_optional_when=[])
+        result = credential_requirement(server)
+        assert result == CredentialRequirement(
+            required=False, declared=False, relaxed_by=None
+        )
+
+    def test_declared_false_ignores_optional_when(self) -> None:
+        # Clause 3: declared False short-circuits; api_key_optional_when is
+        # irrelevant and must not be consulted.
+        server = _server(
+            requires_api_key=False,
+            api_key_optional_when=["SOME_URL"],
+            extra_env={"SOME_URL": "http://host"},
+        )
+        result = credential_requirement(server)
+        assert result.required is False
+        assert result.relaxed_by is None
+
+
+class TestExtraEnvRelaxation:
+    def test_relaxed_by_extra_env(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        result = credential_requirement(server)
+        assert result == CredentialRequirement(
+            required=False, declared=True, relaxed_by="FIRECRAWL_API_URL"
+        )
+        assert requires_credential(server) is False
+
+    def test_first_usable_name_wins_in_declared_order(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRST_URL", "SECOND_URL"],
+            extra_env={"SECOND_URL": "http://host"},
+        )
+        # FIRST_URL absent, SECOND_URL usable -> relaxed_by SECOND_URL.
+        result = credential_requirement(server)
+        assert result.relaxed_by == "SECOND_URL"
+
+    def test_absent_from_extra_env_fails_closed(self) -> None:
+        server = _server(api_key_optional_when=["FIRECRAWL_API_URL"], extra_env={})
+        result = credential_requirement(server)
+        assert result.required is True
+        assert result.relaxed_by is None
+
+
+class TestOsEnvironInversionGuard:
+    """Clause 2: the predicate must never read os.environ. This is the guard
+    against the env-strip inversion documented in the plan: sanitized_subprocess_env
+    strips managed secret keys from os.environ before the child spawns, so a
+    predicate that relaxed on os.environ would open the gate while the child
+    never receives the variable."""
+
+    def test_monkeypatch_setenv_does_not_relax(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
+        server = _server(api_key_optional_when=["FIRECRAWL_API_URL"], extra_env={})
+        result = credential_requirement(server)
+        assert result.required is True
+        assert result.relaxed_by is None
+
+    def test_credential_requirement_has_no_env_kwarg(self) -> None:
+        import inspect
+
+        sig = inspect.signature(credential_requirement)
+        assert "env" not in sig.parameters
+
+
+class TestPlaceholderValuesRejected:
+    def test_empty_string_rejected(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": ""},
+        )
+        assert credential_requirement(server).required is True
+
+    def test_whitespace_only_rejected(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "   "},
+        )
+        assert credential_requirement(server).required is True
+
+    def test_unexpanded_placeholder_braced_rejected(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "${FIRECRAWL_API_URL}"},
+        )
+        assert credential_requirement(server).required is True
+
+    def test_unexpanded_placeholder_bare_rejected(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "$FIRECRAWL_API_URL"},
+        )
+        assert credential_requirement(server).required is True
+
+
+class TestSelfRelaxationImpossible:
+    def test_self_relax_via_env_var_ignored(self) -> None:
+        server = _server(
+            env_var="FIRECRAWL_API_KEY",
+            api_key_optional_when=["FIRECRAWL_API_KEY"],
+            extra_env={"FIRECRAWL_API_KEY": "some-value"},
+        )
+        result = credential_requirement(server)
+        assert result.required is True
+        assert result.relaxed_by is None
+
+    def test_self_relax_via_secret_key_ignored(self) -> None:
+        server = _server(
+            env_var="FIRECRAWL_API_KEY",
+            secret_key="FIRECRAWL_NAMESPACED_KEY",
+            api_key_optional_when=["FIRECRAWL_NAMESPACED_KEY"],
+            extra_env={"FIRECRAWL_NAMESPACED_KEY": "some-value"},
+        )
+        result = credential_requirement(server)
+        assert result.required is True
+        assert result.relaxed_by is None
+
+    def test_self_relax_dropped_at_parse_time(self) -> None:
+        data = {
+            "description": "",
+            "keywords": [],
+            "install": {},
+            "command": "firecrawl-mcp",
+            "args": [],
+            "requires_api_key": True,
+            "env_var": "FIRECRAWL_API_KEY",
+            "api_key_optional_when": ["FIRECRAWL_API_KEY", "FIRECRAWL_API_URL"],
+        }
+        server = _parse_server_config("firecrawl", data)
+        assert server.api_key_optional_when == ["FIRECRAWL_API_URL"]
+
+
+class TestChildEnvClause2a:
+    def test_child_env_overrides_extra_env_source(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://host-from-manifest"},
+        )
+        # child_env represents the configured-duplicate override: the value the
+        # child will actually receive is a dead placeholder, so the predicate
+        # must judge that value, not the manifest's extra_env.
+        result = credential_requirement(
+            server, child_env={"FIRECRAWL_API_URL": "${FIRECRAWL_API_URL}"}
+        )
+        assert result.required is True
+        assert result.relaxed_by is None
+
+    def test_child_env_none_falls_back_to_extra_env(self) -> None:
+        server = _server(
+            api_key_optional_when=["FIRECRAWL_API_URL"],
+            extra_env={"FIRECRAWL_API_URL": "http://localhost:3002"},
+        )
+        result = credential_requirement(server, child_env=None)
+        assert result.required is False
+        assert result.relaxed_by == "FIRECRAWL_API_URL"
+
+    def test_child_env_relaxes_when_extra_env_empty(self) -> None:
+        server = _server(api_key_optional_when=["FIRECRAWL_API_URL"], extra_env={})
+        result = credential_requirement(
+            server, child_env={"FIRECRAWL_API_URL": "http://localhost:3002"}
+        )
+        assert result.required is False
+        assert result.relaxed_by == "FIRECRAWL_API_URL"
+
+
+class TestFieldParsing:
+    def _parse(self, **data_overrides: object) -> ServerConfig:
+        data: dict[str, object] = dict(
+            description="",
+            keywords=[],
+            install={},
+            command="firecrawl-mcp",
+            args=[],
+            requires_api_key=True,
+            env_var="FIRECRAWL_API_KEY",
+        )
+        data.update(data_overrides)
+        return _parse_server_config("firecrawl", data)
+
+    def test_absent_key_yields_empty_list(self) -> None:
+        server = self._parse()
+        assert server.api_key_optional_when == []
+
+    def test_non_list_yields_empty_list_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            server = self._parse(api_key_optional_when="FIRECRAWL_API_URL")
+        assert server.api_key_optional_when == []
+        assert "api_key_optional_when" in caplog.text
+
+    def test_non_string_members_dropped(self) -> None:
+        server = self._parse(api_key_optional_when=["FIRECRAWL_API_URL", 123, None])
+        assert server.api_key_optional_when == ["FIRECRAWL_API_URL"]
+
+    def test_absent_field_matches_default_behaviour(self) -> None:
+        # Byte-for-byte today's behaviour: requires_api_key True, no relaxer.
+        server = self._parse()
+        assert requires_credential(server) is True
+
+
+class TestDuckTypingAndNone:
+    def test_none_server_not_required(self) -> None:
+        result = credential_requirement(None)
+        assert result == CredentialRequirement(
+            required=False, declared=False, relaxed_by=None
+        )
+        assert requires_credential(None) is False
+
+    def test_duck_typed_object_without_api_key_optional_when(self) -> None:
+        class Discovered:
+            requires_api_key = True
+            env_var = "SOME_KEY"
+            secret_key = None
+            # No api_key_optional_when / extra_env attributes at all.
+
+        result = credential_requirement(Discovered())
+        assert result.required is True
+        assert result.relaxed_by is None
+
+    def test_duck_typed_object_with_extra_env(self) -> None:
+        class Discovered:
+            requires_api_key = True
+            env_var = "SOME_KEY"
+            secret_key = None
+            api_key_optional_when = ["SOME_URL"]
+            extra_env = {"SOME_URL": "http://host"}
+
+        result = credential_requirement(Discovered())
+        assert result.required is False
+        assert result.relaxed_by == "SOME_URL"

--- a/tests/test_manifest_provision.py
+++ b/tests/test_manifest_provision.py
@@ -12,10 +12,12 @@ Live smoke tier (opt-in, ``pytest -m live``):
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import pmcp.manifest.loader as _loader_module
 from pmcp.manifest.installer import JobManager
 from pmcp.manifest.loader import load_manifest
 from pmcp.policy.policy import PolicyManager
@@ -23,9 +25,19 @@ from pmcp.tools.handlers import GatewayTools
 
 # ---------------------------------------------------------------------------
 # Module-level manifest load — shared across all parametrized cases
+#
+# Loaded with an explicit manifest_path so NO private/custom overlay applies
+# (load_manifest() only merges overlays for its no-arg default path). Without
+# this, a developer's real ~/.pmcp/manifest.yaml server_env patch (e.g.
+# pointing firecrawl at a self-hosted FIRECRAWL_API_URL) would change
+# _api_key_servers' effective-requirement behaviour under test — the shipped
+# manifest's api_key_optional_when field (Consiliency/pmcp#114) makes that
+# overlay load-bearing for the first time, where before P5 it was inert for
+# gating purposes.
 # ---------------------------------------------------------------------------
 
-_manifest = load_manifest()
+_SHIPPED_MANIFEST_PATH = Path(_loader_module.__file__).parent / "manifest.yaml"
+_manifest = load_manifest(_SHIPPED_MANIFEST_PATH)
 _all_servers = list(_manifest.servers.values())
 _api_key_servers = [s for s in _all_servers if s.requires_api_key]
 _no_key_servers = [s for s in _all_servers if not s.requires_api_key]


### PR DESCRIPTION
Executes **v11 Phase 5 (P5)** per `plans/phase-plan-v11-P5.md`. Closes #114.

Lets a manifest entry declare its credential optional under an explicit named condition, so reaching a self-hosted endpoint no longer requires planting a placeholder secret. **Security-sensitive** — the failure mode is a server reachable without auth, so verification is weighted toward fail-closed.

## One predicate, seven consumers

`credential_requirement` / `requires_credential` in `manifest/loader.py`, plus `ServerConfig.api_key_optional_when`. Every gate converted:

| # | Consumer | Site |
|---|---|---|
| 1 | eager startup | `config/loader.py:1038` — passes `child_env` for the configured-duplicate case |
| 2 | install | `manifest/installer.py:547` |
| 3 | lifecycle connect | `tools/handlers.py:3200` |
| 4 | provisioning | `tools/handlers.py:4058` |
| 5 | diagnostics | `cli_commands/secrets.py:95` — **two** changes; without skipping manifest-`extra_env` literals in the missing-keys loop, gate 5 would falsely flip `ok=false` |
| 6 | capability discovery | `tools/handlers.py:3365` — feeds 9 downstream sites |
| 7 | `pmcp init` | `cli.py:1528` |

**Why the count moved 4 → 5 → 6 → 7 across review rounds:** `pmcp init` has no `requires_api_key` token at all — it gates on `env_var` alone. Six rounds of grepping for the symbol could never find it. The executing agent traced each consumer's call site rather than trusting the enumeration, and confirmed that is why it was missed.

Shipped `firecrawl: api_key_optional_when: ["FIRECRAWL_API_URL"]` — inert on its own, proven.

## The centralization guard is itself tested

An AST guard enforces four properties: allowlisted manifest-attribute reads, no `child_env=os.environ` misuse, no dynamic `getattr`/subscript bypass, and allowlist liveness.

Crucially, the agent **verified the guard actually guards** — reverted a converted gate to raw `requires_api_key`, confirmed the guard failed, reverted back, confirmed it re-passed. That self-test is not in the plan; an untested guard is a guard that might not guard anything, and it is worth folding into future plans.

## Fail-closed verification

`test_credential_optionality_e2e.py` drives **all seven gates against one fixture in both directions**: relaxed (positive outcomes at every gate — not merely the absence of error markers) and four fail-closed variants — no relaxer declared, relaxer unset, self-relaxing credential, and relaxer present **only in `os.environ`**.

`test_credential_child_env.py` proves IF-0-P5-4 across all three real env-construction paths, run with the relaxer registered as a PMCP-managed secret so `sanitized_subprocess_env`'s strip is genuinely exercised. That is the test that catches the `os.environ`-inversion bug — a gate relaxing while the child never receives the variable, sending the server to the vendor endpoint unauthenticated.

Both configured-duplicate override cases (empty string, `${VAR}` placeholder) fail closed as specified.

## A pre-existing test was environment-dependent

`tests/test_manifest_provision.py` called `load_manifest()` at module level with no isolation, so it picked up **the developer's real `~/.pmcp/manifest.yaml`** — which on this machine carries a `server_env` patch pointing firecrawl at a self-hosted URL. Harmless before P5, since `extra_env` was never read for gating; P5 makes it load-bearing and it broke `test_provision_missing_api_key[firecrawl]`.

Fixed by loading with an explicit `manifest_path`, which by design applies no overlays. One pre-existing test touched, documented in the SL-4 commit as the plan requires.

## Live-boot verification

`test_credential_boot.py` (`-m live`) uses P6CLEAN's isolation recipe verbatim — `HOME`+`XDG_CONFIG_HOME` redirect, `--policy` fixture-only allowlist, `.venv/bin/pmcp`, port 38345, never 3344. Asserts `eager+lazy==1` with `skipped=106/policy_denied=106` (the correct isolated-run signature), a real `gateway.invoke` round trip, and `/proc/<pid>/environ` on the live child showing the relaxer present and the credential absent.

Run three times; the live gateway never blipped — same PID before and after, resolved via `ss`, never by name-matching.

## Roadmap amended

`specs/phase-plans-v11.md` P5 section gained a post-execution amendments block: the consumer count six → seven, and `Produces` corrected from `IF-0-P5-1` alone to `IF-0-P5-1..4`.

## Verification

```
pytest       2343 passed, 3 skipped   (2277 baseline + exactly 66 new)
ruff check / format  clean
mypy src/    clean, 41 files
grep requires_api_key src/pmcp  26 refs — matches the plan exactly
live gateway :3344  pid unchanged throughout
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TipZqutam94G46ynLXKuWt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->