### PR TITLE
test: pin manifest path in credential-gate startup tests (fixes #125)

### DIFF
--- a/tests/test_credential_gates_startup.py
+++ b/tests/test_credential_gates_startup.py
@@ -37,10 +37,22 @@ def _pin_manifest_path(monkeypatch: pytest.MonkeyPatch, manifest_path: Path) -> 
     user-overlay lookup, not the independent project-overlay walk from
     Path.cwd() (_find_project_manifest). Passing an explicit manifest_path
     puts load_manifest() into its documented no-overlay mode, bypassing both
-    (Consiliency/pmcp#125)."""
+    (Consiliency/pmcp#125).
+
+    Both binding styles must be patched. cli.run_init imports load_manifest
+    INSIDE the function, so it picks up a patch on the loader module at call
+    time; cli_commands.secrets imports it at MODULE scope, binding the name
+    once at import, where a loader-module patch never reaches it. Patching
+    only the former silently leaves the latter resolving the real overlay
+    chain -- which is a false pass, not a failure, for any test asserting the
+    relaxed direction.
+    """
+    pinned = lambda *a, **kw: _real_load_manifest(manifest_path)  # noqa: E731
+    monkeypatch.setattr("pmcp.manifest.loader.load_manifest", pinned)
+    # Module-scope re-binders. raising=False so this stays correct if a
+    # consumer moves to a call-time import.
     monkeypatch.setattr(
-        "pmcp.manifest.loader.load_manifest",
-        lambda *a, **kw: _real_load_manifest(manifest_path),
+        "pmcp.cli_commands.secrets.load_manifest", pinned, raising=False
     )
 
 
@@ -343,7 +355,7 @@ def _write(path: Path, text: str) -> None:
 class TestGate5SecretsCheck:
     @pytest.mark.asyncio
     async def test_relaxed_server_reports_ok_with_no_missing_keys(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from pmcp.cli_commands.secrets import run_secrets_check
 
@@ -360,11 +372,8 @@ class TestGate5SecretsCheck:
             ),
         )
 
-        with patch.dict(
-            "os.environ",
-            {"HOME": str(home), "PMCP_MANIFEST_PATH": str(overlay)},
-            clear=False,
-        ):
+        _pin_manifest_path(monkeypatch, overlay)
+        with patch.dict("os.environ", {"HOME": str(home)}, clear=False):
             os.environ.pop("CRED_TEST_API_KEY", None)
             output = await run_secrets_check(argparse.Namespace(project=project))
 
@@ -374,7 +383,9 @@ class TestGate5SecretsCheck:
         assert output["ok"] is True
 
     @pytest.mark.asyncio
-    async def test_required_server_still_reports_missing(self, tmp_path: Path) -> None:
+    async def test_required_server_still_reports_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from pmcp.cli_commands.secrets import run_secrets_check
 
         home = tmp_path / "home"
@@ -390,11 +401,8 @@ class TestGate5SecretsCheck:
             ),
         )
 
-        with patch.dict(
-            "os.environ",
-            {"HOME": str(home), "PMCP_MANIFEST_PATH": str(overlay)},
-            clear=False,
-        ):
+        _pin_manifest_path(monkeypatch, overlay)
+        with patch.dict("os.environ", {"HOME": str(home)}, clear=False):
             os.environ.pop("CRED_TEST_API_KEY", None)
             output = await run_secrets_check(argparse.Namespace(project=project))
 
@@ -508,5 +516,4 @@ servers:
 
         captured = capsys.readouterr()
         assert "pmcp secrets set FIRECRAWL_API_KEY" in captured.out
-        assert "No credential needed" not in captured.out
         assert "No credential needed" not in captured.out

--- a/tests/test_credential_gates_startup.py
+++ b/tests/test_credential_gates_startup.py
@@ -16,10 +16,32 @@ from unittest.mock import patch
 
 import pytest
 
+import pmcp.manifest.loader as _manifest_loader_module
 from pmcp.config.loader import StartupSkipReason, resolve_startup_configs
 from pmcp.manifest.installer import MissingApiKeyError, check_api_key
 from pmcp.manifest.loader import ServerConfig
+from pmcp.manifest.loader import load_manifest as _real_load_manifest
 from pmcp.types import LocalMcpServerConfig, RemoteMcpServerConfig, ResolvedServerConfig
+
+# The real shipped manifest.yaml, loaded via an explicit path so NO overlay
+# (~/.pmcp/manifest.yaml, a project .pmcp/manifest.yaml reachable by walking
+# up from cwd, or $PMCP_MANIFEST_PATH) applies (Consiliency/pmcp#125). Same
+# immunity property tests/test_manifest_provision.py already relies on.
+SHIPPED_MANIFEST_PATH = Path(_manifest_loader_module.__file__).parent / "manifest.yaml"
+
+
+def _pin_manifest_path(monkeypatch: pytest.MonkeyPatch, manifest_path: Path) -> None:
+    """Force every load_manifest() call — however many layers of local
+    import away, as in cli.run_init — to resolve against *manifest_path*
+    only. Patching HOME (or Path.home) is NOT sufficient: it only blocks the
+    user-overlay lookup, not the independent project-overlay walk from
+    Path.cwd() (_find_project_manifest). Passing an explicit manifest_path
+    puts load_manifest() into its documented no-overlay mode, bypassing both
+    (Consiliency/pmcp#125)."""
+    monkeypatch.setattr(
+        "pmcp.manifest.loader.load_manifest",
+        lambda *a, **kw: _real_load_manifest(manifest_path),
+    )
 
 
 def _relaxable_server(
@@ -408,15 +430,16 @@ class TestGate5SecretsCheck:
 class TestGate7RunInit:
     @pytest.mark.asyncio
     async def test_relaxed_server_prints_no_credential_needed(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from pmcp.cli import run_init
 
-        home = tmp_path / "home"
-        overlay = tmp_path / "overlay.yaml"
-        home.mkdir()
+        fixture_manifest = tmp_path / "manifest.yaml"
         _write(
-            overlay,
+            fixture_manifest,
             """
 servers:
   firecrawl:
@@ -431,20 +454,16 @@ servers:
       FIRECRAWL_API_URL: "http://localhost:3002"
 """,
         )
+        _pin_manifest_path(monkeypatch, fixture_manifest)
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
         project = tmp_path / "project"
         args = argparse.Namespace(command="init", project=project, force=False)
 
         def _select_firecrawl(prompt: str) -> str:
             return "y" if "firecrawl" in prompt else ""
 
-        with patch.dict(
-            "os.environ",
-            {"HOME": str(home), "PMCP_MANIFEST_PATH": str(overlay)},
-            clear=False,
-        ):
-            os.environ.pop("FIRECRAWL_API_KEY", None)
-            with patch("builtins.input", side_effect=_select_firecrawl):
-                await run_init(args)
+        with patch("builtins.input", side_effect=_select_firecrawl):
+            await run_init(args)
 
         content = (project / ".mcp.json").read_text()
         assert '"firecrawl"' in content
@@ -456,29 +475,38 @@ servers:
 
     @pytest.mark.asyncio
     async def test_required_server_instruction_unchanged(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A server that still requires a credential keeps the exact
-        `pmcp secrets set` instruction — byte-for-byte unchanged."""
+        `pmcp secrets set` instruction — byte-for-byte unchanged.
+
+        Pinned against the real shipped manifest.yaml (no overlay applied),
+        proving this against the actual production firecrawl entry rather
+        than a synthetic one — immune to a developer's own
+        ~/.pmcp/manifest.yaml server_env patch for firecrawl, or any other
+        overlay (Consiliency/pmcp#125). Env-based isolation (patching HOME)
+        was not sufficient here: it blocks only the user-overlay lookup, not
+        the independent project-overlay walk from Path.cwd()."""
         from pmcp.cli import run_init
 
-        home = tmp_path / "home"
-        home.mkdir()
+        _pin_manifest_path(monkeypatch, SHIPPED_MANIFEST_PATH)
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
         project = tmp_path / "project"
         args = argparse.Namespace(command="init", project=project, force=False)
 
         def _select_firecrawl(prompt: str) -> str:
             return "y" if "firecrawl" in prompt else ""
 
-        with patch.dict("os.environ", {"HOME": str(home)}, clear=False):
-            os.environ.pop("FIRECRAWL_API_KEY", None)
-            os.environ.pop("PMCP_MANIFEST_PATH", None)
-            with patch("builtins.input", side_effect=_select_firecrawl):
-                await run_init(args)
+        with patch("builtins.input", side_effect=_select_firecrawl):
+            await run_init(args)
 
         content = (project / ".mcp.json").read_text()
         assert '"firecrawl"' in content
 
         captured = capsys.readouterr()
         assert "pmcp secrets set FIRECRAWL_API_KEY" in captured.out
+        assert "No credential needed" not in captured.out
         assert "No credential needed" not in captured.out


### PR DESCRIPTION
Fixes #125.

`TestGate7RunInit::test_required_server_instruction_unchanged` passes in CI but fails on any machine where the operator has a real `~/.pmcp/manifest.yaml` supplying a relaxer variable. The relaxer legitimately fires, so `run_init` prints "No credential needed" instead of the expected `pmcp secrets set FIRECRAWL_API_KEY`.

This is a **test-isolation defect, not a gate defect** — the credential-gate logic is correct and is unchanged here.

## Why patching HOME wasn't enough

Patching `HOME` blocks only the user-overlay lookup. It does not block the independent project-overlay walk from `Path.cwd()` (`_find_project_manifest`), which is independent of both `--project` and `HOME`. These tests now pin an explicit `manifest_path`, putting `load_manifest()` into its documented no-overlay mode — the same immunity property `tests/test_manifest_provision.py` already relies on.

## The direction that matters

The failing test asserted the **required** direction, so a local overlay made it fail loudly. The dangerous case is the opposite: a test asserting the **relaxed** direction would pass *for the wrong reason* — green because the operator's overlay supplied the relaxer, not because the code works. Both directions in this file are now pinned, which is why this is a 3-site fix rather than a one-line one.

## Verification

- 17/17 in the file green **with** an operator overlay present at `~/.pmcp/manifest.yaml`
- 17/17 green under an isolated `HOME`
- Full suite 2364 passed / 3 skipped; ruff, ruff format, mypy clean

The isolated direction must be tested by changing where the code looks (`HOME=/tmp/... XDG_CONFIG_HOME=/tmp/...`), never by removing the operator's file — deleting the input that gives a test its meaning and observing a pass manufactures the result instead of verifying it.

## Impact

CI is unaffected (clean runner, no overlay). This only ever failed for operators running the suite locally against a real self-hosted deployment — exactly the configuration `server_env` was added to support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->