### PR TITLE
test: cover all six proxied handlers over the modern wire (EC-P2-6)

### DIFF
--- a/tests/runtime/test_wire_modern_era.py
+++ b/tests/runtime/test_wire_modern_era.py
@@ -10,7 +10,15 @@ handler completes inside the 15s deferral window (IF-0-P2-4).
 
 from __future__ import annotations
 
-from mcp.types import CallToolResult, DiscoverResult, ListToolsResult
+from mcp.types import (
+    CallToolResult,
+    DiscoverResult,
+    GetPromptResult,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListToolsResult,
+    ReadResourceResult,
+)
 from mcp.types.version import MODERN_PROTOCOL_VERSIONS
 
 from tests.runtime.harness import BootedGateway, modern_post
@@ -69,3 +77,63 @@ def test_modern_tools_call_invalid_arguments_fails_schema_validation(
     assert result.is_error is True
     text = result.content[0].text  # type: ignore[union-attr]
     assert text.startswith("Input validation error:")
+
+
+def test_modern_resources_list_returns_typed_result(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    """EC-P2-6 headline: all six proxied handlers, not just the three the
+    criterion's body enumerates. README claims modern support for resources
+    and prompts, so it needs deployed-wire evidence like tools does."""
+    raw = modern_post(gateway_on_spare_port.base_url, "resources/list", {})
+    assert "error" not in raw, raw
+    ListResourcesResult.model_validate(raw["result"])
+
+
+def test_modern_resources_read_returns_typed_result(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    """`resources/read` is name-bearing: it requires an `Mcp-Name` header
+    carrying the `uri`, a rung `tools/list` never exercises."""
+    listed = ListResourcesResult.model_validate(
+        modern_post(gateway_on_spare_port.base_url, "resources/list", {})["result"]
+    )
+    assert listed.resources, "fixture exposes no resources to read"
+    uri = str(listed.resources[0].uri)
+    raw = modern_post(
+        gateway_on_spare_port.base_url, "resources/read", {"uri": uri}, name=uri
+    )
+    assert "error" not in raw, raw
+    result = ReadResourceResult.model_validate(raw["result"])
+    assert result.contents
+
+
+def test_modern_prompts_list_returns_typed_result(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    raw = modern_post(gateway_on_spare_port.base_url, "prompts/list", {})
+    assert "error" not in raw, raw
+    ListPromptsResult.model_validate(raw["result"])
+
+
+def test_modern_prompts_get_returns_typed_result(
+    gateway_on_spare_port: BootedGateway,
+) -> None:
+    """`prompts/get` is name-bearing on `name`."""
+    listed = ListPromptsResult.model_validate(
+        modern_post(gateway_on_spare_port.base_url, "prompts/list", {})["result"]
+    )
+    assert listed.prompts, "fixture exposes no prompts to get"
+    prompt = listed.prompts[0]
+    # Supply every required argument: a prompt whose required args are absent
+    # fails downstream, which would test the error path, not the happy one.
+    arguments = {a.name: "world" for a in (prompt.arguments or []) if a.required}
+    raw = modern_post(
+        gateway_on_spare_port.base_url,
+        "prompts/get",
+        {"name": prompt.name, "arguments": arguments},
+        name=prompt.name,
+    )
+    assert "error" not in raw, raw
+    result = GetPromptResult.model_validate(raw["result"])
+    assert result.messages


### PR DESCRIPTION
Follow-up to #129. **Tests only — no source changes, and no defect found.**

## The gap

EC-P2-6's headline says *"the six proxied handlers work under a modern envelope"*, but its enumerated body specifies only three cases — a modern `tools/list`, a modern `tools/call`, and an invalid-argument `tools/call`. The committed test matched the body exactly, so the criterion's **letter was met while four of six handlers had no deployed-wire evidence**.

That matters because #129's README claims modern support for `resources/list`, `resources/read`, `prompts/list`, and `prompts/get`. Two are **name-bearing** — `resources/read` carries the `uri` in `Mcp-Name`, `prompts/get` carries the `name` — a header rung `tools/list` never exercises. Documented but unverified.

## Result

**All four pass.** The port was correct; this was purely a coverage gap, not a defect. `tests/runtime/` goes 18 → 22.

## A trap worth recording

My first draft of the `prompts/get` test omitted the fixture prompt's **required** argument and got `-32603 Internal server error`. I briefly took that for a real era-specific bug — it wasn't. With arguments supplied it returns a proper `GetPromptResult` with `resultType: complete` and the modern `_meta` stamped.

The lasting hazard: a `prompts/get` test that omits required arguments **silently tests the error path while looking like it tests the happy one** — and would still "pass" against a broken handler. The committed test derives arguments from the prompt's own declared `required` flags rather than hardcoding them. (Separately: a missing required argument arguably deserves a cleaner error than `-32603`; not era-specific, out of scope here.)

Found by an advisor-board seat reviewing the release-version question — it read the criterion's headline where the implementation read its body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->