### PR TITLE
chore: v1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-08-06
+
 ### Added
 - **Manifest credential optionality (`api_key_optional_when`).** A manifest
   server entry can now name the `extra_env` variable (e.g. a self-hosted base
@@ -59,6 +61,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the wrong release.
 
 ### Fixed
+- **Credential-gate startup tests no longer depend on the machine's manifest
+  overlays.** `tests/test_credential_gates_startup.py` passed in CI but failed
+  for any operator with a real `~/.pmcp/manifest.yaml` supplying a relaxer
+  variable: the relaxer legitimately fired, so `pmcp init` printed
+  "No credential needed" where the test expected the credential instruction.
+  Patching `HOME` is not sufficient to isolate manifest resolution — it blocks
+  only the user-overlay lookup, not the independent project-overlay walk from
+  `Path.cwd()`, and `PMCP_MANIFEST_PATH` is the top of the overlay chain rather
+  than a bypass. These tests now pin an explicit manifest path. The direction
+  that mattered was the inverse of the observed failure: a test asserting the
+  *relaxed* path would have passed for the wrong reason — green because the
+  operator's overlay supplied the relaxer, not because the code worked.
+  (Consiliency/pmcp#125)
 - **The last outstanding item from `specs/phase-plans-v10.md` Phase 6 is closed
   out.** `test_monitor_server_ready_on_startup_pattern`
   (`tests/test_manifest.py`) asserted `job.status == "server_ready"` after a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.21.1"
+version = "1.22.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.21.1"
+__version__ = "1.22.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.21.1"
+version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **v1.22.0** from `main` (`f3eda1d`). Minor bump — adds a feature.

## Contents

- **P5** — manifest credential optionality (`api_key_optional_when`), one shared predicate behind all seven `requires_api_key` gates (#114)
- **P1** — release-guard hardening: `min-version-smoke`, weekly `schedule:`, `__version__` drift test, corrected `mcp` floor (#122)
- **P6CLEAN** — de-flaked `test_monitor_server_ready_on_startup_pattern` (#123)
- **#125** — credential-gate startup tests no longer depend on the machine's manifest overlays (#126)

## Version sites

Both bumped together: `pyproject.toml` and `src/pmcp/__init__.py`. P1's drift test (`tests/test_package_metadata.py`) is what makes that a checked invariant rather than a habit — bumping one without the other makes `/health` and the `pmcp/{version}` User-Agent report the wrong release, which is how 0.1.2 shipped wrong in the sibling repo.

## Verification

- Full suite 2364 passed / 3 skipped
- ruff, ruff format, mypy clean
- Drift test green against the bumped version

Merging this and pushing `v1.22.0` triggers `release.yml` → build → PyPI (trusted publishing) → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->