### PR TITLE
feat(P2): gateway runtime parity on mcp 2.x

### DIFF
--- a/.claude/docs-catalog.json
+++ b/.claude/docs-catalog.json
@@ -1,18 +1,20 @@
 {
   "version": 1,
-  "last_updated": "2026-08-06T06:22:47+00:00",
+  "last_updated": "2026-08-08T06:49:11+00:00",
   "files": {
     "README.md": {
       "purpose": "root project README",
       "touched_by_phases": [
-        "P5"
+        "P5",
+        "P2"
       ]
     },
     "CHANGELOG.md": {
       "purpose": "release changelog",
       "touched_by_phases": [
         "P1",
-        "P5"
+        "P5",
+        "P2"
       ]
     },
     "CONTRIBUTING.md": {
@@ -25,7 +27,8 @@
     "SECURITY.md": {
       "purpose": "security policy",
       "touched_by_phases": [
-        "P5"
+        "P5",
+        "P2"
       ]
     },
     ".claude/plans/ticklish-inventing-stearns.md": {
@@ -51,7 +54,8 @@
     "specs/phase-plans-v11.md": {
       "purpose": "multi-phase roadmap spec",
       "touched_by_phases": [
-        "P1"
+        "P1",
+        "P2"
       ]
     },
     "specs/phase-plans-v2.md": {
@@ -146,6 +150,12 @@
       "purpose": "per-phase lane plan",
       "touched_by_phases": [
         "P1"
+      ]
+    },
+    "plans/phase-plan-v11-P2.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": [
+        "P2"
       ]
     },
     "plans/phase-plan-v11-P5.md": {

--- a/.github/probe/p1_probe_client.py
+++ b/.github/probe/p1_probe_client.py
@@ -17,7 +17,7 @@ import json
 import sys
 
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 SENTINEL = "p1-floor-ok:"
 
@@ -58,7 +58,7 @@ def _check(label: str, result: object) -> dict:
     produce a JSON body at all, and `ok` catches gateway-level ones.
     """
     payload = _text_of(result)
-    if getattr(result, "isError", False):
+    if getattr(result, "is_error", False):
         raise ProbeFailure(f"{label} failed at the transport level: {payload}")
 
     try:
@@ -81,7 +81,7 @@ def _check(label: str, result: object) -> dict:
 
 
 async def main(url: str) -> None:
-    async with streamablehttp_client(url) as (read, write, _):
+    async with streamable_http_client(url) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
 

--- a/.github/probe/p1_probe_server.py
+++ b/.github/probe/p1_probe_server.py
@@ -18,9 +18,9 @@ The gateway SIGKILLs orphaned downstream processes at startup, matching on
 unrelated process on the runner can collide with.
 """
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
-mcp = FastMCP("p1probe")
+mcp = MCPServer("p1probe")
 
 
 @mcp.tool()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The declared `mcp` bound is raised from `>=1.8.0,<2.0.0` to `>=2.0.0,<3.0.0`,
+  and the gateway's upstream server and downstream client are ported onto it.**
+  pmcp now serves two protocol eras simultaneously, each reached a different
+  way: the handshake era — `2024-11-05` through `2025-11-25` — is negotiated
+  the way it always was, through `initialize`; the modern era — `2026-07-28`
+  — is not negotiable through `initialize` at all, and is instead selected
+  per request by the `MCP-Protocol-Version` header plus a `params._meta`
+  envelope (`io.modelcontextprotocol/protocolVersion` and
+  `io.modelcontextprotocol/clientCapabilities`), with `server/discover`
+  advertising it out of band. Downstream, pmcp continues to speak only the
+  handshake era to the servers it proxies — `client/manager.py`'s
+  `PREFERRED_PROTOCOL_VERSION` ceiling is unchanged at `2025-11-25` — so no
+  downstream server is reached at `2026-07-28` by this or any prior release.
+  One limitation of the modern era is structural, not a pmcp gap: it has no
+  back-channel, so server-initiated requests such as `sampling/createMessage`
+  and `elicitation/create` do not exist at `2026-07-28` (pmcp does not proxy
+  either today, so this changes nothing pmcp currently does — it is recorded
+  here because a future phase that wants to add one will hit it).
+  Declares `httpx`, `httpx2`, and `jsonschema` as direct dependencies for the
+  first time — `mcp` 2.0.0 depends on `httpx2` rather than `httpx`, and no
+  longer validates tool input schemas itself — closing the undeclared-
+  transitive-dependency gap that has shipped this repo broken before.
+
 ## [1.22.0] - 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -776,11 +776,23 @@ values. Audit events are bounded in memory and include method/action, server or
 tool identity, protocol version when known, task ID when present, outcome,
 latency, auth state, and redacted error text.
 
-PMCP's Streamable HTTP endpoint remains compatible with existing clients that
-send no draft headers. It also tolerates `MCP-Protocol-Version`, `Mcp-Method`,
-and `Mcp-Name` request headers for clients experimenting with draft MCP
-transport conventions. These headers are compatibility inputs, not a promise
-that PMCP implements every draft MCP extension.
+PMCP's Streamable HTTP endpoint serves two protocol eras on the same `/mcp`
+route, upstream of clients. A client that negotiates through `initialize` is
+served the handshake era — `2024-11-05` through `2025-11-25`. A client that
+instead sends an `MCP-Protocol-Version: 2026-07-28` header together with a
+`params._meta` envelope carrying `io.modelcontextprotocol/protocolVersion`
+and `io.modelcontextprotocol/clientCapabilities` is served the modern era —
+`2026-07-28` — for `tools/list`, `tools/call`, `resources/list`,
+`resources/read`, `prompts/list`, `prompts/get`, and `server/discover`. The
+modern era is not reachable through `initialize`; it is selected per request
+by those headers. Because the modern era has no server-initiated
+back-channel, requests like `sampling/createMessage` and `elicitation/create`
+do not exist at `2026-07-28` — PMCP does not proxy either today, so this is a
+protocol-era limitation, not a PMCP gap. Downstream, PMCP's connections to
+the servers it proxies are negotiated only at the handshake era described
+above (`2025-11-25` preferred) — no downstream server is ever reached at
+`2026-07-28`. A modern-era client's `tools/call` is still proxied live over
+that handshake-era downstream connection; only the upstream envelope differs.
 
 Servers stopped with `gateway.disconnect_server` remain visible in health as
 `offline` or `lazy` when PMCP still knows their configuration, and startup policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,9 +113,16 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
   held in gateway memory for visibility and cancellation. They are not durable
   audit records and do not provide cross-user authorization isolation on
   unauthenticated local transports.
-- **Draft protocol compatibility is additive**: PMCP tolerates current/draft MCP
-  protocol and Streamable HTTP header metadata where documented, but unsupported
-  draft extensions remain out of scope until PMCP explicitly claims them.
+- **Two protocol eras are served on one endpoint, through the same policy
+  gate**: the `MCP-Protocol-Version: 2026-07-28` header plus a `params._meta`
+  envelope route a request to the modern era instead of the
+  `initialize`-negotiated handshake era (`2024-11-05`–`2025-11-25`) — see
+  README's protocol-negotiation section. Both eras dispatch through the same
+  registered handlers, so the same policy, audit, and input-schema validation
+  applies regardless of which era selected the request; the modern era is not
+  a lower-trust bypass. Unsupported draft extensions beyond the six proxied
+  operations and `server/discover` remain out of scope until PMCP explicitly
+  claims them.
 
 ## Reporting a Vulnerability
 

--- a/plans/phase-plan-v11-P2.md
+++ b/plans/phase-plan-v11-P2.md
@@ -855,6 +855,18 @@ overrides the docs-sweep template's default list for this phase only.
   moved to `:1856`/`:1879`. The error-`code`/`data` discard exists at `:1718` as well as
   `:1506`. `src/pmcp/manifest/registry.py` is **not** affected despite a camelCase regex
   suggesting otherwise, and needs no owner.
+- **Post-execution: all of the above confirmed as planned, plus findings SL-1..SL-4
+  surfaced only by running the real gates** — `Tool(inputSchema=...)` validates at
+  runtime but fails `mypy` (26 sites in `tools/handlers.py` needed `input_schema=` after
+  all), a second `httpx2.AsyncClient` leak on failed connects (not just the reconnect
+  path IF-0-P2-2 named), an open `disconnect_all()`/anyio cancel-scope interaction
+  deferred to P3B, three pre-existing test bugs unmasked by the port, and
+  `booted_gateway()`'s no-live-gateway-required semantics. The `cli.py`/error-discard
+  line numbers above have moved again since this note was written (`:1856`/`:1879` and
+  `:1544`/`:1760` respectively — re-grep rather than trust either set of numbers). Full
+  record with citations: `specs/phase-plans-v11.md` → Phase 2 →
+  `### Post-execution amendments`. The V5a verification command in this file's own
+  `## Verification` block was corrected in place for the same reason (item 1 there).
 
 ## Execution Policy
 - execute: effort=medium
@@ -1065,9 +1077,17 @@ rg -n '2026-07-28' CHANGELOG.md
 rg -n '2025-11-25' CHANGELOG.md
 # V5a — the four now-direct dependencies are declared with two-sided bounds, and the
 #       two 2.0.0 API removals have no callers left.
+#       POST-EXECUTION CORRECTION (SL-docs, see specs/phase-plans-v11.md > Phase 2 >
+#       Post-execution amendments, item 1): the bare `from mcp.server.fastmcp` grep
+#       below has one INTENTIONAL match once SL-4 lands —
+#       tests/runtime/test_downstream_handshake_era.py's `DOWNSTREAM_1X_SRC`, a string
+#       literal holding the source of the mcp==1.25.0-pinned subprocess fixture
+#       EC-P2-4 requires. It is never imported into this 2.0.0 process — confirmed by
+#       AST that the module has zero real fastmcp imports. Exclude that one file by
+#       path rather than deleting the fixture.
 rg -n '"mcp>=2\.0\.0,<3\.0\.0"|"httpx>=|"httpx2>=|"jsonschema>=' pyproject.toml
 ! rg -n 'AnyUrl' src/pmcp/server.py
 ! rg -n 'JSONRPCMessage\.model_validate' src/pmcp/
-! rg -n 'from mcp.server.fastmcp' .github/probe/ tests/
+! rg -n 'from mcp.server.fastmcp' .github/probe/ tests/ --glob '!tests/runtime/test_downstream_handshake_era.py'
 gh pr view 112 --json state,url --jq '.state'   # expect CLOSED
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,21 +31,53 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # Upper bound is load-bearing: mcp 2.0.0 renamed
-    # mcp.client.streamable_http.streamablehttp_client to streamable_http_client,
-    # which client/manager.py imports at module scope. Without the cap a fresh
-    # install resolves to 2.x and the gateway dies on startup with an ImportError.
-    # Raising this requires porting that import (and auditing the rest of 2.x).
+    # Upper bound is load-bearing: 3.0.0 is unreleased and unaudited. pmcp's
+    # P2 phase ported the gateway's upstream handlers and downstream
+    # transport onto mcp 2.0.0's rewritten low-level Server (typed on_*
+    # callbacks replace the removed decorators) and Streamable HTTP client
+    # (streamable_http_client replaces streamablehttp_client, and owns a
+    # caller-supplied httpx2.AsyncClient rather than building its own). A
+    # future 3.x may reshape either surface again; raising this cap requires
+    # re-auditing both the way P2 did for 2.x, not just relaxing the pin.
     #
-    # The lower bound is load-bearing too, and was set by INSTALLING, not by
-    # reading source. client/manager.py imports streamablehttp_client from
-    # mcp.client.streamable_http at module scope, and that module first exists
-    # in mcp 1.8.0: the previously declared >=1.0.0 was never installable, and
-    # 1.0.0/1.6.0/1.7.0/1.7.1 all die with
-    # `ModuleNotFoundError: No module named 'mcp.client.streamable_http'`.
-    # At 1.8.0 the gateway boots, listens, and serves a real downstream tool
-    # call. The min-version-smoke CI job re-proves this floor on every run.
-    "mcp>=1.8.0,<2.0.0",
+    # The lower bound is load-bearing too: 2.0.0 is the first mcp release
+    # with all three symbols pmcp now imports directly — the low-level
+    # Server's on_* constructor kwargs (server.py), streamable_http_client
+    # (client/manager.py), and the server/discover handler + the
+    # 2026-07-28 modern-era envelope (mcp_types.version) — and it is also
+    # simply the oldest stable 2.x release; there is no 2.0.0-rc or 1.x
+    # release that has these. Below 2.0.0, client/manager.py's module-scope
+    # `from mcp.client.streamable_http import streamable_http_client`
+    # raises ImportError (that name doesn't exist before 2.0.0) and the
+    # gateway dies on startup. The min-version-smoke CI job re-proves this
+    # floor on every run, including a real downstream tool call through a
+    # booted gateway.
+    "mcp>=2.0.0,<3.0.0",
+    # httpx (distinct from httpx2 below) is for cli.py's two diagnostics
+    # probes (_probe_sse_endpoint, _probe_http_health), which do a bare
+    # `import httpx`. Through mcp 1.x this rode in transitively via mcp's
+    # own httpx dependency; mcp 2.0.0 depends on httpx2 instead and declares
+    # no httpx at all, so an undeclared `import httpx` would now be a
+    # ModuleNotFoundError on a clean install. Declared directly rather than
+    # left transitive, per this repo's standing rule against undeclared
+    # transitive imports (it has shipped broken twice riding one).
+    "httpx>=0.27,<1.0",
+    # httpx2 (distinct from httpx above) is for client/manager.py's
+    # downstream Streamable HTTP transport: streamable_http_client requires
+    # a caller-supplied httpx2.AsyncClient (mcp 2.0.0 no longer builds and
+    # owns its own), and pmcp constructs one explicitly with
+    # follow_redirects=True to match 1.x's create_mcp_http_client default,
+    # since httpx2.AsyncClient's own default is False. The floor matches
+    # mcp 2.0.0's own `Requires-Dist: httpx2>=2.5.0`.
+    "httpx2>=2.5.0,<3.0.0",
+    # jsonschema is for server.py's restored tool input-schema validation.
+    # mcp 1.x's low-level Server did `jsonschema.validate(instance=arguments,
+    # schema=tool.inputSchema)` inside its call_tool decorator; mcp 2.0.0's
+    # low-level Server does no such validation (mcp/server/validation.py is
+    # sampling/elicitation only), so pmcp now does this check itself and
+    # must depend on jsonschema directly rather than ride mcp's transitive
+    # `Requires-Dist: jsonschema>=4.20.0`, whose floor this matches.
+    "jsonschema>=4.20.0,<5.0.0",
     "pydantic>=2.0",
     "pyjwt[crypto]>=2.10.0",
     "pyyaml>=6.0",

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -249,6 +249,130 @@ Raise `pmcp` onto `mcp` 2.x so it runs correctly on the new library and negotiat
 - redaction posture: `metadata_only`
 - note: if Assumption 1a (the two-era split) proves wrong, this phase must raise a roadmap amendment before P3B is planned.
 
+### Post-execution amendments
+
+Recorded by SL-docs after SL-1 through SL-4 landed and were verified. Assumption 1a
+(the two-era split) was **confirmed, not falsified** — `mcp_types/version.py` declares
+exactly the split this roadmap describes — so nothing below reopens that axis; these are
+corrections to detail the roadmap's lane partition and scope notes got wrong or omitted,
+plus findings surfaced only during execution.
+
+1. **The roadmap's 4-lane partition (Scope notes, above) omits four files the phase plan
+   had to give an explicit owner.** `src/pmcp/manifest/refresher.py` (its `ClientSession`/
+   `stdio_client` imports were verified unaffected, but the file needed an owner to prove
+   that), `src/pmcp/transport/http.py` and `src/pmcp/tools/handlers.py` (both went to Lane
+   A / SL-2, alongside `src/pmcp/server.py`), and `.github/probe/**` (went to Lane D /
+   SL-4). `src/pmcp/manifest/registry.py` was checked and needs **no** owner: it has no
+   `mcp` import, and its camelCase identifiers (`isLatest`, `remoteUrl`, `nextCursor`, …)
+   are keys of the unrelated MCP Registry REST API, not MCP protocol models — a camelCase
+   regex sweep pulls it in but a check for `mcp` usage correctly excludes it.
+2. **`mcp.server.fastmcp` not existing in `mcp` 2.0.0 is what actually gates EC-P2-1.**
+   `.github/probe/p1_probe_server.py` imported it; `min-version-smoke` boots a gateway
+   from that probe at the declared floor, so EC-P2-1 cannot pass until the probe is
+   ported to `mcp.server.MCPServer`. The roadmap's Scope notes for Lane D name the probes
+   but not this specific blocking dependency.
+3. **Two hard runtime breaks the roadmap never named, both load-bearing:**
+   - `Resource.uri` and `TextResourceContents.uri` move from `AnyUrl` to `str` in `mcp`
+     2.0.0. `Resource(uri=AnyUrl(...))` raises `ValidationError` under 2.0.0's `Tool`/
+     `Resource` models; `src/pmcp/server.py` constructed exactly that at four call sites
+     and imported `AnyUrl` for it. SL-2 dropped the import and passed plain strings.
+   - `JSONRPCMessage` stops being a pydantic model — it is a bare `types.UnionType` in
+     2.0.0 (`mcp_types/jsonrpc.py`) with no `.model_validate`. `client/manager.py` called
+     `JSONRPCMessage.model_validate(...)` on every outbound remote request and
+     notification; the replacement is `mcp_types.jsonrpc_message_adapter` (a
+     `TypeAdapter`), which SL-3 substituted at both call sites.
+   - A **measured** finding narrows the churn these two breaks might suggest: 2.0.0's
+     `MCPModel` keeps `populate_by_name=True`, so constructor-keyword camelCase (e.g.
+     `Tool(inputSchema=...)`) still validates — only *attribute reads* of the camelCase
+     name break. `src/pmcp/tools/handlers.py`'s 26 `inputSchema=` construction sites
+     therefore needed no source change; only the handful of `.inputSchema`/`.mimeType`/
+     `.isError` *attribute reads* elsewhere (`src/pmcp/server.py`, and seven sites in
+     `tests/`) had to move to snake_case. See item 6 below for a second gate the plan
+     checked only against runtime evidence, not this one.
+4. **`cli.py`'s two `import httpx` sites are at `:1856` and `:1879`**, not the roadmap's
+   approximate `~:1844`/`~:1867` (both files have moved since the roadmap was written).
+   Both were left unedited, per Decision 2: `httpx` is now declared directly rather than
+   riding `mcp`'s (removed) transitive dependency, and `httpx2` is declared separately for
+   the downstream transport client — two HTTP stacks coexist deliberately.
+5. **The JSON-RPC error `code`/`data` discard the roadmap flagged exists at two sites, not
+   one**: `client/manager.py`'s stdio path (`_handle_stdout_line`, currently `:1544`) and
+   its remote path (`_read_sse`, currently `:1760` — the roadmap's `~:1718` has also
+   moved). Both do `Exception(payload["error"].get("message", "Unknown error"))`,
+   discarding `code` and `data`. No P2 exit criterion depends on typed downstream errors,
+   so SL-3 left the behaviour unchanged at both sites and added a `# TODO(P3B)` naming the
+   dropped fields at each — **deferred to P3B**, not a P2 defect.
+6. **Three of the "resolved" Execution Notes decisions, plus a fourth the roadmap didn't
+   anticipate at all, all confirmed as recorded** — Decision 1 (`Server.__init__(on_*=...)`
+   over `add_request_handler`, on typed-`params_type` and mypy-checked-result-type
+   grounds), Decision 2 (declare both `httpx` and `httpx2`, leave `cli.py` unedited), and
+   Decision 3 (keep the default `OpenTelemetryMiddleware`, pinned by test rather than left
+   to inherit silently) all landed exactly as decided, with the source citations the plan
+   gives. The fourth, found only once execution ran the CI gates the plan's own reasoning
+   had not: **`Tool(inputSchema=...)` validates at runtime but fails `mypy`**, both true
+   simultaneously. SL-2/SL-4 hit `Unexpected keyword argument "inputSchema" for "Tool"; did
+   you mean "input_schema"?` from `uv run mypy src/pmcp --exclude baml_client` on the
+   pre-fix tree and changed all 26 sites in `src/pmcp/tools/handlers.py` to `input_schema=`
+   (confirmed by this docs session: `git show 5f40168:src/pmcp/tools/handlers.py | grep -c
+   inputSchema=` on the pre-P2 commit is exactly 26; `mypy` on the current, fixed tree is
+   clean). Runtime acceptance is fine — `populate_by_name=True` accepts the field name and
+   the camelCase alias equally as a *constructor* keyword — but mypy synthesizes
+   `Tool.__init__` from
+   the field names via `dataclass_transform` and has no notion of alias acceptance, so it
+   only accepts `input_schema=`. `uv run mypy src/pmcp` is a required CI gate
+   (`tool test command` for SL-2.4/SL-4.8), so this is not cosmetic: item 3's "26 sites
+   need no change" claim was verified against runtime behaviour only, which is the wrong
+   gate. All 26 sites in `src/pmcp/tools/handlers.py` were changed to `input_schema=`.
+   **Rule for future phases: in pmcp source, prefer the field name over the wire alias**,
+   even where an SDK's own prose examples show the camelCase alias — it is the only form
+   both runtime and `mypy` accept.
+7. **A second `httpx2.AsyncClient` leak beyond the one IF-0-P2-2 named.** IF-0-P2-2
+   describes the reconnect-path leak (`_cleanup_client` not closing `sse_exit_stack` for
+   remote clients) and SL-3 fixed it. Execution surfaced a second, adjacent leak the
+   interface freeze didn't name: if entering the transport context itself raises *after*
+   the owned `httpx2.AsyncClient` is already in `remote_stack`, the client leaked on
+   failed connects too. SL-3 fixed both in `_connect_remote_stream` — the client is
+   entered into `remote_stack` first, and a transport-context failure now closes
+   `remote_stack` in the `except` branch before re-raising, rather than leaking. Note the
+   *first* leak (the reconnect path) is **pre-existing** — it predates the mcp 2.x port,
+   since `_cleanup_client` never closed `sse_exit_stack` for remote clients even on 1.x —
+   so it reads as a bug fix carried by this phase, not as a regression 2.x introduced.
+8. **Open debt for P3B, surfaced but not a P2 defect.** `ClientManager`'s concurrent
+   `asyncio.gather` shutdown of every managed client (the `disconnect_all` path) trips
+   anyio's cross-task cancel-scope guard when a fully connected-then-torn-down
+   streamable-HTTP client crosses an event-loop boundary while sharing that loop with
+   another anyio-driven server (e.g. a test's own uvicorn fixture). Isolated by bisection:
+   reproduces with a plain, unauthenticated, non-redirected connect, so it is orthogonal
+   to IF-0-P2-2's transport rebuild and reads as an anyio/httpx2/uvicorn interaction
+   rather than a pmcp defect. `tests/runtime/test_downstream_remote.py` works around it by
+   sharing one `run_fake_remote` lifecycle across all of EC-P2-7's assertions and using
+   per-name `disconnect_server()` rather than `disconnect_all()`; its module docstring
+   carries the full reproduction recipe. Not an exit criterion for P2 — flagged here so
+   P3B (which touches `ClientManager`'s shutdown paths directly) inherits the context
+   rather than rediscovering it.
+9. **Three pre-existing test bugs surfaced once migration errors stopped masking them**,
+   all unrelated to the port and fixed in the same commit that repaired the suite
+   (`dcc2b0d`): a `test_scoped_advisor_audit.py` call to `gateway.provision` omitted the
+   schema-required `server_name` argument, which only started failing once IF-0-P2-1's
+   restored input-schema validation ran — correctly — *before* the policy check the test
+   meant to exercise; the same file's audit-latch test asserted the raised exception's own
+   message ("audit sink is unavailable") rather than the fixed, non-leaking message
+   `_handle_call_tool`'s `except ScopedAdvisorAuditError` has always mapped it to ("Scoped
+   advisor audit channel failed" — unchanged by this port); and
+   `test_baseline_constraints.py` pinned the *absence* of a `description` field on
+   `Server`/`Implementation`, which `mcp` 2.0.0 added. pmcp does not use the new
+   `description` surface — a possible future target, deliberately not acted on here — the
+   test now documents the surface exists rather than asserting it doesn't.
+10. **`booted_gateway()` (`tests/runtime/harness.py`) must not require a live gateway on
+    `:3344`.** `tests/runtime/` runs under the default `uv run pytest tests/` on every CI
+    matrix leg with no marker (see the plan's "No new pytest marker" note), and GitHub
+    runners carry no pmcp systemd unit at all. A hard assertion that a live gateway exists
+    would have failed 13 of 18 runtime tests on the phase PR's own CI — making EC-P2-8
+    unreachable there before it could even report red for a real reason. The fixture
+    treats an absent live gateway (`live_pid is None`) as "nothing to protect, proceed,"
+    matching the plan's own V0a/V0b semantics where an empty `LIVE_PID` on both sides is a
+    passing comparison, not an abort condition. Recorded so a future edit doesn't
+    reintroduce a hard assert here.
+
 ---
 
 ### Phase 3B — Subscriptions and GET retirement (P3B)

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -17,9 +17,10 @@ from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any, TypeVar
 
+import httpx2
 import mcp.types as mcp_types
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.message import SessionMessage
 
 from pmcp.auth import sanitize_auth_diagnostic
@@ -456,6 +457,12 @@ class ManagedClient:
     is_remote: bool = False
     sse_exit_stack: AsyncExitStack | None = None
     write_stream: Any | None = None
+    # The httpx2.AsyncClient pmcp owns for a streamable-HTTP downstream (mcp
+    # 2.0.0's streamable_http_client() takes a caller-supplied client and does
+    # not close it — see IF-0-P2-2). None for SSE and stdio downstreams, which
+    # don't take one. Entered into sse_exit_stack, so it closes with the
+    # transport; exposed here so tests (and callers) can assert `.is_closed`.
+    remote_http_client: httpx2.AsyncClient | None = None
     status: ServerStatus = field(
         default_factory=lambda: ServerStatus(
             name="",
@@ -1377,11 +1384,29 @@ class ClientManager:
         headers = _remote_headers(
             config.name, remote_config, project_root=self._project_root
         )
+        # mcp 2.0.0's streamable_http_client() no longer builds its own httpx
+        # client from headers/timeout kwargs the way 1.x's streamablehttp_client()
+        # did internally via create_mcp_http_client(); it takes a caller-supplied
+        # httpx2.AsyncClient and (per IF-0-P2-2) does not close it. Reproduce
+        # create_mcp_http_client's behaviour explicitly: follow_redirects=True
+        # (httpx2's own default is False) and the same (30s connect, 300s read)
+        # timeout. `headers` is omitted entirely when unset, matching 1.x's
+        # create_mcp_http_client(headers=None) passthrough.
+        remote_timeout = httpx2.Timeout(30.0, read=300.0)
+        if headers is not None:
+            http_client = httpx2.AsyncClient(
+                follow_redirects=True, timeout=remote_timeout, headers=headers
+            )
+        else:
+            http_client = httpx2.AsyncClient(
+                follow_redirects=True, timeout=remote_timeout
+            )
         await self._connect_remote_stream(
             config,
-            streamablehttp_client(remote_config.url, headers=headers),
+            streamable_http_client(remote_config.url, http_client=http_client),
             transport_name="streamable HTTP",
             resolved_headers=headers,
+            remote_http_client=http_client,
         )
 
     async def _connect_remote_stream(
@@ -1391,6 +1416,7 @@ class ClientManager:
         *,
         transport_name: str,
         resolved_headers: dict[str, str] | None = None,
+        remote_http_client: httpx2.AsyncClient | None = None,
     ) -> None:
         """Connect to a remote MCP server using a read/write stream transport."""
         name = config.name
@@ -1414,7 +1440,17 @@ class ClientManager:
         logger.info(f"Connecting to remote MCP server via {transport_name}: {name}")
 
         remote_stack = AsyncExitStack()
-        transport = await remote_stack.enter_async_context(transport_context)
+        # Enter the owned httpx2 client before the transport: AsyncExitStack
+        # unwinds LIFO, so on cleanup the transport closes first and the client
+        # last, and if entering the transport itself raises, the except below
+        # still closes (rather than leaks) the client we already own.
+        if remote_http_client is not None:
+            await remote_stack.enter_async_context(remote_http_client)
+        try:
+            transport = await remote_stack.enter_async_context(transport_context)
+        except Exception:
+            await remote_stack.aclose()
+            raise
         read_stream, write_stream = transport[:2]
 
         managed = ManagedClient(
@@ -1425,6 +1461,7 @@ class ClientManager:
             write_stream=write_stream,
             status=status,
             resolved_remote_headers=resolved_headers,
+            remote_http_client=remote_http_client,
         )
         self._clients[name] = managed
 
@@ -1504,6 +1541,9 @@ class ClientManager:
                 managed.status.pending_request_count = len(managed.pending_requests)
 
                 if "error" in message:
+                    # TODO(P3B): message["error"] also carries JSON-RPC "code"
+                    # and "data" fields that are dropped here, exposing only
+                    # "message" to callers.
                     pending.future.set_exception(
                         Exception(message["error"].get("message", "Unknown error"))
                     )
@@ -1717,6 +1757,9 @@ class ClientManager:
                     managed.status.pending_request_count = len(managed.pending_requests)
 
                     if "error" in payload:
+                        # TODO(P3B): payload["error"] also carries JSON-RPC
+                        # "code" and "data" fields that are dropped here,
+                        # exposing only "message" to callers.
                         pending.future.set_exception(
                             Exception(payload["error"].get("message", "Unknown error"))
                         )
@@ -1781,7 +1824,11 @@ class ClientManager:
         if managed.is_remote:
             if managed.write_stream is None:
                 raise RuntimeError("Remote stream not connected")
-            msg = mcp_types.JSONRPCMessage.model_validate(request)
+            # mcp 2.0.0's JSONRPCMessage is a bare union (JSONRPCRequest |
+            # JSONRPCNotification | JSONRPCResponse | JSONRPCError), not a
+            # pydantic model, so it has no .model_validate(); construct via its
+            # published TypeAdapter instead.
+            msg = mcp_types.jsonrpc_message_adapter.validate_python(request)
             await managed.write_stream.send(SessionMessage(msg))
         else:
             if not managed.process or not managed.process.stdin:
@@ -1899,7 +1946,7 @@ class ClientManager:
         if managed.is_remote:
             if managed.write_stream is None:
                 raise RuntimeError("Remote stream not connected")
-            msg = mcp_types.JSONRPCMessage.model_validate(notification)
+            msg = mcp_types.jsonrpc_message_adapter.validate_python(notification)
             await managed.write_stream.send(SessionMessage(msg))
         elif managed.process and managed.process.stdin:
             data = json.dumps(notification) + "\n"
@@ -2003,7 +2050,29 @@ class ClientManager:
                     await asyncio.shield(task)
                 except (asyncio.CancelledError, Exception):
                     pass
-        await _terminate_process_tree(managed.process, name)
+        if managed.is_remote:
+            # Previously a no-op for remote clients: this function closed no
+            # transport at all here, so a reconnect (the only caller that hits
+            # this branch) leaked the SSE/streamable-HTTP transport — and, since
+            # IF-0-P2-2, would also leak the owned httpx2.AsyncClient. Guarded
+            # the same way as the two explicit-disconnect close sites
+            # (`disconnect_server`, `_disconnect_all_unlocked`), but this
+            # function's contract is "never raises", so an unmatched error is
+            # logged and swallowed here rather than re-raised.
+            if managed.sse_exit_stack is not None:
+                try:
+                    await managed.sse_exit_stack.aclose()
+                except RuntimeError as e:
+                    if _is_cancel_scope_task_mismatch_error(e):
+                        logger.debug(
+                            f"[{name}] Ignoring SSE shutdown cancel-scope mismatch: {e}"
+                        )
+                    else:
+                        logger.warning(f"[{name}] Error closing remote transport: {e}")
+                except Exception as e:
+                    logger.warning(f"[{name}] Error closing remote transport: {e}")
+        else:
+            await _terminate_process_tree(managed.process, name)
         self._clients.pop(name, None)
         self._servers.pop(name, None)
         self._remove_server_indexes(name)

--- a/src/pmcp/server.py
+++ b/src/pmcp/server.py
@@ -11,18 +11,30 @@ import sys
 from pathlib import Path
 from typing import Any, Literal
 
+import jsonschema
 from mcp.server import Server
+from mcp.server.context import ServerRequestContext
 from mcp.types import (
+    BlobResourceContents,
+    CallToolRequestParams,
+    CallToolResult,
+    ContentBlock,
+    GetPromptRequestParams,
     GetPromptResult,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListToolsResult,
+    PaginatedRequestParams,
     Prompt,
     PromptArgument,
     PromptMessage,
+    ReadResourceRequestParams,
+    ReadResourceResult,
     Resource,
     TextContent,
     TextResourceContents,
     Tool,
 )
-from pydantic import AnyUrl
 
 from pmcp.client.manager import ClientManager
 from pmcp.config.guidance import GuidanceConfig, load_guidance_config
@@ -171,8 +183,16 @@ class GatewayServer:
 
     def _create_server(self, instructions: str | None = None) -> None:
         """Create the MCP server with optional capability instructions."""
-        self._server = Server("mcp-gateway", instructions=instructions)
-        self._setup_handlers()
+        self._server = Server(
+            "mcp-gateway",
+            instructions=instructions,
+            on_list_tools=self._handle_list_tools,
+            on_call_tool=self._handle_call_tool,
+            on_list_resources=self._handle_list_resources,
+            on_read_resource=self._handle_read_resource,
+            on_list_prompts=self._handle_list_prompts,
+            on_get_prompt=self._handle_get_prompt,
+        )
 
     def _record_scoped_invocation(
         self,
@@ -195,12 +215,13 @@ class GatewayServer:
         if self._scoped_advisor_audit is not None:
             self._scoped_advisor_audit.require_available()
 
-    def _setup_handlers(self) -> None:
-        """Set up MCP request handlers."""
-        if self._server is None:
-            raise RuntimeError("Server not initialized")
+    async def _handle_list_tools(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: PaginatedRequestParams | None,
+    ) -> ListToolsResult:
+        """Adapter for `tools/list`: wraps the bare-list body into a typed result."""
 
-        @self._server.list_tools()
         async def list_tools() -> list[Tool]:
             self._require_scoped_audit()
             return sorted(
@@ -212,8 +233,45 @@ class GatewayServer:
                 key=lambda tool: tool.name,
             )
 
-        @self._server.call_tool()
-        async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        return ListToolsResult(tools=await list_tools())
+
+    def _find_gateway_tool(self, name: str) -> Tool | None:
+        """Look up a gateway tool definition by name, for input-schema validation."""
+        return next(
+            (tool for tool in get_gateway_tool_definitions() if tool.name == name),
+            None,
+        )
+
+    async def _handle_call_tool(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: CallToolRequestParams,
+    ) -> CallToolResult:
+        """Adapter for `tools/call`.
+
+        Restores the behaviour the removed 1.x ``call_tool`` decorator supplied:
+        argument unpacking from typed params, tool input-schema validation
+        (2.0.0's low-level ``Server`` does none), and wrapping the domain
+        body's bare ``list[TextContent]`` into a ``CallToolResult``.
+        """
+        name = params.name
+        arguments = params.arguments or {}
+
+        tool = self._find_gateway_tool(name)
+        if tool is not None:
+            try:
+                jsonschema.validate(instance=arguments, schema=tool.input_schema)
+            except jsonschema.ValidationError as e:
+                return CallToolResult(
+                    is_error=True,
+                    content=[
+                        TextContent(
+                            type="text", text=f"Input validation error: {e.message}"
+                        )
+                    ],
+                )
+
+        async def call_tool(name: str, arguments: dict[str, Any]) -> list[ContentBlock]:
             try:
                 result: Any
                 self._require_scoped_audit()
@@ -365,8 +423,16 @@ class GatewayServer:
                     )
                 ]
 
-        # Resource handlers - proxy from downstream servers + L3 guidance
-        @self._server.list_resources()
+        content = await call_tool(name, arguments)
+        return CallToolResult(content=content)
+
+    async def _handle_list_resources(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: PaginatedRequestParams | None,
+    ) -> ListResourcesResult:
+        """Adapter for `resources/list`: proxies downstream servers + L3 guidance."""
+
         async def list_resources() -> list[Resource]:
             self._require_scoped_audit()
             resources = self._client_manager.get_all_resources()
@@ -378,10 +444,10 @@ class GatewayServer:
             ]
             resource_list = [
                 Resource(
-                    uri=AnyUrl(r.uri),
+                    uri=r.uri,
                     name=r.name or r.uri,
                     description=r.description,
-                    mimeType=r.mime_type,
+                    mime_type=r.mime_type,
                 )
                 for r in allowed_resources
             ]
@@ -395,17 +461,27 @@ class GatewayServer:
             ):
                 resource_list.append(
                     Resource(
-                        uri=AnyUrl("pmcp://guidance/code-execution"),
+                        uri="pmcp://guidance/code-execution",
                         name="Code Execution Guide",
                         description="Comprehensive guide for using PMCP with code execution patterns",
-                        mimeType="text/markdown",
+                        mime_type="text/markdown",
                     )
                 )
 
             return sorted(resource_list, key=lambda resource: str(resource.uri))
 
-        @self._server.read_resource()
-        async def read_resource(uri: AnyUrl) -> list[TextResourceContents]:
+        return ListResourcesResult(resources=await list_resources())
+
+    async def _handle_read_resource(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: ReadResourceRequestParams,
+    ) -> ReadResourceResult:
+        """Adapter for `resources/read`."""
+
+        async def read_resource(
+            uri: str,
+        ) -> list[TextResourceContents | BlobResourceContents]:
             self._require_scoped_audit()
             # Find resource by URI
             uri_str = str(uri)
@@ -431,8 +507,8 @@ class GatewayServer:
 
                 return [
                     TextResourceContents(
-                        uri=AnyUrl(uri_str),
-                        mimeType="text/markdown",
+                        uri=uri_str,
+                        mime_type="text/markdown",
                         text=content,
                     )
                 ]
@@ -454,16 +530,23 @@ class GatewayServer:
             # Convert to TextResourceContents
             return [
                 TextResourceContents(
-                    uri=AnyUrl(c.get("uri", uri_str)),
-                    mimeType=c.get("mimeType"),
+                    uri=c.get("uri", uri_str),
+                    mime_type=c.get("mimeType"),
                     text=c.get("text", ""),
                 )
                 for c in contents
                 if "text" in c  # Only text contents for now
             ]
 
-        # Prompt handlers - proxy from downstream servers
-        @self._server.list_prompts()
+        return ReadResourceResult(contents=await read_resource(params.uri))
+
+    async def _handle_list_prompts(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: PaginatedRequestParams | None,
+    ) -> ListPromptsResult:
+        """Adapter for `prompts/list`: proxies downstream servers."""
+
         async def list_prompts() -> list[Prompt]:
             self._require_scoped_audit()
             prompts = self._client_manager.get_all_prompts()
@@ -492,7 +575,16 @@ class GatewayServer:
             ]
             return sorted(prompts_list, key=lambda prompt: prompt.name)
 
-        @self._server.get_prompt()
+        return ListPromptsResult(prompts=await list_prompts())
+
+    async def _handle_get_prompt(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        params: GetPromptRequestParams,
+    ) -> GetPromptResult:
+        """Adapter for `prompts/get`. The body already returns `GetPromptResult`
+        directly, so this adapter only unpacks typed params."""
+
         async def get_prompt(
             name: str, arguments: dict[str, str] | None = None
         ) -> GetPromptResult:
@@ -518,6 +610,8 @@ class GatewayServer:
                     for m in messages
                 ],
             )
+
+        return await get_prompt(params.name, params.arguments)
 
     async def initialize(self) -> None:
         """Initialize connections to downstream servers and generate capability summary."""

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -282,7 +282,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Set include_offline=True to also discover provisionable servers not yet running. "
                 "This is the primary tool discovery entry point."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {
@@ -329,7 +329,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Get detailed information about a specific tool, including its arguments and constraints. "
                 "Use this before invoking a tool to understand its requirements."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "tool_id": {
@@ -347,7 +347,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Arguments are validated against the tool schema before execution. "
                 "Output is automatically truncated if too large."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "tool_id": {
@@ -405,7 +405,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Use this when new MCP servers have been configured or to recover from connection errors. "
                 "Refuses by default while downstream requests are pending; set force=true to cancel them."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "source": {
@@ -431,7 +431,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Connect or start a known downstream MCP server by name. "
                 "Resolves configured, provisioned manifest, and registered discovered servers."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {
@@ -448,7 +448,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Disconnect a running downstream MCP server without changing persistent config. "
                 "Refuses by default when that server has pending requests; set force=true to cancel them."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {
@@ -470,7 +470,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Restart a known downstream MCP server without changing persistent config. "
                 "Refuses by default when that server has pending requests; set force=true to cancel them."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {
@@ -492,7 +492,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Get the health status of the gateway and all connected MCP servers. "
                 "Shows server status, tool counts, and last refresh time."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {},
             },
@@ -503,7 +503,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Show read-only effective configuration and startup policy status "
                 "with source attribution and non-secret diagnostics."
             ),
-            inputSchema={"type": "object", "properties": {}},
+            input_schema={"type": "object", "properties": {}},
         ),
         Tool(
             name="gateway.get_startup_policy",
@@ -511,7 +511,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Return persisted autoStart and legacy disableAutoStart entries "
                 "grouped by config source."
             ),
-            inputSchema={"type": "object", "properties": {}},
+            input_schema={"type": "object", "properties": {}},
         ),
         Tool(
             name="gateway.set_startup_policy",
@@ -519,7 +519,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Preview or explicitly apply an autoStart add/remove/set operation "
                 "against one selected config source or path."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "operation": {
@@ -547,7 +547,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "it does NOT start anything — call gateway.provision to actually install/start the recommended server. "
                 "Prefer this over gateway.provision when you don't already know the exact server name."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {
@@ -570,7 +570,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Detects the platform (mac/wsl/linux/windows) and probes for installed CLIs. "
                 "This information is used to prefer CLIs over MCP servers when matching capabilities."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "platform": {
@@ -595,7 +595,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Poll gateway.provision_status to check progress. "
                 "Use gateway.request_capability instead if you don't know the exact server name."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {
@@ -612,7 +612,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Update a subordinate MCP server package to latest version and reconnect it. "
                 "Use this when invoke/describe/provision warn that a newer version is available."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {
@@ -629,7 +629,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Store credentials for a server and make them available to provisioning. "
                 "Use this when gateway.provision reports missing authentication."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {
@@ -679,7 +679,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Prepare and optionally submit a PMCP feedback issue to GitHub. "
                 "By default returns an exact preview payload; set confirm_submission=true to submit."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "title": {
@@ -719,7 +719,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Use after gateway.provision returns a job_id. "
                 "Returns progress percentage, output log, and final tools when complete."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "job_id": {
@@ -737,7 +737,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Shows elapsed time, heartbeat age, and current state for each request. "
                 "Use this to monitor long-running operations before deciding to cancel."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server": {
@@ -755,7 +755,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Use force=true to cancel anyway. "
                 "Use gateway.list_pending first to see request IDs and health status."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "request_id": {
@@ -777,7 +777,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "List brokered downstream MCP tasks. "
                 "MCP task IDs are opaque downstream task identifiers, not PMCP request IDs."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {
@@ -794,7 +794,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
         Tool(
             name="gateway.tasks_get",
             description="Get current status for one downstream MCP task.",
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {"type": "string"},
@@ -809,7 +809,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Fetch a downstream MCP task result and apply the same output "
                 "redaction and truncation options as gateway.invoke."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {"type": "string"},
@@ -831,7 +831,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Cancel a downstream MCP task by opaque task ID. "
                 "Use gateway.cancel only for PMCP request IDs from gateway.list_pending."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "server_name": {"type": "string"},
@@ -848,7 +848,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Use this when gateway.request_capability returns not_available. "
                 "Returns package names and metadata; call gateway.register_discovered_server then gateway.provision to install."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "query": {
@@ -873,7 +873,7 @@ def get_gateway_tool_definitions() -> list[Tool]:
                 "Call this after gateway.search_registry to register the chosen package, "
                 "then call gateway.provision to install and start it."
             ),
-            inputSchema={
+            input_schema={
                 "type": "object",
                 "properties": {
                     "package": {

--- a/tests/mcp2x/test_client_transport.py
+++ b/tests/mcp2x/test_client_transport.py
@@ -1,0 +1,584 @@
+"""SL-3.1 — downstream Streamable HTTP client transport contract on mcp 2.x.
+
+Covers IF-0-P2-2: the pmcp-owned httpx2.AsyncClient that ``_connect_streamable_http``
+now builds and threads into ``streamable_http_client(url, http_client=...)``, and
+Trap 6: ``jsonrpc_message_adapter.validate_python(...)`` replacing the removed
+``JSONRPCMessage.model_validate(...)`` on every outbound remote request and
+notification. Also proves (per the phase plan's SL-3 task table) that
+``manifest/refresher.py`` and ``cli.py``'s two diagnostics probes still resolve
+against real mcp 2.0.0 / httpx objects, without assuming it from a source read.
+
+This module owns no production code — it is evidence for
+``src/pmcp/client/manager.py``, ``src/pmcp/manifest/refresher.py``, and
+``src/pmcp/cli.py``, all SL-3-owned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.server
+import json
+import sys
+import threading
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx2
+import pytest
+
+import mcp.types as mcp_types
+from mcp.shared.message import SessionMessage
+from mcp.types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
+
+from pmcp.client.manager import (
+    ClientManager,
+    ManagedClient,
+    PREFERRED_PROTOCOL_VERSION,
+    _remote_headers,
+)
+from pmcp.types import (
+    RemoteMcpServerConfig,
+    ResolvedServerConfig,
+    ServerStatus,
+    ServerStatusEnum,
+)
+
+
+class _EmptyReadStream:
+    """A read stream that yields nothing, for connect-then-disconnect tests."""
+
+    def __aiter__(self) -> "_EmptyReadStream":
+        return self
+
+    async def __anext__(self) -> None:
+        raise StopAsyncIteration
+
+
+# === IF-0-P2-2: the owned httpx2.AsyncClient ===
+
+
+class TestConnectStreamableHttpBuildsOwnedClient:
+    @pytest.mark.asyncio
+    async def test_client_carries_redirects_timeout_and_headers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_connect_streamable_http` must build the httpx2.AsyncClient that 1.x's
+        removed `create_mcp_http_client` used to build internally, and pass it
+        as `http_client=` — not `headers=`/`timeout=`, which 2.x's
+        `streamable_http_client` no longer accepts at all.
+        """
+        manager = ClientManager()
+        monkeypatch.setenv("PMCP_TEST_TOKEN", "test-token")
+
+        config = ResolvedServerConfig(
+            name="remote-http",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http",
+                url="https://example.com/mcp",
+                headers={"Authorization": "Bearer ${PMCP_TEST_TOKEN}"},
+            ),
+        )
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(
+            url: str, *, http_client: httpx2.AsyncClient | None = None, **_: Any
+        ):
+            captured["url"] = url
+            captured["http_client"] = http_client
+            yield _EmptyReadStream(), MagicMock()
+
+        monkeypatch.setattr(
+            "pmcp.client.manager.streamable_http_client", fake_streamable_http_client
+        )
+        manager._send_initialize = AsyncMock()  # type: ignore[method-assign]
+
+        async def fake_send_request(*args: object, **kwargs: object) -> dict:
+            return {"tools": []}
+
+        manager._send_request = AsyncMock(side_effect=fake_send_request)  # type: ignore[method-assign]
+        manager._read_sse = AsyncMock()  # type: ignore[method-assign]
+
+        await manager._connect_streamable_http(config)
+        try:
+            assert captured["url"] == "https://example.com/mcp"
+            client = captured["http_client"]
+            assert isinstance(client, httpx2.AsyncClient)
+            # httpx2's own default is False; the removed create_mcp_http_client
+            # set True, so a caller-supplied client must too (IF-0-P2-2).
+            assert client.follow_redirects is True
+            assert client.timeout == httpx2.Timeout(30.0, read=300.0)
+            assert client.headers["authorization"] == "Bearer test-token"
+
+            managed = manager._clients["remote-http"]
+            assert managed.remote_http_client is client
+            assert client.is_closed is False
+        finally:
+            await manager.disconnect_all()
+
+        # Closing the managed connection must close the owned client too
+        # (IF-0-P2-2 / EC-P2-7's is_closed-after-cleanup assertion).
+        assert client.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_headers_omitted_when_remote_headers_resolves_to_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Matching 1.x's create_mcp_http_client(headers=None) passthrough: an
+        unconfigured-headers server must not force an empty headers dict onto
+        the built client.
+        """
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name="remote-http-noauth",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http", url="https://example.com/mcp"
+            ),
+        )
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(
+            url: str, *, http_client: httpx2.AsyncClient | None = None, **_: Any
+        ):
+            captured["http_client"] = http_client
+            yield _EmptyReadStream(), MagicMock()
+
+        monkeypatch.setattr(
+            "pmcp.client.manager.streamable_http_client", fake_streamable_http_client
+        )
+        manager._send_initialize = AsyncMock()  # type: ignore[method-assign]
+        manager._send_request = AsyncMock(return_value={"tools": []})  # type: ignore[method-assign]
+        manager._read_sse = AsyncMock()  # type: ignore[method-assign]
+
+        await manager._connect_streamable_http(config)
+        try:
+            client = captured["http_client"]
+            # httpx2.AsyncClient always exposes a Headers object; assert no
+            # caller-supplied auth header leaked in, not that it's literally empty.
+            assert "authorization" not in client.headers
+        finally:
+            await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_transport_connect_failure_does_not_leak_owned_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If entering the transport context raises, the httpx2 client already
+        entered into the exit stack must still be closed, not leaked.
+        """
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name="remote-http-fail",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http", url="https://example.com/mcp"
+            ),
+        )
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def failing_streamable_http_client(
+            url: str, *, http_client: httpx2.AsyncClient | None = None, **_: Any
+        ):
+            captured["http_client"] = http_client
+            raise ConnectionRefusedError("boom")
+            yield  # pragma: no cover - unreachable, keeps this an async generator
+
+        monkeypatch.setattr(
+            "pmcp.client.manager.streamable_http_client", failing_streamable_http_client
+        )
+
+        with pytest.raises(ConnectionRefusedError):
+            await manager._connect_streamable_http(config)
+
+        client = captured["http_client"]
+        assert client.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_reconnect_closes_prior_owned_client_via_cleanup_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_connect_remote_stream` calls `_cleanup_client` on the *reconnect*
+        path (an existing live connection found under the same server name) —
+        not `disconnect_all`/`_shutdown_one`, which is a different code path.
+        Before this lane, `_cleanup_client` closed no transport at all for
+        remote clients, so a reconnect leaked the prior connection's transport
+        (and, after IF-0-P2-2, would also leak its owned httpx2.AsyncClient).
+        Exercise the reconnect path directly rather than inferring the close
+        from `disconnect_all`.
+        """
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name="remote-reconnect",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http", url="https://example.com/mcp"
+            ),
+        )
+
+        built_clients: list[httpx2.AsyncClient] = []
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(
+            url: str, *, http_client: httpx2.AsyncClient | None = None, **_: Any
+        ):
+            assert http_client is not None
+            built_clients.append(http_client)
+            yield _EmptyReadStream(), MagicMock()
+
+        monkeypatch.setattr(
+            "pmcp.client.manager.streamable_http_client", fake_streamable_http_client
+        )
+        manager._send_initialize = AsyncMock()  # type: ignore[method-assign]
+        manager._send_request = AsyncMock(return_value={"tools": []})  # type: ignore[method-assign]
+        manager._read_sse = AsyncMock()  # type: ignore[method-assign]
+
+        await manager._connect_streamable_http(config)
+        client_a = built_clients[0]
+        assert client_a.is_closed is False
+
+        # Second connect for the same server name hits _connect_remote_stream's
+        # "Existing live connection found; cleaning up before reconnect"
+        # branch, which calls _cleanup_client(name, existing) on client A's
+        # managed connection before establishing client B's.
+        await manager._connect_streamable_http(config)
+        client_b = built_clients[1]
+
+        try:
+            assert client_a.is_closed is True
+            assert client_b.is_closed is False
+            assert manager._clients["remote-reconnect"].remote_http_client is client_b
+        finally:
+            await manager.disconnect_all()
+        assert client_b.is_closed is True
+
+
+# === Trap 6: JSONRPCMessage -> jsonrpc_message_adapter ===
+
+
+class TestOutboundEnvelopeAdapter:
+    """`_send_request`/`_send_initialize` build every outbound remote request and
+    notification via `mcp_types.jsonrpc_message_adapter.validate_python(...)`
+    (JSONRPCMessage has no `.model_validate` in 2.0.0 — it's a bare union).
+    Assert the constructed SessionMessage's wire dump reproduces the input
+    dict byte-identically, including nested `params.arguments`.
+    """
+
+    def _managed_remote_client(self) -> tuple[ManagedClient, list[SessionMessage]]:
+        sent: list[SessionMessage] = []
+
+        class _CapturingWriteStream:
+            async def send(self, msg: SessionMessage) -> None:
+                sent.append(msg)
+
+        config = ResolvedServerConfig(
+            name="remote-adapter",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http", url="https://example.com/mcp"
+            ),
+        )
+        managed = ManagedClient(
+            config=config,
+            is_remote=True,
+            write_stream=_CapturingWriteStream(),
+            status=ServerStatus(
+                name="remote-adapter", status=ServerStatusEnum.ONLINE, tool_count=0
+            ),
+        )
+        return managed, sent
+
+    @pytest.mark.asyncio
+    async def test_request_envelope_round_trips_with_nested_arguments(self) -> None:
+        manager = ClientManager()
+        managed, sent = self._managed_remote_client()
+
+        params = {
+            "name": "echo",
+            "arguments": {"text": "hi", "nested": {"a": 1, "b": [1, 2, 3]}},
+        }
+
+        async def resolve_future() -> None:
+            # _send_request awaits a future the (absent) reader would resolve;
+            # resolve it ourselves once the request has been written so the
+            # call returns instead of timing out.
+            while not sent:
+                await asyncio.sleep(0)
+            request_id = next(iter(managed.pending_requests))
+            managed.pending_requests[request_id].future.set_result({"ok": True})
+
+        await asyncio.gather(
+            manager._send_request(managed, "tools/call", params, timeout_ms=1000),
+            resolve_future(),
+        )
+
+        assert len(sent) == 1
+        session_msg = sent[0]
+        dumped = session_msg.message.model_dump(
+            by_alias=True, mode="json", exclude_none=True
+        )
+        assert dumped["jsonrpc"] == "2.0"
+        assert dumped["method"] == "tools/call"
+        assert dumped["params"] == params
+        assert isinstance(dumped["id"], int)
+
+        # And the adapter itself round-trips the exact envelope pmcp constructs.
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": dumped["id"],
+            "method": "tools/call",
+            "params": params,
+        }
+        model = mcp_types.jsonrpc_message_adapter.validate_python(envelope)
+        assert (
+            model.model_dump(by_alias=True, mode="json", exclude_none=True) == envelope
+        )
+
+    @pytest.mark.asyncio
+    async def test_notification_envelope_round_trips(self) -> None:
+        manager = ClientManager()
+        managed, sent = self._managed_remote_client()
+
+        async def fake_send_request(*_args: object, **_kwargs: object) -> dict:
+            return {"protocolVersion": PREFERRED_PROTOCOL_VERSION, "capabilities": {}}
+
+        manager._send_request = AsyncMock(side_effect=fake_send_request)  # type: ignore[method-assign]
+
+        await manager._send_initialize(managed)
+
+        # _send_initialize sends the "initialized" notification directly on
+        # write_stream (not through _send_request, which is mocked above).
+        assert len(sent) == 1
+        dumped = sent[0].message.model_dump(
+            by_alias=True, mode="json", exclude_none=True
+        )
+        assert dumped == {"jsonrpc": "2.0", "method": "notifications/initialized"}
+
+    def test_initialize_request_envelope_round_trips(self) -> None:
+        """The `initialize` envelope pmcp sends is itself a `tools/call`-shaped
+        JSON-RPC request (method="initialize"); prove the adapter round-trips
+        its nested params (protocolVersion/capabilities/clientInfo) too.
+        """
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PREFERRED_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "mcp-gateway", "version": "1.0.0"},
+            },
+        }
+        model = mcp_types.jsonrpc_message_adapter.validate_python(envelope)
+        assert isinstance(model, mcp_types.jsonrpc.JSONRPCRequest)
+        assert (
+            model.model_dump(by_alias=True, mode="json", exclude_none=True) == envelope
+        )
+        # SessionMessage(<concrete model>).message.model_dump(...) is what
+        # _read_sse relies on for the read side (unaffected by Trap 6).
+        session_msg = SessionMessage(model)
+        assert (
+            session_msg.message.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            )
+            == envelope
+        )
+
+
+# === Protocol version ladder: unchanged by this lane ===
+
+
+class TestPreferredProtocolVersionUnchanged:
+    def test_preferred_version_governs_the_handshake_not_the_modern_era(self) -> None:
+        assert PREFERRED_PROTOCOL_VERSION == "2025-11-25"
+        assert PREFERRED_PROTOCOL_VERSION in HANDSHAKE_PROTOCOL_VERSIONS
+        assert PREFERRED_PROTOCOL_VERSION not in MODERN_PROTOCOL_VERSIONS
+
+
+# === sse_client: genuinely unchanged ===
+
+
+class TestConnectSseUnchanged:
+    @pytest.mark.asyncio
+    async def test_connect_sse_still_calls_sse_client_with_headers_kwarg(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = ClientManager()
+        monkeypatch.setenv("PMCP_TEST_TOKEN", "sse-token")
+        config = ResolvedServerConfig(
+            name="remote-sse",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                url="https://example.com/sse",
+                headers={"Authorization": "Bearer ${PMCP_TEST_TOKEN}"},
+            ),
+        )
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def fake_sse_client(url: str, headers: dict[str, str] | None = None):
+            captured["url"] = url
+            captured["headers"] = headers
+            yield _EmptyReadStream(), MagicMock()
+
+        monkeypatch.setattr("pmcp.client.manager.sse_client", fake_sse_client)
+        manager._send_initialize = AsyncMock()  # type: ignore[method-assign]
+        manager._send_request = AsyncMock(return_value={"tools": []})  # type: ignore[method-assign]
+        manager._read_sse = AsyncMock()  # type: ignore[method-assign]
+
+        await manager._connect_sse(config)
+        try:
+            assert captured["url"] == "https://example.com/sse"
+            assert captured["headers"] == {"Authorization": "Bearer sse-token"}
+            # SSE connections never build an owned httpx2 client (2.x's
+            # sse_client is unchanged and still owns its own transport).
+            assert manager._clients["remote-sse"].remote_http_client is None
+        finally:
+            await manager.disconnect_all()
+
+
+# === manifest/refresher.py: proven unchanged against a real mcp 2.0.0 server ===
+
+
+_REFRESHER_FIXTURE_SERVER = '''
+from mcp.server.mcpserver import MCPServer
+
+server = MCPServer("refresher-fixture")
+
+
+@server.tool()
+def echo(text: str) -> str:
+    """Echo back the input text."""
+    return text
+
+
+if __name__ == "__main__":
+    server.run("stdio")
+'''
+
+
+class TestManifestRefresherUnaffected:
+    @pytest.mark.asyncio
+    async def test_refresh_server_round_trips_through_real_2x_stdio_session(
+        self, tmp_path: Path
+    ) -> None:
+        """`refresher.py` imports `ClientSession`/`StdioServerParameters`/
+        `stdio_client` unchanged from mcp 2.0.0 (all three survive per Trap 4)
+        and uses none of the pydantic-model attributes that reshaped (Trap 5).
+        Exercised end to end rather than assumed.
+        """
+        from pmcp.manifest.loader import ServerConfig
+        from pmcp.manifest.refresher import refresh_server
+
+        fixture = tmp_path / "refresher_fixture_server.py"
+        fixture.write_text(_REFRESHER_FIXTURE_SERVER)
+
+        server_config = ServerConfig(
+            name="refresher-fixture",
+            description="fixture",
+            keywords=[],
+            install={},
+            command=sys.executable,
+            args=[str(fixture)],
+        )
+
+        result = await refresh_server(server_config)
+
+        assert result is not None
+        assert [t.name for t in result.tools] == ["echo"]
+        assert result.tools[0].description == "Echo back the input text."
+
+
+# === cli.py: proven to need zero diff — httpx still resolves, probes still work ===
+
+
+class _HealthStubHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - stdlib method name
+        if self.path == "/health":
+            body = json.dumps({"ok": True}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/sse":
+            body = b"event: message\ndata: {}\n\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        pass  # keep test output quiet
+
+
+@pytest.fixture
+def health_stub_server() -> Any:
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _HealthStubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+class TestCliHttpxProbesUnaffectedByMcp2x:
+    """cli.py does a bare `import httpx` inside these two functions; per
+    Decision 2 pmcp declares `httpx` directly (pyproject.toml), so both still
+    resolve after mcp 2.0.0 stops supplying it transitively. Exercised against
+    a real local server rather than assumed from the source read.
+    """
+
+    @pytest.mark.asyncio
+    async def test_probe_http_health_resolves_httpx_and_reaches_stub(
+        self, health_stub_server: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pmcp.cli import _probe_http_health
+
+        port = health_stub_server.server_address[1]
+        monkeypatch.setenv("PMCP_GATEWAY_URL", f"http://127.0.0.1:{port}/mcp")
+
+        ok, detail, status_code = await _probe_http_health(timeout_s=5.0)
+
+        assert ok is True
+        assert status_code == 200
+        assert "reachable" in detail
+
+    @pytest.mark.asyncio
+    async def test_probe_sse_endpoint_resolves_httpx_and_reaches_stub(
+        self, health_stub_server: Any
+    ) -> None:
+        from pmcp.cli import _probe_sse_endpoint
+
+        port = health_stub_server.server_address[1]
+        ok, detail = await _probe_sse_endpoint(
+            f"http://127.0.0.1:{port}/sse", timeout_s=5.0
+        )
+
+        assert ok is True
+        assert "HTTP 200" in detail
+
+
+# === _remote_headers: sanity that the None-vs-dict contract IF-0-P2-2 relies on holds ===
+
+
+def test_remote_headers_returns_none_when_unconfigured() -> None:
+    config = RemoteMcpServerConfig(
+        type="streamable-http", url="https://example.com/mcp"
+    )
+    assert _remote_headers("s", config) is None

--- a/tests/mcp2x/test_dependency_bounds.py
+++ b/tests/mcp2x/test_dependency_bounds.py
@@ -1,0 +1,104 @@
+"""SL-1.1 — pin the declared dependency bounds and prove they resolve.
+
+Written before SL-1.2's `pyproject.toml`/`uv.lock` edit (test-before-impl per
+the phase plan's SL-1 task table), so this module is expected to fail until
+that edit lands. It is the single piece of evidence for IF-0-P2-3: the four
+direct declarations (`mcp`, `httpx`, `httpx2`, `jsonschema`) are two-sided,
+the P1 floor-parsing regex still matches and yields `2.0.0`, the installed
+`mcp` is genuinely 2.x, and `httpx`/`httpx2` are distinct distributions so a
+future resolver change cannot silently collapse one into the other.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+# Same regex `.github/workflows/test.yml`'s `min-version-smoke` job uses to
+# parse the declared `mcp` floor. Duplicated here (rather than imported) on
+# purpose: it is a text-file contract between this repo and that workflow
+# step, not a Python symbol either side exports.
+FLOOR_REGEX = r'"mcp>=([0-9.]+),<'
+
+DIRECT_DEPENDENCIES = ("mcp", "httpx", "httpx2", "jsonschema")
+
+# Deliberately not parsed with `tomllib`: that's stdlib-only on Python
+# 3.11+, and this repo's CI matrix includes 3.10 (`.github/workflows/test.yml`
+# `python-version: ["3.10", "3.11", "3.12"]`). Reaching for `tomli` as a
+# fallback would just re-create the undeclared-transitive-dependency problem
+# this lane exists to close. A plain regex over the quoted specifier strings
+# in the `dependencies = [...]` block is the same text-file contract
+# `min-version-smoke`'s own floor regex already relies on.
+DEPENDENCY_SPECIFIER_RE = re.compile(r'"([A-Za-z0-9_.\[\]-]+(?:[<>=!~][^"]*)?)"')
+
+
+def _dependencies() -> list[str]:
+    text = PYPROJECT_PATH.read_text()
+    match = re.search(r"dependencies\s*=\s*\[(.*?)\n\]", text, re.DOTALL)
+    assert match, f"could not find a dependencies = [...] block in {PYPROJECT_PATH}"
+    return DEPENDENCY_SPECIFIER_RE.findall(match.group(1))
+
+
+def _specifier_for(name: str, dependencies: list[str]) -> str:
+    for dep in dependencies:
+        # Match the package name at the start of the specifier so "httpx"
+        # doesn't accidentally match the "httpx2" entry.
+        if re.match(rf"^{re.escape(name)}(?=[<>=!\s\[]|$)", dep):
+            return dep
+    pytest.fail(f"no dependency entry found for {name!r} in {PYPROJECT_PATH}")
+
+
+@pytest.mark.parametrize("name", DIRECT_DEPENDENCIES)
+def test_declared_bounds_are_two_sided(name: str) -> None:
+    specifier = _specifier_for(name, _dependencies())
+    assert ">=" in specifier, f"{name} has no floor: {specifier!r}"
+    assert "<" in specifier, f"{name} has no ceiling: {specifier!r}"
+
+
+def test_mcp_floor_matches_declared_ceiling_style() -> None:
+    # mcp specifically must be declared as >=2.0.0,<3.0.0 per IF-0-P2-3.
+    specifier = _specifier_for("mcp", _dependencies())
+    assert "mcp>=2.0.0,<3.0.0" in specifier.replace(" ", ""), specifier
+
+
+def test_installed_mcp_is_2x() -> None:
+    version = importlib.metadata.version("mcp")
+    assert version.startswith("2."), (
+        f"installed mcp is {version!r}, expected a 2.x release "
+        "(run `uv sync --all-extras` after the pyproject.toml bump)"
+    )
+
+
+def test_p1_floor_regex_still_matches_and_yields_2_0_0() -> None:
+    text = PYPROJECT_PATH.read_text()
+    match = re.search(FLOOR_REGEX, text)
+    assert match, (
+        f"the min-version-smoke floor regex {FLOOR_REGEX!r} no longer "
+        "matches pyproject.toml's mcp specifier"
+    )
+    assert match.group(1) == "2.0.0"
+
+
+def test_httpx_httpx2_jsonschema_all_importable() -> None:
+    import httpx  # noqa: F401
+    import httpx2  # noqa: F401
+    import jsonschema  # noqa: F401
+
+
+def test_httpx_and_httpx2_are_distinct_modules() -> None:
+    import httpx
+    import httpx2
+
+    assert httpx is not httpx2
+    assert httpx.__name__ != httpx2.__name__
+    assert sys.modules["httpx"] is not sys.modules["httpx2"]
+    # Distinct distributions, so their __version__ attributes are resolved
+    # independently — a resolver bug that collapsed one into the other would
+    # make these identical (or make one attribute lookup fail).
+    assert httpx.__version__ != httpx2.__version__

--- a/tests/mcp2x/test_server_handlers.py
+++ b/tests/mcp2x/test_server_handlers.py
@@ -1,0 +1,299 @@
+"""SL-2.1 — pin the mcp 2.x upstream server-handler contract (IF-0-P2-1).
+
+Exercises the six `_handle_*` adapters `GatewayServer` registers through
+`Server.__init__(on_*=...)` directly against the real mcp 2.0.0 dispatch
+surface: each method's `HandlerEntry.params_type` is the SDK's canonical
+model, and each handler's return value is the SDK's canonical result model.
+
+Also pins the Trap 5 model-reshape facts SL-2 carries through `server.py`:
+`Resource`/`TextResourceContents.uri` is `str` (not `AnyUrl`), `Tool`'s
+schema field is `input_schema` (not `inputSchema`), and the dropped
+`extra="allow"` on `Tool` is the proxying-fidelity risk EC-P2-3 guards —
+every gateway tool must survive a `model_dump(by_alias=True)` round trip
+with an identical re-dump.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.server.connection import Connection
+from mcp.server.context import ServerRequestContext
+from mcp.server.session import ServerSession
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    GetPromptRequestParams,
+    GetPromptResult,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    ReadResourceRequestParams,
+    ReadResourceResult,
+    Tool,
+)
+
+from pmcp.server import GatewayServer
+from pmcp.tools.handlers import get_gateway_tool_definitions
+from pmcp.types import PromptArgumentInfo, PromptInfo, ResourceInfo
+
+# A HANDSHAKE_PROTOCOL_VERSIONS member; the specific value is irrelevant to
+# these handlers, which read no protocol-version-gated behaviour off `ctx`.
+PROTOCOL_VERSION = "2025-11-25"
+
+METHOD_PARAMS_TYPES: dict[str, type] = {
+    "tools/list": PaginatedRequestParams,
+    "tools/call": CallToolRequestParams,
+    "resources/list": PaginatedRequestParams,
+    "resources/read": ReadResourceRequestParams,
+    "prompts/list": PaginatedRequestParams,
+    "prompts/get": GetPromptRequestParams,
+}
+
+
+def _make_ctx() -> ServerRequestContext[Any, Any]:
+    """A real `ServerRequestContext` with a stubbed back-channel.
+
+    None of the six handlers touch `ctx.session` or any other `ctx` field —
+    they close over `self` exactly as the original 1.x closures did — so the
+    `DispatchContext` backing the session is a bare mock; `Connection`,
+    `ServerSession`, and `ServerRequestContext` themselves are the genuine
+    mcp 2.0.0 types the real runner builds.
+    """
+    connection = Connection.from_envelope(PROTOCOL_VERSION, None, None)
+    session = ServerSession(MagicMock(), connection)
+    return ServerRequestContext(
+        session=session,
+        lifespan_context={},
+        protocol_version=PROTOCOL_VERSION,
+        method="test",
+    )
+
+
+@pytest.fixture
+def server() -> GatewayServer:
+    srv = GatewayServer()
+    srv._create_server(instructions="test instructions")
+    return srv
+
+
+class TestRegistration:
+    """IF-0-P2-1: registered through `Server.__init__(on_*=...)`, canonical params_type."""
+
+    @pytest.mark.parametrize("method", list(METHOD_PARAMS_TYPES))
+    def test_params_type_is_canonical(self, server: GatewayServer, method: str) -> None:
+        assert server._server is not None
+        entry = server._server.get_request_handler(method)
+        assert entry is not None, f"no handler registered for {method!r}"
+        assert entry.params_type is METHOD_PARAMS_TYPES[method]
+
+    def test_server_discover_is_registered(self, server: GatewayServer) -> None:
+        assert server._server is not None
+        assert server._server.get_request_handler("server/discover") is not None
+
+    def test_middleware_keeps_default_otel(self, server: GatewayServer) -> None:
+        """Decision 3: the default OpenTelemetryMiddleware is kept, explicitly."""
+        assert server._server is not None
+        assert len(server._server.middleware) == 1
+        assert type(server._server.middleware[0]).__name__ == "OpenTelemetryMiddleware"
+
+
+class TestListTools:
+    @pytest.mark.asyncio
+    async def test_returns_typed_result(self, server: GatewayServer) -> None:
+        assert server._server is not None
+        entry = server._server.get_request_handler("tools/list")
+        assert entry is not None
+        result = await entry.handler(_make_ctx(), PaginatedRequestParams())
+        assert isinstance(result, ListToolsResult)
+        assert len(result.tools) > 0
+        assert all(isinstance(t, Tool) for t in result.tools)
+        names = [t.name for t in result.tools]
+        assert names == sorted(names)
+
+
+class TestCallTool:
+    @pytest.mark.asyncio
+    async def test_health_call_returns_typed_result(
+        self, server: GatewayServer
+    ) -> None:
+        assert server._server is not None
+        entry = server._server.get_request_handler("tools/call")
+        assert entry is not None
+        params = CallToolRequestParams(name="gateway.health", arguments={})
+        result = await entry.handler(_make_ctx(), params)
+        assert isinstance(result, CallToolResult)
+        assert result.is_error is False
+        assert len(result.content) == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_arguments_fail_schema_validation(
+        self, server: GatewayServer
+    ) -> None:
+        """EC-P2-3: `gateway.describe` requires `tool_id: string`; feed it an int."""
+        assert server._server is not None
+        entry = server._server.get_request_handler("tools/call")
+        assert entry is not None
+        params = CallToolRequestParams(
+            name="gateway.describe", arguments={"tool_id": 12345}
+        )
+        result = await entry.handler(_make_ctx(), params)
+        assert isinstance(result, CallToolResult)
+        assert result.is_error is True
+        assert result.content[0].text.startswith("Input validation error:")  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_skips_schema_check_and_errors_via_body(
+        self, server: GatewayServer
+    ) -> None:
+        """No schema to validate against for an unknown tool; the original
+        body's `Unknown tool` ValueError still surfaces as a caught error
+        result (preserving 1.x behaviour: call_tool itself never raises)."""
+        assert server._server is not None
+        entry = server._server.get_request_handler("tools/call")
+        assert entry is not None
+        params = CallToolRequestParams(name="gateway.does_not_exist", arguments={})
+        result = await entry.handler(_make_ctx(), params)
+        assert isinstance(result, CallToolResult)
+        assert result.is_error is False  # unchanged 1.x behaviour: not flagged isError
+        assert "Unknown tool" in result.content[0].text  # type: ignore[union-attr]
+
+
+class TestListResources:
+    @pytest.mark.asyncio
+    async def test_returns_typed_result_with_str_uri(
+        self, server: GatewayServer
+    ) -> None:
+        server._client_manager._resources = {
+            "test::file:///readme.md": ResourceInfo(
+                resource_id="test::file:///readme.md",
+                server_name="test",
+                uri="file:///readme.md",
+                name="README",
+                description="Project readme",
+                mime_type="text/markdown",
+            ),
+        }
+        assert server._server is not None
+        entry = server._server.get_request_handler("resources/list")
+        assert entry is not None
+        result = await entry.handler(_make_ctx(), PaginatedRequestParams())
+        assert isinstance(result, ListResourcesResult)
+        assert len(result.resources) >= 1
+        for resource in result.resources:
+            # Trap 5: Resource.uri is str in 2.0.0; constructing with AnyUrl
+            # raises ValidationError, so this only passes if server.py builds
+            # Resource(uri=<str>, ...) rather than Resource(uri=AnyUrl(...), ...).
+            assert isinstance(resource.uri, str)
+
+
+class TestReadResource:
+    @pytest.mark.asyncio
+    async def test_unknown_uri_raises(self, server: GatewayServer) -> None:
+        """Exception -> JSON-RPC error mapping: the runner maps an uncaught
+        ValueError, so the adapter must let it propagate rather than catch it."""
+        assert server._server is not None
+        entry = server._server.get_request_handler("resources/read")
+        assert entry is not None
+        params = ReadResourceRequestParams(uri="file:///does-not-exist")
+        with pytest.raises(ValueError, match="Unknown resource"):
+            await entry.handler(_make_ctx(), params)
+
+    @pytest.mark.asyncio
+    async def test_guidance_resource_returns_typed_result_with_str_uri(
+        self, server: GatewayServer
+    ) -> None:
+        assert server._server is not None
+        entry = server._server.get_request_handler("resources/read")
+        assert entry is not None
+        params = ReadResourceRequestParams(uri="pmcp://guidance/code-execution")
+        result = await entry.handler(_make_ctx(), params)
+        assert isinstance(result, ReadResourceResult)
+        assert len(result.contents) == 1
+        assert isinstance(result.contents[0].uri, str)
+
+
+class TestListPrompts:
+    @pytest.mark.asyncio
+    async def test_returns_typed_result(self, server: GatewayServer) -> None:
+        server._client_manager._prompts = {
+            "test::greeting": PromptInfo(
+                prompt_id="test::greeting",
+                server_name="test",
+                name="greeting",
+                description="Generate a greeting",
+                arguments=[
+                    PromptArgumentInfo(name="name", description="Name", required=True)
+                ],
+            ),
+        }
+        assert server._server is not None
+        entry = server._server.get_request_handler("prompts/list")
+        assert entry is not None
+        result = await entry.handler(_make_ctx(), PaginatedRequestParams())
+        assert isinstance(result, ListPromptsResult)
+        assert len(result.prompts) == 1
+
+
+class TestGetPrompt:
+    @pytest.mark.asyncio
+    async def test_policy_blocked_prompt_raises(self, tmp_path: Any) -> None:
+        """Exception -> JSON-RPC error mapping for the policy-denial path."""
+        policy_file = tmp_path / "policy.json"
+        policy_file.write_text('{"prompts": {"denylist": ["test::secret"]}}')
+        srv = GatewayServer(policy_path=policy_file)
+        srv._create_server(instructions="test")
+        assert srv._server is not None
+        entry = srv._server.get_request_handler("prompts/get")
+        assert entry is not None
+        params = GetPromptRequestParams(name="test::secret", arguments=None)
+        with pytest.raises(ValueError, match="blocked by policy"):
+            await entry.handler(_make_ctx(), params)
+
+    @pytest.mark.asyncio
+    async def test_returns_typed_result(self, server: GatewayServer) -> None:
+        server._client_manager._prompts = {
+            "test::greeting": PromptInfo(
+                prompt_id="test::greeting",
+                server_name="test",
+                name="greeting",
+                description="Generate a greeting",
+                arguments=None,
+            ),
+        }
+
+        async def fake_get_prompt(
+            prompt_id: str, arguments: dict[str, str] | None
+        ) -> dict[str, Any]:
+            return {
+                "description": "hi",
+                "messages": [{"role": "user", "content": {"text": "hello"}}],
+            }
+
+        server._client_manager.get_prompt = fake_get_prompt  # type: ignore[method-assign]
+        assert server._server is not None
+        entry = server._server.get_request_handler("prompts/get")
+        assert entry is not None
+        params = GetPromptRequestParams(name="test::greeting", arguments=None)
+        result = await entry.handler(_make_ctx(), params)
+        assert isinstance(result, GetPromptResult)
+        assert result.messages[0].content.text == "hello"  # type: ignore[union-attr]
+
+
+class TestModelReshape:
+    """Trap 5, pinned as a build-breaking assertion rather than a note."""
+
+    def test_tool_schema_field_is_snake_case(self) -> None:
+        assert "input_schema" in Tool.model_fields
+        assert "inputSchema" not in Tool.model_fields
+
+    def test_gateway_tools_survive_alias_round_trip(self) -> None:
+        """Proxying-fidelity: catches the dropped `extra="allow"` on `Tool` —
+        a field that silently disappeared in transit would fail this."""
+        for tool in get_gateway_tool_definitions():
+            dumped = tool.model_dump(by_alias=True)
+            revalidated = Tool.model_validate(dumped)
+            assert revalidated.model_dump(by_alias=True) == dumped, tool.name

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -1,0 +1,12 @@
+"""Fixture wiring for tests/runtime/.
+
+pytest only discovers fixtures from conftest.py (or modules explicitly
+imported into it) — a fixture defined in a plain helper module like
+`harness.py` is invisible to the collector otherwise. Re-exporting it here
+is what makes `gateway_on_spare_port` usable by every test module in this
+directory without a per-module import.
+"""
+
+from __future__ import annotations
+
+from tests.runtime.harness import gateway_on_spare_port  # noqa: F401

--- a/tests/runtime/fake_remote.py
+++ b/tests/runtime/fake_remote.py
@@ -1,0 +1,111 @@
+"""SL-4.4 — a real mcp 2.x Streamable HTTP downstream, for EC-P2-7.
+
+Every existing remote-downstream test in this repo patches
+`pmcp.client.manager.streamable_http_client`; Execution Notes >
+"EC-P2-7 is greenfield" explicitly disqualifies that as evidence here — the
+whole point is proving the *rebuilt* transport really carries headers,
+really follows redirects, and really doesn't leak clients across
+reconnects, none of which a patched transport can show. This module is a
+genuine `mcp.server.MCPServer` served over Streamable HTTP by uvicorn's
+programmatic `Server` API, run in-process as a background task on the
+current event loop so a real, in-process `ClientManager` can connect to it
+within the same test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+import uvicorn
+from mcp.server import MCPServer
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, RedirectResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+AUTH_HEADER = "authorization"
+
+
+class _AuthGate:
+    """ASGI middleware: 401s any `/mcp` request whose `Authorization` header
+    doesn't match exactly. Wraps the MCPServer's own Starlette app rather
+    than replacing it, so the real Streamable HTTP session-manager lifespan
+    (background tasks, event store) is untouched."""
+
+    def __init__(self, app: ASGIApp, *, expected_value: str) -> None:
+        self.app = app
+        self._expected = expected_value.encode()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope["path"] == "/mcp":
+            headers = dict(scope["headers"])
+            actual = headers.get(AUTH_HEADER.encode(), b"")
+            if actual != self._expected:
+                response = PlainTextResponse("Unauthorized", status_code=401)
+                await response(scope, receive, send)
+                return
+        await self.app(scope, receive, send)
+
+
+def build_fake_remote_app(*, expected_auth_value: str) -> Starlette:
+    """One real tool behind the auth gate, plus `/relocated`, which
+    307-redirects to `/mcp` (307 preserves method + body, unlike 301/302/303
+    — required for a POST-based MCP session to still resolve past it, and
+    the property that proves IF-0-P2-2's `follow_redirects=True`)."""
+    mcp = MCPServer("fake-remote")
+
+    @mcp.tool()
+    def fr_echo(text: str) -> str:
+        """Echo the supplied text back with a fixed, greppable prefix."""
+        return f"fr-echo:{text}"
+
+    app = mcp.streamable_http_app()
+
+    async def redirect_to_mcp(request: Request) -> RedirectResponse:
+        return RedirectResponse(url="/mcp", status_code=307)
+
+    app.add_route("/relocated", redirect_to_mcp, methods=["POST", "GET"])
+    app.add_middleware(_AuthGate, expected_value=expected_auth_value)
+    return app
+
+
+@dataclass
+class RunningFakeRemote:
+    port: int
+    base_url: str
+    mcp_url: str
+    redirect_url: str
+
+
+@contextlib.asynccontextmanager
+async def run_fake_remote(
+    port: int, *, expected_auth_value: str
+) -> AsyncIterator[RunningFakeRemote]:
+    """Serve `build_fake_remote_app()` in-process on `port`, as a background
+    asyncio task on the caller's own event loop, for the duration of the
+    `async with` block."""
+    app = build_fake_remote_app(expected_auth_value=expected_auth_value)
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", lifespan="on"
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    try:
+        for _ in range(200):
+            if server.started:
+                break
+            await asyncio.sleep(0.05)
+        else:
+            raise RuntimeError("fake remote server never started")
+        yield RunningFakeRemote(
+            port=port,
+            base_url=f"http://127.0.0.1:{port}",
+            mcp_url=f"http://127.0.0.1:{port}/mcp",
+            redirect_url=f"http://127.0.0.1:{port}/relocated",
+        )
+    finally:
+        server.should_exit = True
+        await task

--- a/tests/runtime/harness.py
+++ b/tests/runtime/harness.py
@@ -152,16 +152,27 @@ def booted_gateway(
     "Boot isolation requires all six controls together" verbatim:
       - never binds :3344, resolved via `alloc_port()`
       - passes all six isolation controls plus a cwd inside the throwaway dir
-      - the live gateway's pid and child set are identical before and after
+      - a live gateway on :3344, if one exists, has an identical pid and
+        child set before and after (on a runner with none, the pid stays
+        `None` throughout -- see below)
       - never deletes or moves the operator's real files — only the
         redirected `HOME`/`XDG_CONFIG_HOME` env vars change where the code
         looks, matching "Never isolate by moving or deleting files outside
         the worktree"
     """
+    # A live gateway on :3344 is an operator-host fixture, not a CI one --
+    # V0a/V0b in the plan's own Verification block treat an empty
+    # `LIVE_PID` as a valid state (`test "$(...)" = "$LIVE_PID"` passes
+    # when both sides are empty), and CI's runners have no pmcp systemd
+    # unit at all. Mirror that: `None` here means "nothing to protect",
+    # not "abort" -- the boot-isolation and wire-behaviour evidence this
+    # harness exists for must still run on a runner with no live gateway.
     live_pid = _live_gateway_pid()
-    assert live_pid, "FAIL: could not resolve live gateway pid on :3344 -- abort"
-    assert _live_health_ok(), "live gateway health check failed BEFORE boot -- abort"
-    children_before = _children_of(live_pid)
+    if live_pid is not None:
+        assert _live_health_ok(), (
+            "live gateway health check failed BEFORE boot -- abort"
+        )
+    children_before = _children_of(live_pid) if live_pid is not None else []
 
     with tempfile.TemporaryDirectory(prefix="pmcp-rt-") as work_str:
         work = Path(work_str)
@@ -261,12 +272,22 @@ def booted_gateway(
                 proc.kill()
                 proc.wait(timeout=10)
 
-    assert _live_health_ok(), "FAIL: live gateway died during/after the boot"
-    children_after = _children_of(live_pid)
-    assert children_before == children_after, (
-        "FAIL: live gateway's child set changed -- "
-        f"before={children_before} after={children_after}"
+    # A gateway that didn't exist before this boot must not exist after it
+    # either -- this harness allocates a spare port and must never leave
+    # its own process listening on :3344 (`port != 3344` already backs
+    # this at the transport level; this re-checks at the process level).
+    live_pid_after = _live_gateway_pid()
+    assert live_pid_after == live_pid, (
+        "FAIL: live gateway pid on :3344 changed across the boot -- "
+        f"before={live_pid} after={live_pid_after}"
     )
+    if live_pid is not None:
+        assert _live_health_ok(), "FAIL: live gateway died during/after the boot"
+        children_after = _children_of(live_pid)
+        assert children_before == children_after, (
+            "FAIL: live gateway's child set changed -- "
+            f"before={children_before} after={children_after}"
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/runtime/harness.py
+++ b/tests/runtime/harness.py
@@ -1,0 +1,369 @@
+"""SL-4 — deployed-wire runtime acceptance harness, shared by tests/runtime/*.
+
+Not collected by pytest itself (no `test_*` names) — `tests/runtime/test_harness.py`
+is the collectable module that pins the contract this file provides.
+
+Provides:
+  - `alloc_port()` — a real ephemeral-port allocator (`socket.bind(("127.0.0.1", 0))`);
+    no test under this package may hardcode a port literal for its own gateway.
+  - `booted_gateway()` — a context manager that boots an isolated gateway on a
+    spare port with all six isolation controls (`--config`, `--project`,
+    `--policy`, `--lock-dir`, redirected `HOME`/`XDG_CONFIG_HOME`, and a cwd
+    inside the throwaway dir), waits for `/health`, and asserts the live
+    `:3344` gateway's pid and child set are unchanged across the cycle
+    (Execution Notes > Runtime-step safety). Reuses
+    `tests.test_credential_boot._live_gateway_pid` / `_children_of` rather
+    than reinventing them, per the plan.
+  - `gateway_on_spare_port` — a session-scoped pytest fixture wrapping
+    `booted_gateway()` with the harness's one `rt-fixture` downstream
+    eagerly started, shared by the handshake-era and modern-era wire tests
+    (SL-4.2, SL-4.3).
+  - `modern_post()` / `modern_envelope()` / `decode_modern_response()` — build
+    and send an IF-0-P2-4 modern-envelope JSON-RPC request over HTTP and
+    decode the response regardless of framing (plain `application/json` or
+    one `text/event-stream` `data:` frame — IF-0-P2-4, Execution Notes >
+    "EC-P2-6 must go over the deployed HTTP wire").
+  - `RT_FIXTURE_SRC` — a real stdio `mcp.server.MCPServer` (2.0.0) exposing
+    one tool and one prompt, registered as the harness gateway's sole
+    `autoStart` downstream so `prompts/list`/`prompts/get` (which pmcp only
+    ever proxies from a live downstream — there is no built-in prompt) have
+    real typed content to exercise.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from mcp.shared.inbound import (
+    MCP_METHOD_HEADER,
+    MCP_NAME_HEADER,
+    MCP_PROTOCOL_VERSION_HEADER,
+)
+from mcp.types import CLIENT_CAPABILITIES_META_KEY, PROTOCOL_VERSION_META_KEY
+from mcp.types.version import LATEST_MODERN_VERSION
+
+from tests.test_credential_boot import _children_of, _live_gateway_pid
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIVE_GATEWAY_PORT = 3344  # NEVER boot a tests/runtime/ fixture on this port.
+
+RT_FIXTURE_SRC = '''\
+from mcp.server import MCPServer
+
+mcp = MCPServer("rt-fixture")
+
+
+@mcp.tool()
+def rt_echo(text: str) -> str:
+    """Echo the supplied text back with a fixed, greppable prefix."""
+    return f"rt-echo:{text}"
+
+
+@mcp.prompt()
+def rt_greeting(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+
+if __name__ == "__main__":
+    mcp.run()
+'''
+
+
+def alloc_port() -> int:
+    """A real allocator: bind to an OS-assigned ephemeral port and release it.
+
+    Ports 38344 and 38345 are already claimed by tests/test_credential_boot.py
+    and its P6CLEAN sibling; this harness never hardcodes a port so it cannot
+    collide with those or with itself across concurrent test runs.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _live_health_ok() -> bool:
+    result = subprocess.run(
+        ["curl", "-sf", f"http://127.0.0.1:{LIVE_GATEWAY_PORT}/health"],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+@dataclass
+class BootedGateway:
+    """State of one isolated gateway booted by `booted_gateway()`."""
+
+    base_url: str
+    mcp_url: str
+    port: int
+    work_dir: Path
+    boot_log: Path
+    command: list[str]
+    env: dict[str, str]
+    cwd: Path
+    proc: subprocess.Popen[bytes]
+
+
+def _wait_for_health(proc: subprocess.Popen[bytes], boot_log: Path, port: int) -> None:
+    for _ in range(60):
+        result = subprocess.run(
+            ["curl", "-sf", f"http://127.0.0.1:{port}/health"],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        if proc.poll() is not None:
+            pytest.fail(f"fixture gateway exited early:\n{boot_log.read_text()}")
+        time.sleep(0.5)
+    pytest.fail(f"fixture gateway never became healthy:\n{boot_log.read_text()}")
+
+
+@contextlib.contextmanager
+def booted_gateway(
+    *,
+    extra_servers: dict[str, Any] | None = None,
+    extra_allowlist: list[str] | None = None,
+) -> Iterator[BootedGateway]:
+    """Boot one fully isolated gateway with the `rt-fixture` stdio downstream
+    eagerly started, on a spare port never `:3344`.
+
+    `extra_servers` / `extra_allowlist` let a caller (e.g. SL-4.5's mcp-1.x
+    downstream) add another `mcpServers` entry to the same isolated boot
+    without duplicating the isolation plumbing.
+
+    Guarantees, matching Execution Notes > "Runtime-step safety" and
+    "Boot isolation requires all six controls together" verbatim:
+      - never binds :3344, resolved via `alloc_port()`
+      - passes all six isolation controls plus a cwd inside the throwaway dir
+      - the live gateway's pid and child set are identical before and after
+      - never deletes or moves the operator's real files — only the
+        redirected `HOME`/`XDG_CONFIG_HOME` env vars change where the code
+        looks, matching "Never isolate by moving or deleting files outside
+        the worktree"
+    """
+    live_pid = _live_gateway_pid()
+    assert live_pid, "FAIL: could not resolve live gateway pid on :3344 -- abort"
+    assert _live_health_ok(), "live gateway health check failed BEFORE boot -- abort"
+    children_before = _children_of(live_pid)
+
+    with tempfile.TemporaryDirectory(prefix="pmcp-rt-") as work_str:
+        work = Path(work_str)
+        fake_home = work / "home"
+        fake_home.mkdir()
+        project = work / "proj"
+        project.mkdir()
+        lock_dir = work / "lock"
+
+        # Unique command basename + a fresh-mktemp arg, so
+        # _kill_orphan_processes' (Path(command).name, tuple(args))
+        # fingerprint (server.py) cannot collide with anything the live
+        # gateway is running — same recipe as test_credential_boot.py.
+        fixture_py = work / "rt_fixture_server.py"
+        fixture_py.write_text(RT_FIXTURE_SRC)
+        wrapper = work / "rt-fixture-server"
+        wrapper.write_text(
+            f'#!/bin/sh\nexec {REPO_ROOT}/.venv/bin/python {fixture_py} "$@"\n'
+        )
+        wrapper.chmod(0o755)
+
+        servers: dict[str, Any] = {
+            "rt-fixture": {"command": str(wrapper), "args": ["--rt-run", str(work)]}
+        }
+        if extra_servers:
+            servers.update(extra_servers)
+        auto_start = sorted({"rt-fixture", *(extra_servers or {})})
+        allowlist = sorted(
+            {"rt-fixture", *(extra_allowlist or []), *(extra_servers or {})}
+        )
+
+        config_path = work / "config.json"
+        config_path.write_text(
+            json.dumps({"mcpServers": servers, "autoStart": auto_start})
+        )
+
+        policy_path = work / "policy.yaml"
+        policy_lines = "\n".join(f"    - {name}" for name in allowlist)
+        policy_path.write_text(f"servers:\n  allowlist:\n{policy_lines}\n")
+
+        boot_log = work / "gw.log"
+        port = alloc_port()
+        env = {
+            **os.environ,
+            "HOME": str(fake_home),
+            "XDG_CONFIG_HOME": str(fake_home / ".config"),
+        }
+        # No PMCP_MANIFEST_PATH: the shipped manifest layers in additively
+        # regardless of --config, which is exactly what the ~106
+        # skipped/policy_denied entries in every boot log below prove.
+
+        command = [
+            f"{REPO_ROOT}/.venv/bin/pmcp",
+            "--transport",
+            "http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--lock-dir",
+            str(lock_dir),
+            "--config",
+            str(config_path),
+            "--project",
+            str(project),
+            "--policy",
+            str(policy_path),
+            "-l",
+            "info",
+        ]
+        with open(boot_log, "w") as log_fh:
+            proc = subprocess.Popen(
+                command,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                env=env,
+                cwd=work,
+            )
+        try:
+            _wait_for_health(proc, boot_log, port)
+            yield BootedGateway(
+                base_url=f"http://127.0.0.1:{port}",
+                mcp_url=f"http://127.0.0.1:{port}/mcp",
+                port=port,
+                work_dir=work,
+                boot_log=boot_log,
+                command=command,
+                env=env,
+                cwd=work,
+                proc=proc,
+            )
+        finally:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+
+    assert _live_health_ok(), "FAIL: live gateway died during/after the boot"
+    children_after = _children_of(live_pid)
+    assert children_before == children_after, (
+        "FAIL: live gateway's child set changed -- "
+        f"before={children_before} after={children_after}"
+    )
+
+
+@pytest.fixture(scope="session")
+def gateway_on_spare_port() -> Iterator[BootedGateway]:
+    """Session-scoped: one boot shared by every handshake-era and
+    modern-era wire test (SL-4.2, SL-4.3) so each module doesn't pay a
+    fresh ~1-2s subprocess boot per test."""
+    with booted_gateway() as gw:
+        yield gw
+
+
+# For tools/call, prompts/get, resources/read only (IF-0-P2-4).
+_NAME_REQUIRED_METHODS = frozenset({"tools/call", "prompts/get", "resources/read"})
+
+
+def modern_envelope(
+    method: str, params: dict[str, Any] | None = None, *, name: str | None = None
+) -> tuple[dict[str, str], dict[str, Any]]:
+    """Build the (headers, body) pair IF-0-P2-4 requires for a modern-era
+    request: both `_meta` keys, `MCP-Protocol-Version`/`Mcp-Method` always,
+    and `Mcp-Name` for the three named-target methods."""
+    meta_params = dict(params or {})
+    meta_params["_meta"] = {
+        PROTOCOL_VERSION_META_KEY: LATEST_MODERN_VERSION,
+        CLIENT_CAPABILITIES_META_KEY: {},
+    }
+    headers = {
+        "Content-Type": "application/json",
+        # pmcp constructs its session manager with json_response=False, which
+        # answers 406 unless Accept carries both media types (IF-0-P2-4).
+        "Accept": "application/json, text/event-stream",
+        MCP_PROTOCOL_VERSION_HEADER: LATEST_MODERN_VERSION,
+        MCP_METHOD_HEADER: method,
+    }
+    if method in _NAME_REQUIRED_METHODS:
+        assert name is not None, f"{method} requires Mcp-Name"
+        headers[MCP_NAME_HEADER] = name
+    body = {"jsonrpc": "2.0", "id": 1, "method": method, "params": meta_params}
+    return headers, body
+
+
+def decode_modern_response(response: httpx.Response) -> dict[str, Any]:
+    """Decode a modern-era JSON-RPC response regardless of framing.
+
+    pmcp sets json_response=False, so the handler runs under a 15s SSE
+    deferral: a body that completes inside the window is plain
+    `application/json`; otherwise the response commits to
+    `text/event-stream` and the result arrives as one `event: message` /
+    `data: {...}` frame. Asserting only plain JSON would make a *correct*
+    gateway look broken whenever a call is slow or emits progress
+    (IF-0-P2-4).
+    """
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        data_lines = [
+            line for line in response.text.splitlines() if line.startswith("data:")
+        ]
+        assert data_lines, (
+            f"text/event-stream response carried no data: frame: {response.text!r}"
+        )
+        return json.loads(data_lines[-1][len("data:") :].strip())  # noqa: E203
+    return response.json()
+
+
+def modern_post(
+    base_url: str,
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    name: str | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """POST a modern-envelope JSON-RPC request to `<base_url>/mcp` and
+    return the decoded message (regardless of response framing)."""
+    headers, body = modern_envelope(method, params, name=name)
+    response = httpx.post(
+        f"{base_url}/mcp", headers=headers, json=body, timeout=timeout
+    )
+    response.raise_for_status()
+    return decode_modern_response(response)
+
+
+# EC-P2-2's boot-log assertion, shared so every module checks the same regex.
+INITIALIZED_RE = re.compile(r"Gateway initialized: \d+/\d+ servers online")
+
+
+def open_socket_fd_count() -> int:
+    """Count this process's open socket file descriptors via `/proc/self/fd`
+    readlink targets (`socket:[12345]`) — not psutil, which isn't a pmcp
+    dependency. Used by EC-P2-7's leak proof: a growing count across
+    reconnect cycles means a socket escaped `_cleanup_client`."""
+    count = 0
+    for fd in os.listdir("/proc/self/fd"):
+        try:
+            target = os.readlink(f"/proc/self/fd/{fd}")
+        except OSError:
+            continue
+        if target.startswith("socket:"):
+            count += 1
+    return count

--- a/tests/runtime/test_downstream_handshake_era.py
+++ b/tests/runtime/test_downstream_handshake_era.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -80,8 +81,15 @@ def legacy_1x_downstream(
     work = tmp_path_factory.mktemp("pmcp-rt-mcp1x")
     venv_dir = work / "venv"
 
+    # The RUNNING interpreter's own version, not a hardcoded one: CI's
+    # matrix covers 3.10/3.11/3.12 (`.github/workflows/test.yml`), and
+    # pinning "3.11" here would force `uv` to fetch a managed CPython
+    # mid-test on the 3.10/3.12 legs -- a network/toolchain dependency this
+    # fixture doesn't need. mcp==1.25.0 supports all three (Requires-Python
+    # >=3.10).
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     venv_result = subprocess.run(
-        [uv, "venv", str(venv_dir), "--python", "3.11"],
+        [uv, "venv", str(venv_dir), "--python", python_version],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/runtime/test_downstream_handshake_era.py
+++ b/tests/runtime/test_downstream_handshake_era.py
@@ -1,0 +1,151 @@
+"""SL-4.5 — EC-P2-4: a genuine mcp 1.x downstream connected through the 2.x
+gateway.
+
+A session-scoped fixture builds a throwaway venv once (`uv venv <tmp>/mcp1
+&& VIRTUAL_ENV=<tmp>/mcp1 uv pip install "mcp==1.25.0"` — `1.25.0` is the
+version this worktree's own venv resolved before the P2 bump, the known-good
+1.x peer) and registers a real 1.x `FastMCP` stdio server as a downstream.
+The gateway's own interpreter stays on 2.x — `ClientManager` is real,
+in-process, the same class `pmcp.server.GatewayServer` uses — only the
+*subprocess* is pinned to 1.x. That is enough to prove the property EC-P2-4
+names: `ServerStatus.protocol_version` is an internal model
+(`src/pmcp/types.py`), not a wire-only detail, so in-process access through
+`ClientManager` is a legitimate way to "connect through the 2.x gateway"
+without a booted-subprocess gateway in between.
+
+**No skip path**: if `uv` is unavailable or the 1.x install fails, the
+fixture calls `pytest.fail`, not `pytest.skip` — a skipped test exits 0,
+which for a CI acceptance gate *is* passing silently, the exact false-green
+shape this repo keeps getting burned by (Execution Notes). There is no
+legitimate environment to accommodate: `uv sync --all-extras` is already a
+precondition of every command in this plan and every CI job, so a runner
+without `uv` cannot execute the phase at all.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from mcp.types.version import HANDSHAKE_PROTOCOL_VERSIONS, LATEST_MODERN_VERSION
+
+from pmcp.client.manager import ClientManager
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig
+
+DOWNSTREAM_1X_SRC = '''\
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("p2-downstream-1x")
+
+
+@mcp.tool()
+def legacy_echo(text: str) -> str:
+    """Echo the supplied text back with a fixed, greppable prefix."""
+    return f"legacy-echo:{text}"
+
+
+if __name__ == "__main__":
+    mcp.run()
+'''
+
+
+@dataclass
+class Legacy1xDownstream:
+    python: Path
+    script: Path
+
+
+@pytest.fixture(scope="session")
+def legacy_1x_downstream(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[Legacy1xDownstream]:
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.fail(
+            "EC-P2-4 requires `uv` to build a throwaway mcp==1.25.0 venv "
+            "for the downstream fixture -- and `uv sync --all-extras` is "
+            "already a precondition of every command in this plan and "
+            "every CI job, so a runner without `uv` cannot execute this "
+            "phase at all. This is pytest.fail, not pytest.skip: a skip "
+            "would let EC-P2-4 go green having proven nothing."
+        )
+
+    work = tmp_path_factory.mktemp("pmcp-rt-mcp1x")
+    venv_dir = work / "venv"
+
+    venv_result = subprocess.run(
+        [uv, "venv", str(venv_dir), "--python", "3.11"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if venv_result.returncode != 0:
+        pytest.fail(
+            f"EC-P2-4 fixture: `uv venv` failed "
+            f"(exit {venv_result.returncode}):\n{venv_result.stderr}"
+        )
+
+    install_result = subprocess.run(
+        [uv, "pip", "install", "mcp==1.25.0"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "VIRTUAL_ENV": str(venv_dir)},
+    )
+    if install_result.returncode != 0:
+        pytest.fail(
+            f"EC-P2-4 fixture: `uv pip install mcp==1.25.0` failed "
+            f"(exit {install_result.returncode}):\n{install_result.stderr}"
+        )
+
+    python = venv_dir / "bin" / "python"
+    if not python.exists():
+        pytest.fail(f"EC-P2-4 fixture: no python at {python} after venv creation")
+
+    script = work / "p2_downstream_1x.py"
+    script.write_text(DOWNSTREAM_1X_SRC)
+
+    yield Legacy1xDownstream(python=python, script=script)
+
+
+@pytest.mark.asyncio
+async def test_mcp_1x_downstream_negotiates_a_handshake_version_through_2x_gateway(
+    legacy_1x_downstream: Legacy1xDownstream,
+) -> None:
+    manager = ClientManager()
+    config = ResolvedServerConfig(
+        name="legacy-1x",
+        source="custom",
+        config=LocalMcpServerConfig(
+            command=str(legacy_1x_downstream.python),
+            args=[str(legacy_1x_downstream.script)],
+        ),
+    )
+    try:
+        errors = await manager.connect_server(config)
+        assert errors == [], errors
+        assert manager.is_server_online("legacy-1x") is True
+
+        status = manager._servers["legacy-1x"]
+        assert status.protocol_version in HANDSHAKE_PROTOCOL_VERSIONS
+        assert status.protocol_version != LATEST_MODERN_VERSION
+
+        # A real tool call, not just a successful handshake.
+        gateway_tools = GatewayTools(
+            client_manager=manager, policy_manager=PolicyManager()
+        )
+        result = await gateway_tools.invoke(
+            {"tool_id": "legacy-1x::legacy_echo", "arguments": {"text": "1x-proof"}}
+        )
+        assert result.ok is True
+        content = result.result["content"]  # type: ignore[index]
+        assert content[0]["text"] == "legacy-echo:1x-proof"
+    finally:
+        await manager.disconnect_all()

--- a/tests/runtime/test_downstream_remote.py
+++ b/tests/runtime/test_downstream_remote.py
@@ -1,0 +1,175 @@
+"""SL-4.4 — EC-P2-7: the rebuilt downstream Streamable HTTP client, proven
+against a real HTTP peer.
+
+Every existing remote-downstream test in this repo (`tests/test_client_manager.py`)
+patches `streamable_http_client`; that's explicitly disqualified as evidence
+for EC-P2-7 (Execution Notes > "EC-P2-7 is greenfield"), because it proves
+nothing about whether the *rebuilt* client (IF-0-P2-2) actually carries
+headers, actually follows redirects, or actually stops leaking clients
+across reconnects. This module runs a real, in-process `ClientManager`
+against `fake_remote.py`'s real HTTP server instead.
+
+`ClientManager.remote_http_client.is_closed` and the process's open socket
+count are internal-process state unreachable across a subprocess boundary,
+so this must run in-process rather than through a booted gateway subprocess
+— the "no mocks" bar applies to the fake remote peer, not to how the
+gateway code runs.
+
+All five properties below share ONE `run_fake_remote` lifecycle inside ONE
+test function, rather than one `run_fake_remote` per test — empirically,
+not a style choice: a real streamable-http client connection that fully
+establishes its standalone SSE listener and is then torn down leaves
+something in anyio's process-global task/cancel-scope bookkeeping that
+breaks the *next independent* event loop's uvicorn server (reproduced with
+`git bisect`-style isolation — a connect-only cycle, or a second server
+with no client at all, does not trigger it; only a fully connected-then-
+disconnected client followed by a *separate* `asyncio.run()`/event-loop
+boundary does). That is orthogonal to anything IF-0-P2-2 changed — it
+reproduces with a plain, non-redirected, non-authenticated connect too —
+and looks like an anyio/httpx2/uvicorn interaction rather than a pmcp bug;
+reported to the team lead rather than routed around silently. Keeping
+everything in one test function's one event loop avoids it and keeps the
+evidence real.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pmcp.client.manager import ClientManager
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
+from tests.runtime.fake_remote import run_fake_remote
+from tests.runtime.harness import alloc_port, open_socket_fd_count
+
+AUTH_VALUE = "Bearer rt-secret-token"
+
+
+def _config(
+    name: str, url: str, *, headers: dict[str, str] | None = None
+) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=RemoteMcpServerConfig(type="streamable-http", url=url, headers=headers),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
+    manager = ClientManager()
+    connected_names: list[str] = []
+    try:
+        async with run_fake_remote(
+            alloc_port(), expected_auth_value=AUTH_VALUE
+        ) as remote:
+            # 1. Headers set by IF-0-P2-2's httpx2.AsyncClient construction
+            #    really reach the peer: the fake remote 401s without the
+            #    exact configured Authorization value, so a successful
+            #    connect + real gateway.invoke proves the rebuilt client
+            #    carries them, not just that a mock recorded a kwarg.
+            errors = await manager.connect_server(
+                _config(
+                    "fr-auth", remote.mcp_url, headers={"Authorization": AUTH_VALUE}
+                )
+            )
+            assert errors == []
+            connected_names.append("fr-auth")
+            assert manager.is_server_online("fr-auth") is True
+
+            gateway_tools = GatewayTools(
+                client_manager=manager, policy_manager=PolicyManager()
+            )
+            result = await gateway_tools.invoke(
+                {
+                    "tool_id": "fr-auth::fr_echo",
+                    "arguments": {"text": "wire-proof"},
+                }
+            )
+            assert result.ok is True
+            content = result.result["content"]  # type: ignore[index]
+            assert content[0]["text"] == "fr-echo:wire-proof"
+
+            # 2. Negative case: without this, (1) would be hollow — a fake
+            #    remote that accepts everything can't prove headers matter.
+            #    Confirms the 401 gate is live, not dead code.
+            errors = await manager.connect_server(_config("fr-noauth", remote.mcp_url))
+            assert errors != []
+            assert manager.is_server_online("fr-noauth") is False
+
+            # 2b. Wrong value, not just absent.
+            errors = await manager.connect_server(
+                _config(
+                    "fr-wrongauth",
+                    remote.mcp_url,
+                    headers={"Authorization": "Bearer not-the-right-token"},
+                )
+            )
+            assert errors != []
+
+            # 3. Proves follow_redirects=True (IF-0-P2-2): the configured
+            #    URL points at /relocated, which 307s to /mcp. httpx2's own
+            #    default is follow_redirects=False, so this fails if pmcp
+            #    ever drops the explicit override.
+            errors = await manager.connect_server(
+                _config(
+                    "fr-redirect",
+                    remote.redirect_url,
+                    headers={"Authorization": AUTH_VALUE},
+                )
+            )
+            assert errors == []
+            connected_names.append("fr-redirect")
+            assert manager.is_server_online("fr-redirect") is True
+
+            # 4. The leak proof. Calls the private `_connect_streamable_http`
+            #    directly (not the public `connect_server`, whose
+            #    singleflight guard short-circuits as a no-op when the
+            #    server is already ONLINE — manager.py:580-581 — and so
+            #    never reaches the reconnect branch at all): each call finds
+            #    `name in self._clients` from the previous iteration and
+            #    takes `_connect_remote_stream`'s "existing live connection"
+            #    branch, which calls `_cleanup_client` — the method
+            #    IF-0-P2-2 taught to close `managed.sse_exit_stack` (and
+            #    therefore the owned `httpx2.AsyncClient`) for remote
+            #    clients; before this phase it did not.
+            reconnect_config = _config(
+                "fr-reconnect", remote.mcp_url, headers={"Authorization": AUTH_VALUE}
+            )
+            prior_clients = []
+            socket_counts_by_cycle = []
+            for _ in range(5):
+                await manager._connect_streamable_http(reconnect_config)
+                managed = manager._clients["fr-reconnect"]
+                assert managed.remote_http_client is not None
+                prior_clients.append(managed.remote_http_client)
+                socket_counts_by_cycle.append(open_socket_fd_count())
+            connected_names.append("fr-reconnect")
+
+            for closed_client in prior_clients[:-1]:
+                assert closed_client.is_closed is True
+            assert prior_clients[-1].is_closed is False
+
+            # Compare against the count right after the FIRST cycle, not
+            # before it: establishing this server's very first connection
+            # has its own one-time socket cost (control connection +
+            # standalone SSE listener), which is not what this proves.
+            # What matters is that cycles 2-5 add nothing further — every
+            # count in socket_counts_by_cycle[1:] must equal the first.
+            baseline = socket_counts_by_cycle[0]
+            assert all(count == baseline for count in socket_counts_by_cycle[1:]), (
+                f"socket count grew across reconnect cycles: {socket_counts_by_cycle}"
+            )
+    finally:
+        # disconnect_server (not disconnect_all, whose concurrent gather of
+        # every managed client's shutdown can trip anyio's cross-task
+        # cancel-scope guard — see the module docstring) closes each
+        # connected client explicitly.
+        for name in connected_names:
+            if manager.is_server_online(name):
+                await manager.disconnect_server(name, force=True)
+
+    # The final reconnect-cycle client is closed too, by the disconnect
+    # above rather than by a further reconnect.
+    assert prior_clients[-1].is_closed is True

--- a/tests/runtime/test_harness.py
+++ b/tests/runtime/test_harness.py
@@ -1,0 +1,50 @@
+"""SL-4.1 — pin `gateway_on_spare_port` / `booted_gateway`'s isolation contract.
+
+`harness.py` and `conftest.py` are never collected by pytest (no `test_*`
+name), so a command targeting only them verifies nothing — this is the
+collectable module SL-4.1 requires. Every other tests/runtime/ module
+depends on these guarantees holding.
+"""
+
+from __future__ import annotations
+
+from tests.runtime.harness import INITIALIZED_RE, LIVE_GATEWAY_PORT, booted_gateway
+
+
+def test_boot_never_binds_the_live_gateway_port() -> None:
+    with booted_gateway() as gw:
+        assert gw.port != LIVE_GATEWAY_PORT
+        assert gw.port > 0
+
+
+def test_boot_command_carries_all_six_isolation_controls() -> None:
+    with booted_gateway() as gw:
+        command = gw.command
+        assert "--config" in command
+        assert "--project" in command
+        assert "--policy" in command
+        assert "--lock-dir" in command
+        assert gw.env.get("HOME") == str(gw.work_dir / "home")
+        assert gw.env.get("XDG_CONFIG_HOME") == str(gw.work_dir / "home" / ".config")
+        # The sixth control: a cwd inside the throwaway dir, independent of
+        # --project and HOME (`_find_project_manifest()` walks from
+        # `Path.cwd()`).
+        assert gw.cwd == gw.work_dir
+        assert str(gw.cwd).startswith("/tmp") or "pmcp-rt-" in str(gw.cwd)
+
+
+def test_boot_log_reports_initialized_count() -> None:
+    with booted_gateway() as gw:
+        log_text = gw.boot_log.read_text()
+        assert INITIALIZED_RE.search(log_text), log_text
+        assert "Fatal error" not in log_text
+
+
+def test_live_gateway_pid_and_children_are_unchanged_across_a_full_cycle() -> None:
+    """`booted_gateway()` itself snapshots the live gateway's pid and child
+    set before entry and re-asserts both are unchanged on exit (Execution
+    Notes > Runtime-step safety); a completed setup/teardown cycle here is
+    the proof that assertion held for a real boot+shutdown, not just an
+    import."""
+    with booted_gateway():
+        pass

--- a/tests/runtime/test_wire_handshake_era.py
+++ b/tests/runtime/test_wire_handshake_era.py
@@ -1,0 +1,125 @@
+"""SL-4.2 — EC-P2-2, EC-P2-3: handshake-era deployed-wire acceptance.
+
+Drives a real `mcp.ClientSession` over `streamable_http_client` against a
+booted gateway's deployed `/mcp` endpoint (handshake era: the ordinary
+`initialize` negotiation, not the modern per-request `_meta` envelope —
+that's SL-4.3). Every method's response is already the SDK's own typed
+result model — `ClientSession` parses the wire response into it as part of
+a real client's normal codepath, so there is no hand-rolled JSON parsing
+here to accidentally paper over a wire-framing bug.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import (
+    CallToolResult,
+    GetPromptResult,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListToolsResult,
+    ReadResourceResult,
+    Tool,
+)
+
+from tests.runtime.harness import BootedGateway
+
+
+@asynccontextmanager
+async def _session(gw: BootedGateway) -> AsyncIterator[ClientSession]:
+    """Not a pytest fixture, deliberately: an async-generator fixture whose
+    `async with streamable_http_client(...)` spans setup and teardown across
+    pytest-asyncio's per-test event-loop boundary trips anyio's "cancel scope
+    in a different task" guard on teardown. Opening and closing the session
+    entirely inside one test's own coroutine avoids that class of failure."""
+    async with streamable_http_client(gw.mcp_url) as (read, write):
+        async with ClientSession(read, write) as sess:
+            await sess.initialize()
+            yield sess
+
+
+class TestHandshakeEraTypedResults:
+    """EC-P2-3: each of the six proxied methods answers with a typed result."""
+
+    @pytest.mark.asyncio
+    async def test_tools_list_returns_typed_result(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        async with _session(gateway_on_spare_port) as session:
+            result = await session.list_tools()
+        assert isinstance(result, ListToolsResult)
+        assert all(isinstance(t, Tool) for t in result.tools)
+        assert any(t.name == "gateway.health" for t in result.tools)
+
+    @pytest.mark.asyncio
+    async def test_tools_call_returns_typed_result(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        async with _session(gateway_on_spare_port) as session:
+            result = await session.call_tool("gateway.health", {})
+        assert isinstance(result, CallToolResult)
+        assert result.is_error is False
+        assert len(result.content) == 1
+
+    @pytest.mark.asyncio
+    async def test_tools_call_invalid_arguments_fails_schema_validation(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        """`gateway.describe` requires `tool_id: string`; feed it an int."""
+        async with _session(gateway_on_spare_port) as session:
+            result = await session.call_tool("gateway.describe", {"tool_id": 12345})
+        assert isinstance(result, CallToolResult)
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert text.startswith("Input validation error:")
+
+    @pytest.mark.asyncio
+    async def test_resources_list_returns_typed_result(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        async with _session(gateway_on_spare_port) as session:
+            result = await session.list_resources()
+        assert isinstance(result, ListResourcesResult)
+        assert any(r.uri == "pmcp://guidance/code-execution" for r in result.resources)
+
+    @pytest.mark.asyncio
+    async def test_resources_read_returns_typed_result(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        async with _session(gateway_on_spare_port) as session:
+            result = await session.read_resource("pmcp://guidance/code-execution")
+        assert isinstance(result, ReadResourceResult)
+        assert len(result.contents) == 1
+        assert isinstance(result.contents[0].uri, str)
+
+    @pytest.mark.asyncio
+    async def test_prompts_list_returns_typed_result(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        async with _session(gateway_on_spare_port) as session:
+            result = await session.list_prompts()
+        assert isinstance(result, ListPromptsResult)
+        assert any(p.name == "rt-fixture::rt_greeting" for p in result.prompts)
+
+    @pytest.mark.asyncio
+    async def test_prompts_get_returns_typed_result(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        async with _session(gateway_on_spare_port) as session:
+            result = await session.get_prompt(
+                "rt-fixture::rt_greeting", {"name": "wire-test"}
+            )
+        assert isinstance(result, GetPromptResult)
+        text = result.messages[0].content.text  # type: ignore[union-attr]
+        assert "wire-test" in text
+
+
+def test_boot_log_has_no_fatal_error(gateway_on_spare_port: BootedGateway) -> None:
+    """EC-P2-2's other half: the shared boot produced no fatal error."""
+    log_text = gateway_on_spare_port.boot_log.read_text()
+    assert "Fatal error" not in log_text

--- a/tests/runtime/test_wire_modern_era.py
+++ b/tests/runtime/test_wire_modern_era.py
@@ -1,0 +1,71 @@
+"""SL-4.3 — EC-P2-5, EC-P2-6: modern-era deployed-wire acceptance.
+
+Every request is built strictly per IF-0-P2-4's modern envelope (both
+`_meta` keys, matching `MCP-Protocol-Version`/`Mcp-Method`/`Mcp-Name`
+headers, and an `Accept` carrying both media types) via
+`harness.modern_post`, which also accepts either response framing pmcp may
+choose — plain JSON or one SSE `data:` frame — depending on whether the
+handler completes inside the 15s deferral window (IF-0-P2-4).
+"""
+
+from __future__ import annotations
+
+from mcp.types import CallToolResult, DiscoverResult, ListToolsResult
+from mcp.types.version import MODERN_PROTOCOL_VERSIONS
+
+from tests.runtime.harness import BootedGateway, modern_post
+
+
+def test_server_discover_returns_typed_result_with_modern_version(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    """EC-P2-5: no aggregated inventory — `DiscoverResult` carries only
+    `supported_versions`, `capabilities`, and `instructions`."""
+    raw = modern_post(gateway_on_spare_port.base_url, "server/discover", {})
+    assert "error" not in raw, raw
+    result = DiscoverResult.model_validate(raw["result"])
+    assert set(MODERN_PROTOCOL_VERSIONS) <= set(result.supported_versions)
+    assert result.capabilities.tools is not None
+    assert result.capabilities.resources is not None
+    assert result.capabilities.prompts is not None
+
+
+def test_modern_tools_list_returns_typed_aggregated_catalog(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    raw = modern_post(gateway_on_spare_port.base_url, "tools/list", {})
+    assert "error" not in raw, raw
+    result = ListToolsResult.model_validate(raw["result"])
+    assert any(t.name == "gateway.invoke" for t in result.tools)
+
+
+def test_modern_tools_call_returns_typed_result(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    raw = modern_post(
+        gateway_on_spare_port.base_url,
+        "tools/call",
+        {"name": "gateway.health", "arguments": {}},
+        name="gateway.health",
+    )
+    assert "error" not in raw, raw
+    result = CallToolResult.model_validate(raw["result"])
+    assert result.is_error is False
+
+
+def test_modern_tools_call_invalid_arguments_fails_schema_validation(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    """Proves the restored `inputSchema` check (IF-0-P2-1) also holds on the
+    modern era's request path, not just the handshake era's."""
+    raw = modern_post(
+        gateway_on_spare_port.base_url,
+        "tools/call",
+        {"name": "gateway.describe", "arguments": {"tool_id": 12345}},
+        name="gateway.describe",
+    )
+    assert "error" not in raw, raw
+    result = CallToolResult.model_validate(raw["result"])
+    assert result.is_error is True
+    text = result.content[0].text  # type: ignore[union-attr]
+    assert text.startswith("Input validation error:")

--- a/tests/test_baseline_constraints.py
+++ b/tests/test_baseline_constraints.py
@@ -114,14 +114,14 @@ class TestGatewayToolSurface:
         """Verify each tool has a valid inputSchema."""
         tools = get_gateway_tool_definitions()
         for tool in tools:
-            assert tool.inputSchema is not None, (
+            assert tool.input_schema is not None, (
                 f"Tool '{tool.name}' has no inputSchema"
             )
-            assert isinstance(tool.inputSchema, dict), (
+            assert isinstance(tool.input_schema, dict), (
                 f"Tool '{tool.name}' inputSchema is not a dict"
             )
             # All schemas should be objects
-            assert tool.inputSchema.get("type") == "object", (
+            assert tool.input_schema.get("type") == "object", (
                 f"Tool '{tool.name}' inputSchema type is not 'object'"
             )
 
@@ -180,9 +180,13 @@ class TestTransportConstraints:
         )
 
     def test_mcp_sdk_implementation_description_surface_is_documented(self) -> None:
-        """Installed SDK has no Implementation.description field for PMCP to set."""
-        assert "description" not in inspect.signature(Server).parameters
-        assert "description" not in Implementation.model_fields
+        """mcp 2.0.0 added a `description` surface (1.25.0 had none): both
+        `Server.__init__` and `Implementation` now accept/carry it. pmcp does
+        not set it today — this pins the SDK surface as present so a future
+        lane that wants a richer initialize-handshake description has a
+        known, tested target rather than rediscovering the surface."""
+        assert "description" in inspect.signature(Server).parameters
+        assert "description" in Implementation.model_fields
 
 
 # === Test Class 3: Singleton Lock Constraints ===

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -15,6 +15,7 @@ import time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx2
 import pytest
 
 from pmcp.client.manager import (
@@ -1013,13 +1014,24 @@ class TestRemoteConnectSseHeaders:
             async def __anext__(self) -> None:
                 raise StopAsyncIteration
 
+        # mcp 2.0.0's streamable_http_client() no longer builds its own httpx
+        # client from a headers= kwarg (IF-0-P2-2) — pmcp resolves the headers
+        # into an httpx2.AsyncClient it owns and passes that client in, so the
+        # header assertion below spies on the AsyncClient construction rather
+        # than on streamable_http_client's arguments.
+        real_async_client = httpx2.AsyncClient
+
+        def spy_async_client(*args: object, **kwargs: object) -> httpx2.AsyncClient:
+            captured_headers.update(kwargs.get("headers") or {})
+            return real_async_client(*args, **kwargs)  # type: ignore[arg-type]
+
         @asynccontextmanager
-        async def mock_streamablehttp_client(
-            url: str, headers: dict[str, str] | None = None
+        async def mock_streamable_http_client(
+            url: str, *, http_client: httpx2.AsyncClient | None = None
         ):
             assert url == "https://example.com/mcp"
-            captured_headers.update(headers or {})
-            yield EmptyReadStream(), MagicMock(), MagicMock(return_value=None)
+            assert http_client is not None
+            yield EmptyReadStream(), MagicMock()
 
         manager._send_initialize = AsyncMock()
 
@@ -1036,8 +1048,12 @@ class TestRemoteConnectSseHeaders:
         manager._send_request = AsyncMock(side_effect=mock_send_request)
         manager._read_sse = AsyncMock()
 
-        with patch(
-            "pmcp.client.manager.streamablehttp_client", mock_streamablehttp_client
+        with (
+            patch("pmcp.client.manager.httpx2.AsyncClient", spy_async_client),
+            patch(
+                "pmcp.client.manager.streamable_http_client",
+                mock_streamable_http_client,
+            ),
         ):
             await manager._connect_streamable_http(config)
 
@@ -1076,20 +1092,30 @@ class TestRemoteConnectSseHeaders:
             async def __anext__(self) -> None:
                 raise StopAsyncIteration
 
+        real_async_client = httpx2.AsyncClient
+
+        def spy_async_client(*args: object, **kwargs: object) -> httpx2.AsyncClient:
+            captured_headers.update(kwargs.get("headers") or {})
+            return real_async_client(*args, **kwargs)  # type: ignore[arg-type]
+
         @asynccontextmanager
-        async def mock_streamablehttp_client(
-            url: str, headers: dict[str, str] | None = None
+        async def mock_streamable_http_client(
+            url: str, *, http_client: httpx2.AsyncClient | None = None
         ):
             assert url == "https://example.com/mcp"
-            captured_headers.update(headers or {})
-            yield EmptyReadStream(), MagicMock(), MagicMock(return_value=None)
+            assert http_client is not None
+            yield EmptyReadStream(), MagicMock()
 
         manager._send_initialize = AsyncMock()
         manager._send_request = AsyncMock(return_value={"tools": []})
         manager._read_sse = AsyncMock()
 
-        with patch(
-            "pmcp.client.manager.streamablehttp_client", mock_streamablehttp_client
+        with (
+            patch("pmcp.client.manager.httpx2.AsyncClient", spy_async_client),
+            patch(
+                "pmcp.client.manager.streamable_http_client",
+                mock_streamable_http_client,
+            ),
         ):
             await manager._connect_streamable_http(config)
 
@@ -1141,9 +1167,9 @@ class TestRemoteConnectSseHeaders:
             ),
         )
 
-        mock_streamablehttp_client = MagicMock()
+        mock_streamable_http_client = MagicMock()
         with patch(
-            "pmcp.client.manager.streamablehttp_client", mock_streamablehttp_client
+            "pmcp.client.manager.streamable_http_client", mock_streamable_http_client
         ):
             with pytest.raises(MissingRemoteHeaderAuthError) as exc_info:
                 await manager._connect_streamable_http(config)
@@ -1152,7 +1178,7 @@ class TestRemoteConnectSseHeaders:
             "PMCP_OTHER_TOKEN",
             "PMCP_TEST_TOKEN",
         ]
-        mock_streamablehttp_client.assert_not_called()
+        mock_streamable_http_client.assert_not_called()
 
     def test_remote_headers_passes_tenant_context_to_resolver(self) -> None:
         config = RemoteMcpServerConfig(

--- a/tests/test_credential_boot.py
+++ b/tests/test_credential_boot.py
@@ -40,9 +40,9 @@ LIVE_GATEWAY_PORT = 3344  # NEVER boot the test fixture on this port.
 SPARE_PORT = 38345  # Distinct from P6CLEAN's 38344 to avoid any collision.
 
 FIXTURE_SERVER_SRC = """\
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
-mcp = FastMCP("p5-fixture")
+mcp = MCPServer("p5-fixture")
 
 
 @mcp.tool()
@@ -256,10 +256,10 @@ def _wait_for_health(gw_proc: subprocess.Popen, gw_log: Path) -> None:
 
 async def _invoke_fixture_ping() -> None:
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.client.streamable_http import streamable_http_client
 
     url = f"http://127.0.0.1:{SPARE_PORT}/mcp"
-    async with streamablehttp_client(url) as (read, write, _):
+    async with streamable_http_client(url) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             tool_names = {t.name for t in (await session.list_tools()).tools}

--- a/tests/test_scoped_advisor_audit.py
+++ b/tests/test_scoped_advisor_audit.py
@@ -6,14 +6,14 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
-from mcp.types import (
-    CallToolRequest,
-    ListPromptsRequest,
-    ListResourcesRequest,
-    ListToolsRequest,
-)
+from mcp.server.connection import Connection
+from mcp.server.context import ServerRequestContext
+from mcp.server.session import ServerSession
+from mcp.types import CallToolRequestParams, PaginatedRequestParams
 from pydantic import ValidationError
 
 from pmcp.policy.policy import PolicyManager
@@ -64,6 +64,24 @@ def _correlations() -> dict[str, str]:
         "seat_correlation_id": "seat-codex",
         "evidence_label_digest": "a" * 64,
     }
+
+
+# A HANDSHAKE_PROTOCOL_VERSIONS member; the specific value is irrelevant to
+# these handlers, which read no protocol-version-gated behaviour off `ctx`.
+# Mirrors tests/mcp2x/test_server_handlers.py's `_make_ctx` — duplicated
+# rather than imported, since that module belongs to a different lane.
+_PROTOCOL_VERSION = "2025-11-25"
+
+
+def _make_ctx() -> ServerRequestContext[Any, Any]:
+    connection = Connection.from_envelope(_PROTOCOL_VERSION, None, None)
+    session = ServerSession(MagicMock(), connection)
+    return ServerRequestContext(
+        session=session,
+        lifespan_context={},
+        protocol_version=_PROTOCOL_VERSION,
+        method="test",
+    )
 
 
 def test_explicit_policy_failures_are_fatal_but_default_discovery_is_best_effort(
@@ -160,24 +178,31 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     server._gateway_tools._client_manager = manager  # type: ignore[assignment]
     server._create_server()
     assert server._server is not None
-    list_handler = server._server.request_handlers[ListToolsRequest]
-    call_handler = server._server.request_handlers[CallToolRequest]
+    list_entry = server._server.get_request_handler("tools/list")
+    call_tool_entry = server._server.get_request_handler("tools/call")
+    resources_entry = server._server.get_request_handler("resources/list")
+    prompts_entry = server._server.get_request_handler("prompts/list")
+    assert list_entry is not None
+    assert call_tool_entry is not None
+    assert resources_entry is not None
+    assert prompts_entry is not None
 
-    listed = await list_handler(ListToolsRequest(params={}))
-    assert {tool.name for tool in listed.root.tools} == {
+    async def call_handler(name: str, arguments: dict) -> Any:
+        return await call_tool_entry.handler(
+            _make_ctx(), CallToolRequestParams(name=name, arguments=arguments)
+        )
+
+    listed = await list_entry.handler(_make_ctx(), PaginatedRequestParams())
+    assert {tool.name for tool in listed.tools} == {
         "gateway.health",
         "gateway.catalog_search",
         "gateway.describe",
         "gateway.invoke",
     }
-    resources = await server._server.request_handlers[ListResourcesRequest](
-        ListResourcesRequest(params={})
-    )
-    prompts = await server._server.request_handlers[ListPromptsRequest](
-        ListPromptsRequest(params={})
-    )
-    assert resources.root.resources == []
-    assert prompts.root.prompts == []
+    resources = await resources_entry.handler(_make_ctx(), PaginatedRequestParams())
+    prompts = await prompts_entry.handler(_make_ctx(), PaginatedRequestParams())
+    assert resources.resources == []
+    assert prompts.prompts == []
 
     async def fail_registry_discovery(*args, **kwargs):
         raise AssertionError("scoped catalog attempted registry discovery")
@@ -190,67 +215,48 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     )
 
     catalog = await call_handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.catalog_search",
-                "arguments": {
-                    "query": "native cli execution path",
-                    "include_offline": True,
-                },
-            }
-        )
+        "gateway.catalog_search",
+        {"query": "native cli execution path", "include_offline": True},
     )
-    catalog_payload = json.loads(catalog.root.content[0].text)
+    catalog_payload = json.loads(catalog.content[0].text)
     assert catalog_payload["cli_hints"] == []
     assert catalog_payload["registry_candidates"] == []
     assert catalog_payload["manifest_candidates"] == []
     assert catalog_payload["stale_updates"] is None
 
     invoked = await call_handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.invoke",
-                "arguments": {
-                    "tool_id": "firecrawl::web_search",
-                    "arguments": {
-                        "url": "https://example.com/private/path?token=secret",
-                        "query": "super secret query",
-                        "credential": "sk-private-value",
-                    },
-                    **_correlations(),
-                },
-            }
-        )
+        "gateway.invoke",
+        {
+            "tool_id": "firecrawl::web_search",
+            "arguments": {
+                "url": "https://example.com/private/path?token=secret",
+                "query": "super secret query",
+                "credential": "sk-private-value",
+            },
+            **_correlations(),
+        },
     )
-    assert json.loads(invoked.root.content[0].text)["ok"] is True
+    assert json.loads(invoked.content[0].text)["ok"] is True
 
     brightdata = await call_handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.invoke",
-                "arguments": {
-                    "tool_id": "brightdata::scrape_page",
-                    "arguments": {"query": "current benchmark evidence"},
-                    **{**_correlations(), "seat_correlation_id": "seat-gemini"},
-                },
-            }
-        )
+        "gateway.invoke",
+        {
+            "tool_id": "brightdata::scrape_page",
+            "arguments": {"query": "current benchmark evidence"},
+            **{**_correlations(), "seat_correlation_id": "seat-gemini"},
+        },
     )
-    assert json.loads(brightdata.root.content[0].text)["ok"] is True
+    assert json.loads(brightdata.content[0].text)["ok"] is True
 
     downstream_denied = await call_handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.invoke",
-                "arguments": {
-                    "tool_id": "github::create_issue",
-                    "arguments": {"title": "must not mutate"},
-                    **_correlations(),
-                },
-            }
-        )
+        "gateway.invoke",
+        {
+            "tool_id": "github::create_issue",
+            "arguments": {"title": "must not mutate"},
+            **_correlations(),
+        },
     )
-    denied_payload = json.loads(downstream_denied.root.content[0].text)
+    denied_payload = json.loads(downstream_denied.content[0].text)
     assert denied_payload["ok"] is False
     assert denied_payload["auth_state"] == "policy_denied"
 
@@ -259,57 +265,35 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
 
     server._gateway_tools._ensure_server_for_tool = fail_lazy_start  # type: ignore[method-assign]
     lazy_denied = await call_handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.invoke",
-                "arguments": {
-                    "tool_id": "github::unregistered_mutation",
-                    "arguments": {},
-                    **_correlations(),
-                },
-            }
-        )
+        "gateway.invoke",
+        {
+            "tool_id": "github::unregistered_mutation",
+            "arguments": {},
+            **_correlations(),
+        },
     )
-    assert json.loads(lazy_denied.root.content[0].text)["auth_state"] == (
-        "policy_denied"
-    )
+    assert json.loads(lazy_denied.content[0].text)["auth_state"] == ("policy_denied")
 
     describe_denied = await call_handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.describe",
-                "arguments": {"tool_id": "github::unregistered_mutation"},
-            }
-        )
+        "gateway.describe", {"tool_id": "github::unregistered_mutation"}
     )
-    assert (
-        "blocked by policy"
-        in json.loads(describe_denied.root.content[0].text)["message"]
-    )
+    assert "blocked by policy" in json.loads(describe_denied.content[0].text)["message"]
 
     denied = await call_handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.provision",
-                "arguments": {
-                    "tool_id": "raw credential value",
-                    "run_correlation_id": "secret query with spaces",
-                    "seat_correlation_id": "seat secret with spaces",
-                    "evidence_label_digest": "not-a-digest-secret",
-                },
-            }
-        )
+        "gateway.provision",
+        {
+            "server_name": "not-allowlisted-server",
+            "tool_id": "raw credential value",
+            "run_correlation_id": "secret query with spaces",
+            "seat_correlation_id": "seat secret with spaces",
+            "evidence_label_digest": "not-a-digest-secret",
+        },
     )
-    assert "blocked by policy" in json.loads(denied.root.content[0].text)["message"]
+    assert "blocked by policy" in json.loads(denied.content[0].text)["message"]
 
     raw_tool_name = "gateway.sk-secret-token"
-    raw_name_denied = await call_handler(
-        CallToolRequest(params={"name": raw_tool_name, "arguments": {}})
-    )
-    assert (
-        "blocked by policy"
-        in json.loads(raw_name_denied.root.content[0].text)["message"]
-    )
+    raw_name_denied = await call_handler(raw_tool_name, {})
+    assert "blocked by policy" in json.loads(raw_name_denied.content[0].text)["message"]
 
     health = await server._gateway_tools.health()
     assert health.gateway_diagnostics.capabilities == [SCOPED_ADVISOR_AUDIT_CAPABILITY]
@@ -374,17 +358,17 @@ async def test_scoped_server_rejects_uncorrelated_invoke_before_dispatch(
 
     server._gateway_tools.invoke = fake_invoke  # type: ignore[method-assign]
     assert server._server is not None
-    handler = server._server.request_handlers[CallToolRequest]
-    result = await handler(
-        CallToolRequest(
-            params={
-                "name": "gateway.invoke",
-                "arguments": {"tool_id": "firecrawl::web_search"},
-            }
-        )
+    call_tool_entry = server._server.get_request_handler("tools/call")
+    assert call_tool_entry is not None
+    result = await call_tool_entry.handler(
+        _make_ctx(),
+        CallToolRequestParams(
+            name="gateway.invoke",
+            arguments={"tool_id": "firecrawl::web_search"},
+        ),
     )
     assert called is False
-    assert json.loads(result.root.content[0].text)["error"] is True
+    assert json.loads(result.content[0].text)["error"] is True
     await server.shutdown()
 
 
@@ -544,19 +528,23 @@ async def test_failed_audit_latches_before_later_dispatch(tmp_path: Path) -> Non
     assert server._scoped_advisor_audit._file is not None
     server._scoped_advisor_audit._file.close()
 
-    result = await server._server.request_handlers[CallToolRequest](
-        CallToolRequest(
-            params={
-                "name": "gateway.invoke",
-                "arguments": {
-                    "tool_id": "firecrawl::web_search",
-                    "arguments": {"query": "must not dispatch"},
-                    **_correlations(),
-                },
-            }
-        )
+    call_tool_entry = server._server.get_request_handler("tools/call")
+    assert call_tool_entry is not None
+    result = await call_tool_entry.handler(
+        _make_ctx(),
+        CallToolRequestParams(
+            name="gateway.invoke",
+            arguments={
+                "tool_id": "firecrawl::web_search",
+                "arguments": {"query": "must not dispatch"},
+                **_correlations(),
+            },
+        ),
     )
-    assert "audit sink is unavailable" in result.root.content[0].text
+    # `_handle_call_tool`'s outer except maps every `ScopedAdvisorAuditError`
+    # (including "scoped advisor audit sink is unavailable") to this fixed,
+    # non-leaking message — server.py:379/386, unchanged by the mcp 2.x port.
+    assert "Scoped advisor audit channel failed" in result.content[0].text
     assert called is False
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 import json
 
 import pytest
-from mcp.types import CallToolRequest, ListToolsRequest
+from mcp.server.connection import Connection
+from mcp.server.context import ServerRequestContext
+from mcp.server.session import ServerSession
+from mcp.types import CallToolRequestParams, PaginatedRequestParams
 
 from pmcp.server import GatewayServer
 from pmcp.types import (
@@ -16,6 +21,23 @@ from pmcp.types import (
     ServerStatus,
     ServerStatusEnum,
 )
+
+# A HANDSHAKE_PROTOCOL_VERSIONS member; the specific value is irrelevant to
+# these handlers, which read no protocol-version-gated behaviour off `ctx`.
+# Mirrors tests/mcp2x/test_server_handlers.py's `_make_ctx` — duplicated
+# rather than imported, since that module belongs to a different lane.
+_PROTOCOL_VERSION = "2025-11-25"
+
+
+def _make_ctx() -> ServerRequestContext[Any, Any]:
+    connection = Connection.from_envelope(_PROTOCOL_VERSION, None, None)
+    session = ServerSession(MagicMock(), connection)
+    return ServerRequestContext(
+        session=session,
+        lifespan_context={},
+        protocol_version=_PROTOCOL_VERSION,
+        method="test",
+    )
 
 
 class TestGatewayServerInit:
@@ -170,12 +192,12 @@ class TestServerCreation:
         # Server is created, we just verify it's not None
         # (internal _instructions attribute may not be exposed)
 
-    def test_setup_handlers_requires_server(self) -> None:
-        """Test setup_handlers raises if server not initialized."""
-        server = GatewayServer()
-
-        with pytest.raises(RuntimeError, match="Server not initialized"):
-            server._setup_handlers()
+    # `_setup_handlers` no longer exists (IF-0-P2-1: the six handlers are
+    # registered directly via `Server.__init__(on_*=...)` inside
+    # `_create_server`, which always constructs `self._server`), so there is
+    # no remaining seam where a caller can reach an uninitialized `_server`
+    # through this path — the test that pinned `_setup_handlers`' guard is
+    # removed rather than reworked.
 
     @pytest.mark.asyncio
     async def test_lifecycle_tools_are_routed_through_call_tool_handler(self) -> None:
@@ -202,19 +224,21 @@ class TestServerCreation:
         server._gateway_tools.restart_server = fake_restart  # type: ignore[method-assign]
 
         assert server._server is not None
-        handler = server._server.request_handlers[CallToolRequest]
+        entry = server._server.get_request_handler("tools/call")
+        assert entry is not None
 
         for tool_name in [
             "gateway.connect_server",
             "gateway.disconnect_server",
             "gateway.restart_server",
         ]:
-            result = await handler(
-                CallToolRequest(
-                    params={"name": tool_name, "arguments": {"server_name": "test"}}
-                )
+            result = await entry.handler(
+                _make_ctx(),
+                CallToolRequestParams(
+                    name=tool_name, arguments={"server_name": "test"}
+                ),
             )
-            payload = json.loads(result.root.content[0].text)
+            payload = json.loads(result.content[0].text)
             assert payload == {"ok": True, "server": "test"}
 
         assert called == ["connect", "disconnect", "restart"]
@@ -249,7 +273,8 @@ class TestServerCreation:
         server._gateway_tools.tasks_cancel = fake_tasks_cancel  # type: ignore[method-assign]
 
         assert server._server is not None
-        handler = server._server.request_handlers[CallToolRequest]
+        entry = server._server.get_request_handler("tools/call")
+        assert entry is not None
 
         for tool_name in [
             "gateway.tasks_list",
@@ -257,15 +282,14 @@ class TestServerCreation:
             "gateway.tasks_result",
             "gateway.tasks_cancel",
         ]:
-            result = await handler(
-                CallToolRequest(
-                    params={
-                        "name": tool_name,
-                        "arguments": {"server_name": "test", "task_id": "task-1"},
-                    }
-                )
+            result = await entry.handler(
+                _make_ctx(),
+                CallToolRequestParams(
+                    name=tool_name,
+                    arguments={"server_name": "test", "task_id": "task-1"},
+                ),
             )
-            payload = json.loads(result.root.content[0].text)
+            payload = json.loads(result.content[0].text)
             assert payload["ok"] is True
 
         assert called == ["list", "get", "result", "cancel"]
@@ -277,11 +301,13 @@ class TestServerCreation:
         server._create_server()
 
         assert server._server is not None
-        handler = server._server.request_handlers[CallToolRequest]
-        result = await handler(
-            CallToolRequest(params={"name": "gateway.tasks_delete", "arguments": {}})
+        entry = server._server.get_request_handler("tools/call")
+        assert entry is not None
+        result = await entry.handler(
+            _make_ctx(),
+            CallToolRequestParams(name="gateway.tasks_delete", arguments={}),
         )
-        payload = json.loads(result.root.content[0].text)
+        payload = json.loads(result.content[0].text)
         assert payload["error"] is True
         assert "Unknown tool" in payload["message"]
 
@@ -293,9 +319,10 @@ class TestServerCreation:
         server._create_server()
 
         assert server._server is not None
-        handler = server._server.request_handlers[ListToolsRequest]
-        result = await handler(ListToolsRequest(params={}))
-        names = [tool.name for tool in result.root.tools]
+        entry = server._server.get_request_handler("tools/list")
+        assert entry is not None
+        result = await entry.handler(_make_ctx(), PaginatedRequestParams())
+        names = [tool.name for tool in result.tools]
 
         assert names == sorted(names)
         assert {
@@ -330,22 +357,22 @@ class TestServerCreation:
         server._gateway_tools.set_startup_policy = fake_set_startup_policy  # type: ignore[method-assign]
 
         assert server._server is not None
-        handler = server._server.request_handlers[CallToolRequest]
+        entry = server._server.get_request_handler("tools/call")
+        assert entry is not None
         routed: dict[str, str] = {}
         for tool_name in [
             "gateway.config_status",
             "gateway.get_startup_policy",
             "gateway.set_startup_policy",
         ]:
-            result = await handler(
-                CallToolRequest(
-                    params={
-                        "name": tool_name,
-                        "arguments": {"operation": "add", "names": ["svc"]},
-                    }
-                )
+            result = await entry.handler(
+                _make_ctx(),
+                CallToolRequestParams(
+                    name=tool_name,
+                    arguments={"operation": "add", "names": ["svc"]},
+                ),
             )
-            payload = json.loads(result.root.content[0].text)
+            payload = json.loads(result.content[0].text)
             routed[tool_name] = payload["surface"]
             assert payload["ok"] is True
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1241,7 +1241,7 @@ class TestRefreshCompatibility:
             if tool.name == "gateway.refresh"
         )
 
-        schema = refresh_tool.inputSchema
+        schema = refresh_tool.input_schema
         assert "force" in schema["properties"]
         assert schema["properties"]["force"]["type"] == "boolean"
         assert schema.get("required", []) == []
@@ -1848,21 +1848,21 @@ class TestServerLifecycleTools:
         assert "gateway.connect_server" in tools
         assert "gateway.disconnect_server" in tools
         assert "gateway.restart_server" in tools
-        assert tools["gateway.connect_server"].inputSchema["required"] == [
+        assert tools["gateway.connect_server"].input_schema["required"] == [
             "server_name"
         ]
-        assert "force" not in tools["gateway.connect_server"].inputSchema["properties"]
+        assert "force" not in tools["gateway.connect_server"].input_schema["properties"]
         assert (
-            tools["gateway.disconnect_server"].inputSchema["properties"]["force"][
+            tools["gateway.disconnect_server"].input_schema["properties"]["force"][
                 "type"
             ]
             == "boolean"
         )
         assert (
-            tools["gateway.restart_server"].inputSchema["properties"]["force"]["type"]
+            tools["gateway.restart_server"].input_schema["properties"]["force"]["type"]
             == "boolean"
         )
-        assert "force" not in tools["gateway.refresh"].inputSchema.get("required", [])
+        assert "force" not in tools["gateway.refresh"].input_schema.get("required", [])
 
     @pytest.mark.asyncio
     async def test_connect_server_already_online(

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -631,6 +635,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -646,21 +663,28 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -774,15 +798,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.25.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -792,9 +816,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -991,6 +1028,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,6 +1072,9 @@ version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "httpx" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
     { name = "mcp" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -1063,7 +1115,10 @@ http = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
+    { name = "httpx", specifier = ">=0.27,<1.0" },
+    { name = "httpx2", specifier = ">=2.5.0,<3.0.0" },
+    { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
+    { name = "mcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pmcp", extras = ["dev", "http"], marker = "extra == 'all'" },
     { name = "prometheus-client", marker = "extra == 'http'", specifier = ">=0.20" },
@@ -1346,20 +1401,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
 ]
 
 [[package]]
@@ -1782,6 +1823,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Executes roadmap v11 Phase 2 against the merged plan (#128). Five lanes, disjoint file ownership, landed in DAG order onto this integration branch. **`main` sees only this combined PR** — no lane merged alone.

## Lanes

| | |
|---|---|
| **SL-1** `5f40168` | `mcp>=2.0.0,<3.0.0`; declares `httpx`, `httpx2`, `jsonschema` directly (mcp 2.x drops the `httpx` transitive) |
| **SL-2** `3bc8510` | Six handlers → `Server(on_*=...)`; restores schema validation, arg adaptation, result wrapping; `AnyUrl` → `str` |
| **SL-3** `11ec03f` | Streamable HTTP client rebuilt on `httpx2`; `jsonrpc_message_adapter`; closes two transport leaks |
| **SL-4** `dcc2b0d`,`2e21696`,`d6c0300` | 16 test repairs, CI probes ported, runtime acceptance harness |
| **SL-docs** | Doc/spec reconciliation + post-execution amendments |

## Two breaks the roadmap never named

Both would have surfaced mid-execution as baffling runtime failures:

- **`JSONRPCMessage` is no longer a pydantic model** — a bare union with no `model_validate`. `client/manager.py` built *every* outbound remote request through it, so the cap raise alone would have killed every remote downstream. Ported to `jsonrpc_message_adapter.validate_python`, envelopes verified byte-identical.
- **`Resource.uri` is `str`, not `AnyUrl`** — `Resource(uri=AnyUrl(...))` raises `ValidationError`. Four sites in `server.py`.

## Two pre-existing leaks fixed

`_cleanup_client` closed no exit stack while the **reconnect** path calls it — pmcp leaked the transport on every remote reconnect, before this port. A second leak on failed connects (client already in the stack when the transport enter raises) was found during execution. Both fixed; proven by driving the real reconnect branch, not `disconnect_all` (a different function).

## `Tool(inputSchema=...)`: runtime-OK, mypy-fails

Verified both simultaneously — runtime accepts the camelCase alias via `populate_by_name`; mypy rejects it because it synthesizes `__init__` from field names via `dataclass_transform`. The plan asserted these 26 sites were safe on runtime evidence alone, which was the wrong gate: `mypy src/pmcp` is a required job. All renamed.

## EC-P2-1 was unreachable

`.github/probe/p1_probe_server.py` imported `mcp.server.fastmcp` (removed in 2.0.0) and the client unpacked a 3-tuple. `min-version-smoke` runs both and parses the floor — now `2.0.0`. Ported, filenames kept so the workflow needed no edit. The client's `getattr(result, "isError", False)` was also silently returning `False` on every call, making its transport-failure check dead code.

## Acceptance

`tests/runtime/` proves the gateway serves real traffic, not that it imports:

- Real `ClientSession` over `streamable_http_client` to the booted `/mcp` on an OS-allocated port — all six handlers, typed results
- Modern-envelope requests (`_meta` protocolVersion + clientCapabilities, `MCP-Protocol-Version`/`Mcp-Method`/`Mcp-Name` headers), reader accepts both JSON and SSE framings
- **EC-P2-7 uses a real in-process HTTP MCP peer**, not a patched transport: 401 gates the positive case, a 307 route proves `follow_redirects=True`, and 5 reconnect cycles prove no client leak
- **EC-P2-4 pins a real `mcp==1.25.0` subprocess** — hard `pytest.fail`, never `pytest.skip`, since a skip exits 0 and would be a silent pass

`/health` is never used as acceptance — it returns a hardcoded literal.

## Verification

Full suite **2423 passed, 3 skipped, 0 failed** (baseline 2364). `tests/runtime/` 18 passed under `-rs` with no SKIPPED. ruff, ruff format, mypy (41 files) all clean. Live gateway on `:3344` pid and child set unchanged throughout.

Closes #112 (superseded — a bare cap raise ships a dead install; its own `install-smoke` proves it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->