### PR TITLE
feat(P3B)!: subscriptions/listen, GET retirement — pmcp 2.0.0

### DIFF
--- a/.claude/docs-catalog.json
+++ b/.claude/docs-catalog.json
@@ -1,12 +1,13 @@
 {
   "version": 1,
-  "last_updated": "2026-08-08T06:49:11+00:00",
+  "last_updated": "2026-08-09T08:25:53+00:00",
   "files": {
     "README.md": {
       "purpose": "root project README",
       "touched_by_phases": [
         "P5",
-        "P2"
+        "P2",
+        "P3B"
       ]
     },
     "CHANGELOG.md": {
@@ -14,7 +15,8 @@
       "touched_by_phases": [
         "P1",
         "P5",
-        "P2"
+        "P2",
+        "P3B"
       ]
     },
     "CONTRIBUTING.md": {
@@ -28,7 +30,8 @@
       "purpose": "security policy",
       "touched_by_phases": [
         "P5",
-        "P2"
+        "P2",
+        "P3B"
       ]
     },
     ".claude/plans/ticklish-inventing-stearns.md": {
@@ -55,7 +58,8 @@
       "purpose": "multi-phase roadmap spec",
       "touched_by_phases": [
         "P1",
-        "P2"
+        "P2",
+        "P3B"
       ]
     },
     "specs/phase-plans-v2.md": {
@@ -333,6 +337,18 @@
     "plans/v7-issue-tracker.md": {
       "purpose": "markdown document",
       "touched_by_phases": []
+    },
+    "SPEC_COMPLIANCE.md": {
+      "purpose": "MCP specification compliance tracking matrix",
+      "touched_by_phases": [
+        "P3B"
+      ]
+    },
+    "plans/phase-plan-v11-P3B.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": [
+        "P3B"
+      ]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-09
+
+### Removed
+- **`GET /mcp` is retired.** It now answers `405 Method Not Allowed` with
+  `Allow: POST, DELETE` instead of accepting a standing connection. The
+  rmcp-compat pre-session keep-alive SSE workaround that used to answer that
+  GET is gone with it, and so are the two env vars that configured it,
+  `PMCP_MAX_KEEPALIVE_STREAMS` and `PMCP_KEEPALIVE_MAX_SECONDS`. `GET
+  /health` and `GET /metrics` are untouched by this and continue to work
+  exactly as before.
+  The concurrency cap the old keep-alive enforced returns one-for-one as
+  `PMCP_MAX_LISTEN_STREAMS` (same default, 64), bounding the new
+  `subscriptions/listen` stream instead. **The absolute-lifetime cap
+  (`PMCP_KEEPALIVE_MAX_SECONDS`) is deliberately not replaced** — a
+  subscription is long-lived by design, and a server that silently severs it
+  every N seconds is the defect this release fixes, not a property to
+  preserve. If you relied on that env var, there is no replacement for it;
+  what now bounds exposure is the concurrency cap, the SDK's own per-stream
+  event-backlog cap, and `/mcp` auth whenever `auth_mode` is configured.
+  The replacement for the retired GET stream is `subscriptions/listen`
+  (`notifications/tools/list_changed`, `notifications/resources/list_changed`
+  and `notifications/prompts/list_changed`, delivered on an open listen
+  stream), reachable only at protocol version `2026-07-28`. No existing
+  client loses delivered data from this change — pmcp never published
+  anything on the old GET stream, so retiring it removes a channel pmcp
+  never wrote to, not one clients were receiving events over.
+
 ### Changed
 - **The declared `mcp` bound is raised from `>=1.8.0,<2.0.0` to `>=2.0.0,<3.0.0`,
   and the gateway's upstream server and downstream client are ported onto it.**

--- a/README.md
+++ b/README.md
@@ -111,8 +111,12 @@ Quick verification:
 
 ```bash
 systemctl --user is-active pmcp
-curl -sS http://127.0.0.1:3344/mcp
+curl -sS http://127.0.0.1:3344/health
 ```
+
+`/mcp` is POST-only as of 2.0.0 — a bare `curl` against it returns
+`405 Method Not Allowed` with `Allow: POST, DELETE`, so use `/health` for a
+liveness check.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -785,14 +785,43 @@ and `io.modelcontextprotocol/clientCapabilities` is served the modern era —
 `2026-07-28` — for `tools/list`, `tools/call`, `resources/list`,
 `resources/read`, `prompts/list`, `prompts/get`, and `server/discover`. The
 modern era is not reachable through `initialize`; it is selected per request
-by those headers. Because the modern era has no server-initiated
-back-channel, requests like `sampling/createMessage` and `elicitation/create`
-do not exist at `2026-07-28` — PMCP does not proxy either today, so this is a
-protocol-era limitation, not a PMCP gap. Downstream, PMCP's connections to
-the servers it proxies are negotiated only at the handshake era described
-above (`2025-11-25` preferred) — no downstream server is ever reached at
-`2026-07-28`. A modern-era client's `tools/call` is still proxied live over
-that handshake-era downstream connection; only the upstream envelope differs.
+by those headers. The modern era has no server-initiated **request**
+back-channel, so `sampling/createMessage` and `elicitation/create` do not
+exist at `2026-07-28` — PMCP does not proxy either today, so this is a
+protocol-era limitation, not a PMCP gap. (Server-initiated *notifications*
+are a separate mechanism — `subscriptions/listen`, below.) Downstream, PMCP's
+connections to the servers it proxies are negotiated only at the handshake
+era described above (`2025-11-25` preferred) — no downstream server is ever
+reached at `2026-07-28`. A modern-era client's `tools/call` is still proxied
+live over that handshake-era downstream connection; only the upstream
+envelope differs.
+
+**`GET /mcp` is retired.** It now answers `405 Method Not Allowed` with
+`Allow: POST, DELETE` instead of accepting a standing connection; there is no
+persistent GET/SSE channel of any kind, pre-session or otherwise. `GET
+/health` and `GET /metrics` are unaffected and remain separate, unauthenticated
+routes. The replacement for server-initiated notifications is
+`subscriptions/listen` — a long-lived POST stream reachable **only** at
+protocol version `2026-07-28` — over which a client that opens a subscription
+receives `notifications/tools/list_changed`, `notifications/resources/list_changed`,
+and `notifications/prompts/list_changed` as PMCP's own catalog changes (a
+`gateway.connect_server`, `gateway.disconnect_server`, or `gateway.refresh`
+call that adds, removes, or updates downstream tools, resources, or prompts).
+It does not proxy downstream servers' own `notifications/*` (see Non-Goals in
+the roadmap). No existing client loses delivered data from the GET
+retirement — PMCP never published anything on the old GET stream, so this
+removes a channel PMCP never wrote to, not one clients were receiving events
+over. The concurrency cap the old pre-session keep-alive shim enforced
+returns one-for-one as `PMCP_MAX_LISTEN_STREAMS` (default `64`, same as
+before), now bounding `subscriptions/listen` instead. The old shim's
+**absolute-lifetime** cap (`PMCP_KEEPALIVE_MAX_SECONDS`) is deliberately
+**not** replaced — a subscription is long-lived by design, and severing it
+every N seconds was the defect this release fixes, not a property worth
+preserving. `PMCP_MAX_KEEPALIVE_STREAMS` and `PMCP_KEEPALIVE_MAX_SECONDS` are
+both gone; if you relied on either, there is no drop-in replacement for the
+lifetime cap — what bounds exposure instead is the concurrency cap, the SDK's
+own per-stream event-backlog cap, and `/mcp` auth whenever `auth_mode` is
+configured.
 
 Servers stopped with `gateway.disconnect_server` remain visible in health as
 `offline` or `lazy` when PMCP still knows their configuration, and startup policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,14 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
 - Request floods via per-source-IP sliding-window rate limiting (`--rate-limit`
   / `PMCP_RATE_LIMIT`) on `/mcp`
 - Oversized payloads causing OOM (`Content-Length > 10 MB → 413`)
-- Hanging downstream tools consuming connections indefinitely (60 s request timeout)
+- Hanging downstream tools consuming connections indefinitely (60 s request
+  timeout, `--request-timeout` / `PMCP_REQUEST_TIMEOUT`) — applies to every
+  `/mcp` POST **except** `subscriptions/listen`, which is a long-lived stream
+  by design; see "Known limitations" below for what bounds it instead.
+- Unbounded long-lived streams on `/mcp` (`PMCP_MAX_LISTEN_STREAMS`, default
+  64, bounds concurrent `subscriptions/listen` subscriptions; retired GET's
+  pre-session keep-alive concurrency cap is this guard's one-for-one
+  predecessor)
 - Multiple gateway instances fighting over resources (fcntl singleton lock)
 - Reconnect storms from crashing downstream servers (per-server reconnect flag)
 - **Unilateral credential relaxation**: a manifest server's `requires_api_key`
@@ -121,8 +128,22 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
   registered handlers, so the same policy, audit, and input-schema validation
   applies regardless of which era selected the request; the modern era is not
   a lower-trust bypass. Unsupported draft extensions beyond the six proxied
-  operations and `server/discover` remain out of scope until PMCP explicitly
-  claims them.
+  operations, `server/discover`, and `subscriptions/listen` remain out of
+  scope until PMCP explicitly claims them.
+- **`subscriptions/listen` has no absolute-lifetime cap, deliberately**: it is
+  exempt from the `request_timeout` wrapper that bounds every other `/mcp`
+  POST, because that wrapper silently truncated every subscription stream at
+  `request_timeout` seconds (60s by default) with no graceful close frame —
+  the defect this exemption fixes, not a property worth preserving for a
+  connection that is long-lived by design. What bounds exposure instead:
+  `PMCP_MAX_LISTEN_STREAMS` caps concurrent subscriptions (default 64, same
+  as the retired pre-session keep-alive's concurrency cap), the SDK's own
+  per-stream event-backlog cap bounds a single subscription's memory, and
+  `/mcp` auth applies to `subscriptions/listen` exactly as to every other
+  method whenever `auth_mode` is configured. There is no configurable
+  replacement for the retired `PMCP_KEEPALIVE_MAX_SECONDS` absolute-lifetime
+  bound; an operator who needs one must enforce it at a reverse proxy or load
+  balancer in front of PMCP.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,15 @@
 
 | Version | Supported |
 |---------|-----------|
-| 1.14.x  | ✅ Active  |
-| 1.13.x  | ✅ Maintenance |
-| < 1.13  | ❌ No longer supported |
+| 2.0.x   | ✅ Active  |
+| 1.22.x  | ✅ Security fixes only |
+| < 1.22  | ❌ No longer supported |
+
+2.0.0 is a breaking release: `GET /mcp` is retired (405) and the
+`PMCP_KEEPALIVE_MAX_SECONDS` lifetime cap is removed with no replacement by
+design. See the CHANGELOG before upgrading. 1.22.x receives security fixes
+only; it is the last 1.x line and is pinned to `mcp` 1.x, which no longer
+receives upstream releases.
 
 ## Threat Model
 

--- a/SPEC_COMPLIANCE.md
+++ b/SPEC_COMPLIANCE.md
@@ -27,15 +27,16 @@ revision is documented in the MCP specification changelog:
 
 ## Draft Revision Impact
 
-**Partially adopted as of v11 Phase 2 (`2026-07-28`).** PMCP now serves the
-modern era to its own clients for the six proxied operations plus
-`server/discover`, selected per request by an `MCP-Protocol-Version:
-2026-07-28` header and a `params._meta` envelope — never through `initialize`,
-which continues to negotiate the handshake era (`2024-11-05`–`2025-11-25`).
-Downstream connections remain handshake-era only: `PREFERRED_PROTOCOL_VERSION`
-is unchanged at `2025-11-25`, so no downstream server is reached at
-`2026-07-28`. A modern-era `tools/call` is still proxied live over that
-handshake-era downstream connection; only the upstream envelope differs.
+**Partially adopted as of v11 Phase 2 (`2026-07-28`), extended in Phase 3B.**
+PMCP now serves the modern era to its own clients for the six proxied
+operations plus `server/discover` and `subscriptions/listen`, selected per
+request by an `MCP-Protocol-Version: 2026-07-28` header and a `params._meta`
+envelope — never through `initialize`, which continues to negotiate the
+handshake era (`2024-11-05`–`2025-11-25`). Downstream connections remain
+handshake-era only: `PREFERRED_PROTOCOL_VERSION` is unchanged at
+`2025-11-25`, so no downstream server is reached at `2026-07-28`. A modern-era
+`tools/call` is still proxied live over that handshake-era downstream
+connection; only the upstream envelope differs.
 
 The remaining draft migration areas below are **not** yet addressed:
 
@@ -53,6 +54,26 @@ The remaining draft migration areas below are **not** yet addressed:
   adds no aggregated inventory of its own — `DiscoverResult` carries only
   `supported_versions`, `capabilities`, and `instructions`. Covered by
   `tests/runtime/test_wire_modern_era.py`.
+- ~~`subscriptions/listen` becomes the modern-era mechanism for delivering
+  `notifications/tools|resources|prompts/list_changed` to clients, replacing
+  any standing GET/SSE channel.~~ **Shipped (SEP-2575), v11 Phase 3B.**
+  `GET /mcp` is retired — it now returns `405 Method Not Allowed` with
+  `Allow: POST, DELETE` instead of accepting a standing connection —
+  and `subscriptions/listen` is the sole server-initiated channel, reachable
+  only at protocol version `2026-07-28`. The SDK supplies the listener
+  (`ListenHandler`, `SubscriptionBus`) in full; PMCP's own work is the wiring:
+  `ClientManager`'s catalog mutations (`connect_server`, `disconnect_server`,
+  `refresh`, and the other catalog-mutating entry points) publish the
+  corresponding event through `pmcp.subscriptions.BusCatalogEventSink`, which
+  self-schedules its own drain rather than relying on enumerated call sites.
+  `GET /health` and `GET /metrics` are unaffected. No existing client loses
+  delivered data — PMCP never published anything on the retired GET stream.
+  Covered by `tests/mcp2x/test_listen_registration.py`,
+  `tests/mcp2x/test_catalog_publishers.py`, `tests/mcp2x/test_get_retirement.py`,
+  `tests/mcp2x/test_listen_over_http.py`, `tests/runtime/test_get_retired.py`,
+  `tests/runtime/test_subscriptions_e2e.py`, and
+  `tests/runtime/test_publisher_coverage.py` (the AST guard that keeps the
+  publisher wiring honest after this phase).
 - `CacheableResult` changes result caching semantics. Revisit brokered result
   handling and cache boundaries for SEP-2549.
 - Dynamic Client Registration changes toward Client ID Metadata Documents.
@@ -71,5 +92,7 @@ The remaining draft migration areas below are **not** yet addressed:
   `tasks/update`, MRTR, unsolicited handles, and required `resultType`.
 - [x] Re-check release notes for any stable `server/discover` — shipped in v11
   Phase 2; see the Draft Revision Impact entry above.
+- [x] Re-check release notes for any stable `subscriptions/listen` — shipped
+  in v11 Phase 3B; see the Draft Revision Impact entry above.
 - [ ] Re-check release notes for authorization and migration guidance
   operators must follow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "1.22.0"
+version = "2.0.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -97,7 +97,7 @@ Sequencing is constrained by a live hazard. Dependabot PR **#112** already propo
 
 - **IF-0-P1-1** — The four-guard CI contract for first-party Python packages: `install-smoke` (fresh resolve, no lockfile, import the **entry-point** module), `min-version-smoke` (install pinned at the declared floor), a `schedule:` trigger, and a `__version__`-vs-distribution-metadata drift test. P2 and PG both rely on these guards to detect a bad constraint.
 - **IF-0-P2-1** — `pmcp` runs on `mcp>=2.0.0,<3.0.0`, serves the MODERN era (`2026-07-28`) to clients via per-request `_meta` + `server/discover`, and speaks the HANDSHAKE era (ceiling `2025-11-25`) downstream. This is the protocol surface P3B extends.
-- **IF-0-P2-2** — Handler registration shape: `self._server.add_request_handler(<method-string>, <ParamsType>, <handler>)` on the lowlevel `Server`. P3B registers `subscriptions/listen` through this same call. (`server/discover` needs no registration — the 2.x lowlevel `Server` auto-registers it.)
+- **IF-0-P2-2** — ~~Handler registration shape: `self._server.add_request_handler(<method-string>, <ParamsType>, <handler>)` on the lowlevel `Server`. P3B registers `subscriptions/listen` through this same call.~~ **STALE, corrected by P3B — see Phase 3B → Post-execution amendments, item 1.** P2's own Decision 1 (`plans/phase-plan-v11-P2.md:648-666`) rejected `add_request_handler` in favour of `Server.__init__(on_*=...)`, and the frozen mechanism P2 actually shipped is IF-0-P2-1, not this gate — whose ID also collides with P2's plan-level IF-0-P2-2 (the downstream Streamable HTTP transport contract, `plans/phase-plan-v11-P2.md:323`). P3B registers `subscriptions/listen` via `on_subscriptions_listen=` on that same constructor. (`server/discover` needs no registration — the 2.x lowlevel `Server` auto-registers it.)
 - **IF-0-PG-1** — `pangram-mcp` on `mcp` 2.x, reachable from both a 1.x and a 2.x gateway, published to PyPI.
 - **IF-0-P5-1** — A manifest field expressing "credential optional under condition X", replacing the placeholder-secret workaround.
 
@@ -418,6 +418,106 @@ Implement `subscriptions/listen` and retire the HTTP GET endpoint it replaces, w
 - target surfaces: `src/pmcp/transport/http.py`, `src/pmcp/server.py`, `CHANGELOG.md`
 - evidence paths: `plans/phase-plan-v11-P3B.md`
 - redaction posture: `metadata_only`
+
+### Post-execution amendments
+
+Recorded by SL-docs after SL-1 through SL-5 landed and were verified. `plans/phase-plan-v11-P2.md`
+was checked against every item below and needs no edit of its own — its Decision 1 already
+recorded the constructor form correctly; the drift was entirely in this roadmap's own
+Top Interface-Freeze Gates section (item 1).
+
+1. **EC-P3B-1's "IF-0-P2-2 shape" pointed at a stale gate, and the gate itself is now
+   corrected in place above (Top Interface-Freeze Gates).** The roadmap's `IF-0-P2-2`
+   (`:100`, pre-amendment) prescribed `add_request_handler`, which P2's own Decision 1
+   rejected in favour of `Server.__init__(on_*=...)` — and the ID collided with P2's
+   plan-level IF-0-P2-2 (the downstream transport contract, `plans/phase-plan-v11-P2.md:323`).
+   P3B honoured EC-P3B-1's *intent* — register through the frozen handler-registration
+   mechanism, whatever it turns out to be — which is the constructor kwarg
+   `on_subscriptions_listen=`, typed exactly to `ListenHandler.__call__` and the only form
+   `mypy` accepts for a result-typed handler. `src/pmcp/server.py:228`.
+2. **A missing lane-dependency edge: SL-2 → SL-3.** SL-2's declared "Interfaces consumed"
+   named only IF-0-P3B-1 and was marked "Parallel-safe: yes"
+   (`plans/phase-plan-v11-P3B.md:455-456`), but IF-0-P3B-2 requires `GatewayServer` to pass
+   `catalog_events=` into `ClientManager` — a kwarg SL-3 owns. SL-5 *did* declare
+   IF-0-P3B-2 as consumed, so the roadmap-level interface existed; the lane table simply
+   never drew the SL-2 → SL-3 edge. SL-2 correctly stopped short of editing SL-3's file,
+   built everything else, and landed a one-line follow-up (`8a0e4ea`, "IF-0-P3B-2 follow-up")
+   after SL-3 merged (`dce7bf9` then `8a0e4ea`). Future lane tables must derive
+   "Interfaces consumed" from what the interface freeze's *construction order* requires,
+   not from what a lane's own scope paragraph mentions.
+3. **The two production `flush()` calls IF-0-P3B-1 mandated as an "ordering nicety" were
+   removed — a deliberate deviation from the plan's own text, not an oversight.** The plan
+   required `_index_capabilities` and `disconnect_server` to end with
+   `await self._catalog_events.flush()`. Both sit on exactly the paths EC-P3B-4 drives, so
+   the acceptance criterion could have passed with the self-scheduling drain silently
+   broken — `flush()` would deliver the event regardless and the mechanism under test would
+   never run. The plan carried this tension internally: it mandated the flushes *and*
+   required the e2e to prove self-draining. SL-3 resolved it in favour of the criterion;
+   `src/pmcp/client/manager.py` has no `flush()` call on either path (confirmed by grep —
+   the two remaining `flush()`-adjacent comments at `:896` and `:1292` are deliberate
+   "no flush() here" markers), and SL-3's lane tests plus EC-P3B-4 pass without them, which
+   is the proof the self-scheduling drain delivers on production paths rather than riding a
+   flush call site.
+4. **`gateway.refresh` is diff-based and will not reconnect a never-eager server; EC-P3B-4's
+   e2e models a real operator flow rather than assuming a bare refresh redelivers.**
+   `tools/handlers.py`'s refresh builds `to_connect` from `eager_by_name` only, so a
+   disconnected lazy server is left alone by a bare refresh. `tests/runtime/test_subscriptions_e2e.py`
+   therefore adds the second downstream fixture to `autoStart` on the isolated boot's
+   on-disk config between `disconnect_server` and `refresh` — modelling an operator editing
+   `autoStart` then refreshing — rather than defeating or working around the diff logic.
+   Verified by smoke test before the acceptance test was written.
+5. **`client/manager.py:1099` (as cited by this roadmap's Phase 3B scope notes) is
+   `_index_tools` at `:1106` on the commit P3B actually branched from** — consistent with
+   Phase 2's amendment 2, which found the same drift; line numbers in this roadmap are
+   provenance snapshots and move as the tree does.
+6. **The plan mispredicted one test failure.** It expected `tests/test_transport_http.py:212`
+   to go red on GET retirement; it did not, because that line's test
+   (`test_metrics_counter_increments_on_401`) carried a stale comment
+   ("GET with no session ID returns keep-alive SSE") but no assertion on the GET response
+   at all — it passed throughout. Adding a real `405` assertion there was new work SL-5.5
+   did, not a repair of a red test.
+7. **An inherited flaky assertion was fixed, not introduced by this phase.**
+   `tests/runtime/test_downstream_remote.py` asserted strict equality on socket counts
+   across reconnect cycles while its own comment and failure message described detecting
+   *growth*; a late-closing socket makes a later sample lower than an earlier one, so the
+   test could fail on a *decrease* while reporting "socket count grew". Inherited from P2
+   and already on `main` before P3B started; SL-5 changed the assertion to a no-growth
+   check consistent with its own stated intent.
+8. **Two harness capabilities EC-P3B-4 required that SL-5.1's contract did not name in
+   advance**: `booted_gateway(extra_servers_no_autostart=...)` — without it,
+   `gateway.connect_server` in the e2e test would be a no-op rather than a genuine first
+   connect, because the fixture would already be running — and
+   `booted_gateway(request_timeout=...)`, needed for the deployed-wire timing regression
+   that proves the `request_timeout` exemption. Both are additive to the harness's existing
+   design goal (nothing hardcodes a live catalog change) rather than a change to it.
+9. **The anyio `disconnect_all` debt Phase 2's amendment 8 flagged for this phase was
+   deferred again, deliberately — see this plan's Execution Notes → Decision 3 for the full
+   reasoning** (no production exposure in the systemd deployment, a real fix is a
+   concurrency refactor out of scope for the riskiest phase in the roadmap, the P2 workaround
+   still holds, and this phase's only new shutdown code — `ListenHandler.close()` — is sync
+   and never crosses a cancel scope). Recorded here so the debt does not read as forgotten;
+   it is carried forward to a future bounded phase after the 2.0.0 release.
+10. **The SDK ships the listener; this phase wrote no listen-stream state machine.** `mcp`
+    2.0.0's `mcp/server/subscriptions.py` supplies both `ListenHandler` (ack-first,
+    subscription-id stamping, filter honouring, backlog/concurrency bounds, graceful close)
+    and `SubscriptionBus`/`InMemorySubscriptionBus`. P3B's work was the wiring — a sink
+    bridging pmcp's sync catalog mutators to the SDK's async bus, construction order, and
+    HTTP transport survival — not the mechanism. This roadmap's Phase 3B objective and
+    scope notes read as though pmcp builds the subscription machinery; it does not.
+11. **One `2.0.0` release covers both P2 and P3B, deviating from this roadmap's stated
+    cadence.** Execution Notes → "Release cadence" (`:621`) states "P2 is a minor
+    (`1.22.0`)" and "P3B is a MAJOR version" as two separate releases. In practice, `1.22.0`
+    (2026-08-06) shipped P5's manifest credential optionality instead — P2's mcp-2.x port
+    sat in `## [Unreleased]` until P3B's SL-1 promoted it directly into `## [2.0.0]`
+    alongside the GET-retirement entry. This was raised with the operator as the one
+    droppable task in the phase and explicitly decided: keep a single `2.0.0`, do not cut
+    an interim minor at tag time — see `plans/phase-plan-v11-P3B.md`'s Execution Notes →
+    Decision 4 for the reasoning (P2 and P3B are one migration; a minor whose entire
+    content is "the SDK underneath changed" invites operators to take it and the major
+    separately, doubling the upgrade events for one migration) and the CI-coherence argument
+    (P1's drift test pins `pyproject.toml` against `src/pmcp/__init__.py` only, so a
+    CHANGELOG heading of `[2.0.0]` while both files still said `1.22.0` would have left
+    `main` self-inconsistent with nothing in CI flagging it).
 
 ---
 

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "1.22.0"
+__version__ = "2.0.0"

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -30,6 +30,7 @@ from pmcp.remote_auth import (
     MissingRemoteHeaderAuthError,
     resolve_remote_headers_for_tenant,
 )
+from pmcp.subscriptions import CatalogEventSink
 from pmcp.types import (
     LocalMcpServerConfig,
     McpTaskInfo,
@@ -72,6 +73,25 @@ def _is_cancel_scope_task_mismatch_error(exc: BaseException) -> bool:
         and "entered" in msg
         and "exit" in msg
     )
+
+
+class _NullCatalogEventSink:
+    """No-op `CatalogEventSink` used when `ClientManager` is constructed with
+    no `catalog_events` (IF-0-P3B-2's default). Keeps every pre-P3B
+    construction site — `server.py`, `cli.py`, and ~20 test modules — working
+    unchanged: nothing publishes, but nothing raises either."""
+
+    def note_tools_changed(self) -> None:
+        pass
+
+    def note_resources_changed(self) -> None:
+        pass
+
+    def note_prompts_changed(self) -> None:
+        pass
+
+    async def flush(self) -> None:
+        pass
 
 
 async def _terminate_process_tree(
@@ -493,7 +513,12 @@ class ClientManager:
         max_tools_per_server: int = 100,
         max_concurrent_spawns: int = 8,
         project_root: Path | None = None,
+        *,
+        catalog_events: CatalogEventSink | None = None,
     ) -> None:
+        self._catalog_events: CatalogEventSink = (
+            catalog_events or _NullCatalogEventSink()
+        )
         self._clients: dict[str, ManagedClient] = {}
         self._tools: dict[str, ToolInfo] = {}
         self._resources: dict[str, ResourceInfo] = {}
@@ -868,6 +893,10 @@ class ClientManager:
             )
             self._revision_id = _generate_revision_id()
             self._last_refresh_ts = time.time()
+            # Ordering nicety, not the correctness mechanism (see
+            # _index_capabilities): coalesce this disconnect's note_* call(s)
+            # into one delivered burst.
+            await self._catalog_events.flush()
             return (True, cancelled, None)
 
     async def restart_server(
@@ -926,18 +955,30 @@ class ClientManager:
 
     def _remove_server_indexes(self, name: str) -> None:
         """Remove catalog entries owned by one server."""
+        tools_removed = False
         for tool_id, tool in list(self._tools.items()):
             if tool.server_name == name:
                 self._tools.pop(tool_id, None)
+                tools_removed = True
+        resources_removed = False
         for resource_id, resource in list(self._resources.items()):
             if resource.server_name == name:
                 self._resources.pop(resource_id, None)
+                resources_removed = True
+        prompts_removed = False
         for prompt_id, prompt in list(self._prompts.items()):
             if prompt.server_name == name:
                 self._prompts.pop(prompt_id, None)
+                prompts_removed = True
         for key in list(self._tasks):
             if key[0] == name:
                 self._tasks.pop(key, None)
+        if tools_removed:
+            self._catalog_events.note_tools_changed()
+        if resources_removed:
+            self._catalog_events.note_resources_changed()
+        if prompts_removed:
+            self._catalog_events.note_prompts_changed()
 
     def _server_supports_tasks(self, managed: ManagedClient) -> bool:
         capabilities = managed.status.server_capabilities or {}
@@ -1148,6 +1189,8 @@ class ClientManager:
 
             self._tools[tool_id] = tool_info
             indexed += 1
+        if indexed:
+            self._catalog_events.note_tools_changed()
         return indexed
 
     def _index_resources(self, name: str, resources: list[dict[str, Any]]) -> int:
@@ -1176,6 +1219,8 @@ class ClientManager:
                 raw_metadata=_raw_metadata(resource, known_fields),
             )
             self._resources[resource_id] = resource_info
+        if resources:
+            self._catalog_events.note_resources_changed()
         return len(resources)
 
     def _index_prompts(self, name: str, prompts: list[dict[str, Any]]) -> int:
@@ -1215,6 +1260,8 @@ class ClientManager:
                 raw_metadata=_raw_metadata(prompt, known_prompt_fields),
             )
             self._prompts[prompt_id] = prompt_info
+        if prompts:
+            self._catalog_events.note_prompts_changed()
         return len(prompts)
 
     async def _index_capabilities(self, managed: ManagedClient) -> tuple[int, int, int]:
@@ -1245,6 +1292,10 @@ class ClientManager:
         else:
             prompt_count = self._index_prompts(name, prompts_result.get("prompts", []))
 
+        # Ordering nicety, not the correctness mechanism (IF-0-P3B-1's
+        # self-scheduling drain is): coalesce a connect's up-to-three note_*
+        # calls into one delivered burst rather than three scheduled drains.
+        await self._catalog_events.flush()
         return indexed, resource_count, prompt_count
 
     async def _connect_stdio(self, config: ResolvedServerConfig) -> None:
@@ -1541,9 +1592,11 @@ class ClientManager:
                 managed.status.pending_request_count = len(managed.pending_requests)
 
                 if "error" in message:
-                    # TODO(P3B): message["error"] also carries JSON-RPC "code"
-                    # and "data" fields that are dropped here, exposing only
-                    # "message" to callers.
+                    # TODO(post-P3B): message["error"] also carries JSON-RPC
+                    # "code" and "data" fields that are dropped here, exposing
+                    # only "message" to callers. No P3B exit criterion
+                    # mentions typed downstream errors (Execution Notes >
+                    # Decision 5) — deferred again, not actioned in P3B.
                     pending.future.set_exception(
                         Exception(message["error"].get("message", "Unknown error"))
                     )
@@ -1757,9 +1810,12 @@ class ClientManager:
                     managed.status.pending_request_count = len(managed.pending_requests)
 
                     if "error" in payload:
-                        # TODO(P3B): payload["error"] also carries JSON-RPC
-                        # "code" and "data" fields that are dropped here,
-                        # exposing only "message" to callers.
+                        # TODO(post-P3B): payload["error"] also carries
+                        # JSON-RPC "code" and "data" fields that are dropped
+                        # here, exposing only "message" to callers. No P3B
+                        # exit criterion mentions typed downstream errors
+                        # (Execution Notes > Decision 5) — deferred again,
+                        # not actioned in P3B.
                         pending.future.set_exception(
                             Exception(payload["error"].get("message", "Unknown error"))
                         )
@@ -2024,12 +2080,31 @@ class ClientManager:
         self._connect_tasks.clear()
         self._reconnect_tasks.clear()
         self._clients.clear()
+        # Capture non-empty immediately before each clear (not after — the
+        # clear must happen first for the dict to actually be empty
+        # afterward, but the check must be the pre-clear state) so a
+        # wholesale teardown still announces what it emptied. Without this,
+        # refresh([]) (disconnect-all + no reconnect) empties every catalog
+        # and publishes nothing — the listener-with-no-publishers failure
+        # this phase exists to prevent. Deliberately NOT routed through
+        # _remove_server_indexes: that method is per-server-name, this is a
+        # wholesale clear, and rewriting it as a loop over names would
+        # change shutdown semantics for no benefit.
+        had_tools = bool(self._tools)
+        had_resources = bool(self._resources)
+        had_prompts = bool(self._prompts)
         self._tools.clear()
         self._resources.clear()
         self._prompts.clear()
         self._tasks.clear()
         self._servers.clear()
         self._lazy_configs.clear()
+        if had_tools:
+            self._catalog_events.note_tools_changed()
+        if had_resources:
+            self._catalog_events.note_resources_changed()
+        if had_prompts:
+            self._catalog_events.note_prompts_changed()
 
     async def _cleanup_client(self, name: str, managed: ManagedClient) -> None:
         """Cancel a client's read task, kill its process, and remove it from registries.

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -893,10 +893,7 @@ class ClientManager:
             )
             self._revision_id = _generate_revision_id()
             self._last_refresh_ts = time.time()
-            # Ordering nicety, not the correctness mechanism (see
-            # _index_capabilities): coalesce this disconnect's note_* call(s)
-            # into one delivered burst.
-            await self._catalog_events.flush()
+            # No flush() here, deliberately -- see _index_capabilities.
             return (True, cancelled, None)
 
     async def restart_server(
@@ -1292,10 +1289,11 @@ class ClientManager:
         else:
             prompt_count = self._index_prompts(name, prompts_result.get("prompts", []))
 
-        # Ordering nicety, not the correctness mechanism (IF-0-P3B-1's
-        # self-scheduling drain is): coalesce a connect's up-to-three note_*
-        # calls into one delivered burst rather than three scheduled drains.
-        await self._catalog_events.flush()
+        # No flush() here, deliberately: IF-0-P3B-1's self-scheduling drain
+        # is the correctness mechanism, not this call site, and EC-P3B-4
+        # exercises exactly this path -- a flush() here would let that
+        # acceptance test pass even if the self-scheduling drain were
+        # completely broken.
         return indexed, resource_count, prompt_count
 
     async def _connect_stdio(self, config: ResolvedServerConfig) -> None:

--- a/src/pmcp/server.py
+++ b/src/pmcp/server.py
@@ -14,6 +14,7 @@ from typing import Any, Literal
 import jsonschema
 from mcp.server import Server
 from mcp.server.context import ServerRequestContext
+from mcp.server.subscriptions import InMemorySubscriptionBus, ListenHandler
 from mcp.types import (
     BlobResourceContents,
     CallToolRequestParams,
@@ -66,6 +67,7 @@ from pmcp.scoped_advisor_audit import (
     ScopedAdvisorAudit,
     ScopedAdvisorAuditError,
 )
+from pmcp.subscriptions import BusCatalogEventSink
 from pmcp.summary import generate_capability_summary
 from pmcp.tools.handlers import GatewayTools, get_gateway_tool_definitions
 from pmcp.types import (
@@ -77,6 +79,23 @@ from pmcp.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _env_int(name: str, default: int, *, minimum: int) -> int:
+    """Read a positive int from the environment, clamped to ``minimum``.
+
+    Small local copy of `transport/http.py`'s `_env_int` (SL-4's file, not
+    imported from here to avoid a cross-lane import during P3B's parallel
+    execution) -- same behaviour: an absent or unparsable value falls back
+    to `default`, a parsable one is floored at `minimum`.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        return default
 
 
 class GatewayServer:
@@ -138,7 +157,26 @@ class GatewayServer:
         )
         logger.info(f"Guidance level: {self._guidance_config.level}")
 
+        # IF-0-P3B-2: bus, sink, and listen handler are constructed here,
+        # before ClientManager -- `_create_server` (which registers the
+        # handler on `Server`) runs later, so a bus created there would be
+        # invisible to a ClientManager already built.
+        self._subscription_bus = InMemorySubscriptionBus()
+        self._catalog_events = BusCatalogEventSink(self._subscription_bus)
+        self._listen_handler = ListenHandler(
+            self._subscription_bus,
+            max_subscriptions=_env_int(
+                "PMCP_MAX_LISTEN_STREAMS", 64, minimum=1
+            ),
+        )
+
         # Initialize client manager
+        # TODO(P3B/SL-3): pass catalog_events=self._catalog_events once
+        # ClientManager accepts it (IF-0-P3B-2) -- SL-3 (client/manager.py)
+        # lands the constructor kwarg in a sibling lane of this same phase;
+        # this file must not touch client/manager.py itself. Until that
+        # merges, ClientManager uses its null sink and no catalog mutation
+        # publishes -- SL-3's own tests cover that gap, not this lane's.
         self._client_manager = ClientManager(
             max_tools_per_server=self._policy_manager.get_max_tools_per_server(),
             max_concurrent_spawns=self._max_concurrent_spawns,
@@ -192,6 +230,7 @@ class GatewayServer:
             on_read_resource=self._handle_read_resource,
             on_list_prompts=self._handle_list_prompts,
             on_get_prompt=self._handle_get_prompt,
+            on_subscriptions_listen=self._listen_handler,
         )
 
     def _record_scoped_invocation(
@@ -917,6 +956,17 @@ class GatewayServer:
     async def shutdown(self) -> None:
         """Shutdown the server."""
         logger.info("Shutting down MCP Gateway...")
+        # IF-0-P3B-2: close open listen streams first. `close()` is sync and
+        # only closes memory object streams owned by their own handler
+        # tasks (no `disconnect_all`/`ClientManager` interaction, no
+        # cancel-scope crossing), so ordering it first here does not widen
+        # the anyio shutdown debt (Execution Notes > Decision 3). On a real
+        # process exit this runs from a `finally` after the transport has
+        # already ended, so the graceful `SubscriptionsListenResult` frame
+        # may not reach the wire -- that is spec-legal (an abrupt transport
+        # close carries no response); EC-P3B-2's server-close half is proven
+        # deterministically in-process instead (test_listen_registration.py).
+        self._listen_handler.close()
         self._gateway_tools.stop_stale_indexer()
         try:
             await asyncio.wait_for(self._client_manager.disconnect_all(), timeout=10.0)

--- a/src/pmcp/server.py
+++ b/src/pmcp/server.py
@@ -165,22 +165,17 @@ class GatewayServer:
         self._catalog_events = BusCatalogEventSink(self._subscription_bus)
         self._listen_handler = ListenHandler(
             self._subscription_bus,
-            max_subscriptions=_env_int(
-                "PMCP_MAX_LISTEN_STREAMS", 64, minimum=1
-            ),
+            max_subscriptions=_env_int("PMCP_MAX_LISTEN_STREAMS", 64, minimum=1),
         )
 
-        # Initialize client manager
-        # TODO(P3B/SL-3): pass catalog_events=self._catalog_events once
-        # ClientManager accepts it (IF-0-P3B-2) -- SL-3 (client/manager.py)
-        # lands the constructor kwarg in a sibling lane of this same phase;
-        # this file must not touch client/manager.py itself. Until that
-        # merges, ClientManager uses its null sink and no catalog mutation
-        # publishes -- SL-3's own tests cover that gap, not this lane's.
+        # Initialize client manager. catalog_events=self._catalog_events
+        # completes IF-0-P3B-2: ClientManager's catalog mutators publish
+        # through the same sink the listen handler's bus is wired to.
         self._client_manager = ClientManager(
             max_tools_per_server=self._policy_manager.get_max_tools_per_server(),
             max_concurrent_spawns=self._max_concurrent_spawns,
             project_root=project_root,
+            catalog_events=self._catalog_events,
         )
 
         # Initialize gateway tools handler

--- a/src/pmcp/subscriptions.py
+++ b/src/pmcp/subscriptions.py
@@ -1,0 +1,166 @@
+"""Catalog event sink (IF-0-P3B-1): bridges pmcp's sync catalog mutators to
+`mcp` 2.0.0's async `subscriptions/listen` fan-out.
+
+`ClientManager`'s catalog mutators (`_index_tools`, `_index_resources`,
+`_index_prompts`, `_remove_server_indexes`, `_disconnect_all_unlocked`) are
+synchronous; `mcp.server.subscriptions.SubscriptionBus.publish` is async.
+`CatalogEventSink` is the seam: mutators call a sync `note_*` and the sink
+takes care of getting the corresponding `ServerEvent` onto the bus.
+
+No new event vocabulary is defined here. `ToolsListChanged`,
+`ResourcesListChanged`, `PromptsListChanged` and `SubscriptionBus` are
+imported from the SDK (`mcp.shared.subscriptions` / `mcp.server.subscriptions`)
+and re-used as-is.
+
+Correctness mechanism, and why it is written the way it is: each `note_*`
+adds the corresponding event class to a pending *set* (so N index writes in
+one connect coalesce into one event per kind -- these are level triggers,
+"this changed, refetch if you care") and, if a running loop exists and no
+drain is already scheduled, arms a self-draining task. The drain LOOPS until
+the pending set is empty and clears its "live" flag only in the same
+synchronous step as the `while` check that found it empty, with no `await`
+in between. That shape is required, not stylistic: the naive "pop a
+snapshot, publish it, exit" drain has a lost-wakeup race, because
+`InMemorySubscriptionBus.publish` always suspends (it ends with an explicit
+`anyio.lowlevel.checkpoint()`). A `note_*` landing in that suspended window
+would see a live drain task and decline to re-arm; if the drain does not
+re-check `pending` after its await returns, that event is stranded until
+some unrelated later mutation happens to schedule a new drain. Looping
+until the check-for-empty and the flag-clear are back-to-back with nothing
+async between them closes that window.
+
+`flush()` exists only so tests (and, optionally, call sites that want tight
+coalescing around one operation) can drain deterministically. It is not the
+correctness mechanism -- the self-scheduling drain is -- and no call site is
+required to invoke it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Protocol, runtime_checkable
+
+from mcp.server.subscriptions import SubscriptionBus
+from mcp.shared.subscriptions import (
+    PromptsListChanged,
+    ResourcesListChanged,
+    ToolsListChanged,
+)
+
+__all__ = ["CatalogEventSink", "BusCatalogEventSink"]
+
+logger = logging.getLogger(__name__)
+
+# The three catalog-change events this sink publishes. `ResourceUpdated`
+# (single-resource content changes) is out of this sink's scope -- it has no
+# `note_*` here and is not part of IF-0-P3B-1.
+_CatalogEvent = ToolsListChanged | PromptsListChanged | ResourcesListChanged
+_CatalogEventClass = type[_CatalogEvent]
+
+# Fixed publish order for a coalesced drain: tools, then resources, then
+# prompts. Applies to both the self-scheduled drain and `flush()`.
+_ORDER: tuple[_CatalogEventClass, ...] = (
+    ToolsListChanged,
+    ResourcesListChanged,
+    PromptsListChanged,
+)
+
+
+@runtime_checkable
+class CatalogEventSink(Protocol):
+    """What a catalog mutator calls when the tool/resource/prompt list changes."""
+
+    def note_tools_changed(self) -> None:
+        """Record that the tool list changed. Sync, never raises."""
+        ...
+
+    def note_resources_changed(self) -> None:
+        """Record that the resource list changed. Sync, never raises."""
+        ...
+
+    def note_prompts_changed(self) -> None:
+        """Record that the prompt list changed. Sync, never raises."""
+        ...
+
+    async def flush(self) -> None:
+        """Drain any pending events immediately. Not required for correctness."""
+        ...
+
+
+class BusCatalogEventSink:
+    """`CatalogEventSink` that publishes onto a `SubscriptionBus`.
+
+    See the module docstring for the drain-loop correctness argument.
+    """
+
+    def __init__(self, bus: SubscriptionBus) -> None:
+        self._bus = bus
+        self._pending: set[_CatalogEventClass] = set()
+        self._draining = False
+        # Strong references so a scheduled drain is never GC'd mid-flight.
+        self._drain_tasks: set[asyncio.Task[None]] = set()
+
+    def note_tools_changed(self) -> None:
+        self._note(ToolsListChanged)
+
+    def note_resources_changed(self) -> None:
+        self._note(ResourcesListChanged)
+
+    def note_prompts_changed(self) -> None:
+        self._note(PromptsListChanged)
+
+    def _note(self, kind: _CatalogEventClass) -> None:
+        self._pending.add(kind)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop (e.g. a sync unit test): record and return.
+            # A later `flush()` or a note from inside a loop will drain it.
+            return
+        if self._draining:
+            # A drain is already scheduled or running; it will see this
+            # event because it loops until `_pending` is empty rather than
+            # publishing one snapshot and exiting (see module docstring).
+            return
+        self._draining = True
+        task = loop.create_task(self._drain())
+        self._drain_tasks.add(task)
+        task.add_done_callback(self._drain_tasks.discard)
+
+    async def _drain(self) -> None:
+        """Self-scheduled drain: yield once, then loop until pending is empty."""
+        await asyncio.sleep(0)
+        await self._drain_pending()
+        # No `await` between `_drain_pending` finding `_pending` empty (its
+        # `while` test failing) and this clear -- required so a `note_*`
+        # cannot land in a gap and go unobserved by both this drain and the
+        # next `note_*` (which would see `_draining` still True).
+        self._draining = False
+
+    async def flush(self) -> None:
+        """Drain any pending events immediately, in tools/resources/prompts order.
+
+        Idempotent; a no-op when nothing is pending. Not the correctness
+        mechanism -- see module docstring -- call sites are never required
+        to call this.
+        """
+        await self._drain_pending()
+
+    async def _drain_pending(self) -> None:
+        """The frozen drain loop: pop everything pending, publish it, repeat
+        until a pop finds nothing left. Shared by `_drain` and `flush`."""
+        while self._pending:
+            kinds, self._pending = self._pending, set()
+            for kind in _ORDER:
+                if kind in kinds:
+                    await self._publish(kind)
+
+    async def _publish(self, kind: _CatalogEventClass) -> None:
+        try:
+            await self._bus.publish(kind())
+        except Exception:
+            # Isolate a raising bus from the drain, matching
+            # `InMemorySubscriptionBus.publish`'s own listener-isolation
+            # contract -- one bad publish must not stop the next drain.
+            logger.exception("subscription bus publish raised; catalog event dropped")

--- a/src/pmcp/subscriptions.py
+++ b/src/pmcp/subscriptions.py
@@ -131,12 +131,22 @@ class BusCatalogEventSink:
     async def _drain(self) -> None:
         """Self-scheduled drain: yield once, then loop until pending is empty."""
         await asyncio.sleep(0)
-        await self._drain_pending()
-        # No `await` between `_drain_pending` finding `_pending` empty (its
-        # `while` test failing) and this clear -- required so a `note_*`
-        # cannot land in a gap and go unobserved by both this drain and the
-        # next `note_*` (which would see `_draining` still True).
-        self._draining = False
+        try:
+            await self._drain_pending()
+        finally:
+            # `finally`, not a bare trailing statement: if this task is
+            # cancelled mid-drain, an un-cleared `_draining` would leave the
+            # sink permanently wedged -- every later `note_*` would see a
+            # live drain, decline to re-arm, and silently never publish
+            # again. That is the lost-wakeup failure this class exists to
+            # prevent, re-entering through cancellation instead of through
+            # the snapshot-and-exit shape.
+            #
+            # No `await` between `_drain_pending` finding `_pending` empty
+            # (its `while` test failing) and this clear -- required so a
+            # `note_*` cannot land in a gap and go unobserved by both this
+            # drain and the next `note_*`.
+            self._draining = False
 
     async def flush(self) -> None:
         """Drain any pending events immediately, in tools/resources/prompts order.

--- a/src/pmcp/subscriptions.py
+++ b/src/pmcp/subscriptions.py
@@ -123,30 +123,48 @@ class BusCatalogEventSink:
             # event because it loops until `_pending` is empty rather than
             # publishing one snapshot and exiting (see module docstring).
             return
+        self._start_drain(loop)
+
+    def _start_drain(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Mark a drain live and schedule it. Sole setter of `_draining=True`."""
         self._draining = True
         task = loop.create_task(self._drain())
         self._drain_tasks.add(task)
-        task.add_done_callback(self._drain_tasks.discard)
+        task.add_done_callback(self._on_drain_done)
+
+    def _on_drain_done(self, task: asyncio.Task[None]) -> None:
+        """Clear `_draining` and re-arm if work remains. Sole clearer of the flag.
+
+        This lives in the done-callback rather than in a `finally` inside
+        `_drain` because a task cancelled *before it starts* never enters its
+        body at all -- no `finally` can run, and the flag would stay set
+        forever, wedging every later `note_*`. The callback fires for every
+        terminal state: normal return, exception, cancellation mid-run, and
+        cancellation before the first step.
+
+        Re-arming matters as much as clearing. Events noted *while* a drain
+        was in flight stay in `_pending`; if that drain is then cancelled,
+        nothing is scheduled to publish them and they would sit there until
+        some unrelated later mutation happened to arm a drain. A cancellation
+        must delay delivery, never strand it.
+        """
+        self._drain_tasks.discard(task)
+        self._draining = False
+        if not self._pending:
+            return
+        try:
+            self._start_drain(asyncio.get_running_loop())
+        except RuntimeError:  # pragma: no cover - loop already closing
+            pass
 
     async def _drain(self) -> None:
-        """Self-scheduled drain: yield once, then loop until pending is empty."""
+        """Self-scheduled drain: yield once, then loop until pending is empty.
+
+        Deliberately does not touch `_draining` -- `_on_drain_done` owns it,
+        which is what covers the cancelled-before-first-step path.
+        """
         await asyncio.sleep(0)
-        try:
-            await self._drain_pending()
-        finally:
-            # `finally`, not a bare trailing statement: if this task is
-            # cancelled mid-drain, an un-cleared `_draining` would leave the
-            # sink permanently wedged -- every later `note_*` would see a
-            # live drain, decline to re-arm, and silently never publish
-            # again. That is the lost-wakeup failure this class exists to
-            # prevent, re-entering through cancellation instead of through
-            # the snapshot-and-exit shape.
-            #
-            # No `await` between `_drain_pending` finding `_pending` empty
-            # (its `while` test failing) and this clear -- required so a
-            # `note_*` cannot land in a gap and go unobserved by both this
-            # drain and the next `note_*`.
-            self._draining = False
+        await self._drain_pending()
 
     async def flush(self) -> None:
         """Drain any pending events immediately, in tools/resources/prompts order.

--- a/src/pmcp/transport/http.py
+++ b/src/pmcp/transport/http.py
@@ -1,10 +1,13 @@
 """HTTP transport for MCP Gateway.
 
-Uses the MCP streamable-HTTP transport (introduced in MCP spec 2025-03-26) instead
-of the legacy SSE transport.  Clients connect with a single POST to /mcp; the
-server upgrades to an SSE stream for the response when needed.  No persistent
-GET /sse connection is required, which eliminates the race-condition where tool
-calls arrived before the legacy SSE session completed its initialize handshake.
+Uses the MCP streamable-HTTP transport instead of the legacy SSE transport.
+Clients connect with a single POST to /mcp; the server upgrades to an SSE
+stream for the response when needed. GET /mcp is not served: it answers
+405 Method Not Allowed with `Allow: POST, DELETE`. There is no persistent
+GET/SSE connection of any kind, pre-session or otherwise. Server-initiated
+notifications are delivered over `subscriptions/listen` instead -- a
+long-lived POST stream reachable only at protocol version 2026-07-28 (see
+`pmcp.subscriptions`) -- not over a standalone GET channel.
 
 Claude Code config (.mcp.json):
     { "mcpServers": { "pmcp": { "type": "http", "url": "http://127.0.0.1:3344/mcp" } } }
@@ -19,7 +22,6 @@ import hmac
 import ipaddress
 import json
 import logging
-import os
 import uuid
 from collections.abc import AsyncIterator, MutableMapping
 from typing import TYPE_CHECKING, Any, Callable, Literal
@@ -28,7 +30,7 @@ from urllib.parse import urlparse
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from pmcp import __version__
@@ -66,46 +68,6 @@ _rl_store: dict[str, collections.deque] = {}
 _rl_lock: asyncio.Lock | None = None
 
 _MAX_BODY_BYTES: int = 10 * 1024 * 1024  # 10 MB
-
-# ---------------------------------------------------------------------------
-# Transport DoS guards for unauthenticated pre-session traffic
-# ---------------------------------------------------------------------------
-# The pre-session keepalive SSE stream (rmcp compatibility, see handle_mcp) is
-# infinite by design. Without bounds an unauthenticated client can open an
-# unlimited number of long-lived connections and exhaust the server
-# (connection-exhaustion DoS). We cap both the number of concurrent streams and
-# each stream's absolute lifetime. Both are env-tunable for operators.
-_DEFAULT_MAX_KEEPALIVE_STREAMS: int = 64
-_DEFAULT_KEEPALIVE_MAX_SECONDS: float = 300.0
-_KEEPALIVE_HEARTBEAT_SECONDS: float = 30.0
-
-# Live count of open pre-session keepalive streams. Mutated only from the event
-# loop thread; check-then-increment in handle_mcp has no await in between and is
-# therefore atomic. Held in a dict so nested closures can mutate without a
-# module-level ``global`` declaration (mirrors the _rl_store pattern).
-_keepalive_active: dict[str, int] = {"count": 0}
-
-
-def _env_int(name: str, default: int, *, minimum: int) -> int:
-    """Read a positive int from the environment, clamped to ``minimum``."""
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        return max(minimum, int(raw))
-    except ValueError:
-        return default
-
-
-def _env_float(name: str, default: float, *, minimum: float) -> float:
-    """Read a positive float from the environment, clamped to ``minimum``."""
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        return max(minimum, float(raw))
-    except ValueError:
-        return default
 
 
 async def _read_body_capped(
@@ -326,7 +288,7 @@ def create_http_app(
             "Mcp-Name": "accepted",
         },
         session_compatibility={
-            "pre_session_get": "rmcp_keepalive",
+            "get_stream": "retired",
             "initialized_without_session": "accepted",
         },
         auth_metadata_present=bool(auth_metadata.protected_resource_metadata_url),
@@ -590,67 +552,13 @@ def create_http_app(
                     )
                     return Response("Payload Too Large", status_code=413)
 
-        # Workaround for rmcp clients (e.g., Codex) that open the GET common
-        # stream before completing the initialize handshake (and therefore have
-        # no session ID yet). The MCP session manager returns 400 for session-less
-        # GETs; rmcp treats that as fatal and never establishes the common stream,
-        # so server-sent notifications and tool responses routed through that
-        # channel are lost. Return a minimal keep-alive SSE stream instead; rmcp
-        # will re-open the GET with a real session ID once it has one.
-        if request.method == "GET" and not request.headers.get("mcp-session-id"):
-            # DoS guard: cap concurrent pre-session streams and give each an
-            # absolute lifetime so an unauthenticated client cannot open an
-            # unbounded number of infinite connections.
-            max_streams = _env_int(
-                "PMCP_MAX_KEEPALIVE_STREAMS",
-                _DEFAULT_MAX_KEEPALIVE_STREAMS,
-                minimum=1,
-            )
-            if _keepalive_active["count"] >= max_streams:
-                logger.debug(
-                    "handle_mcp [%s]: 503 keepalive stream cap reached (%d)",
-                    request_id,
-                    max_streams,
-                )
-                return _reject(503, "Service Unavailable")
-            # No await between the check above and this increment: atomic on the
-            # event loop. The finally in the generator releases the slot.
-            _keepalive_active["count"] += 1
-            max_seconds = _env_float(
-                "PMCP_KEEPALIVE_MAX_SECONDS",
-                _DEFAULT_KEEPALIVE_MAX_SECONDS,
-                minimum=0.1,
-            )
-
-            async def _keepalive_sse() -> AsyncIterator[bytes]:
-                loop = asyncio.get_running_loop()
-                deadline = loop.time() + max_seconds
-                try:
-                    while loop.time() < deadline:
-                        yield b": keep-alive\n\n"
-                        remaining = deadline - loop.time()
-                        if remaining <= 0:
-                            break
-                        await asyncio.sleep(
-                            min(_KEEPALIVE_HEARTBEAT_SECONDS, remaining)
-                        )
-                except asyncio.CancelledError:
-                    pass
-                finally:
-                    _keepalive_active["count"] -= 1
-
-            logger.debug(
-                "handle_mcp [%s]: rmcp-compat serving pre-session GET as keep-alive"
-                " SSE (deadline=%ss, active=%d)",
-                request_id,
-                max_seconds,
-                _keepalive_active["count"],
-            )
-            return StreamingResponse(
-                _keepalive_sse(),
-                media_type="text/event-stream",
-                headers={"Cache-Control": "no-cache"},
-            )
+        # The JSON-RPC method of this POST body, parsed once below and used
+        # for two independent purposes: the rmcp-compat notifications/initialized
+        # workaround (session-less only), and — the reason it lives at this
+        # scope rather than nested inside that check — deciding whether this
+        # request is exempt from the request_timeout wrap further down.
+        # Stays None for DELETE and for any POST whose body doesn't parse.
+        body_method: str | None = None
 
         # Read the POST body up front, counting bytes against _MAX_BODY_BYTES so
         # a chunked / mislabeled request cannot bypass the header-only cap above.
@@ -678,6 +586,11 @@ def create_http_app(
                 )
                 return Response("Payload Too Large", status_code=413)
 
+            try:
+                body_method = json.loads(body_bytes).get("method")
+            except Exception:
+                pass
+
             # Workaround for rmcp clients (e.g., Codex) that send the
             # notifications/initialized message without the mcp-session-id header.
             # The MCP initialize response includes the session ID, but rmcp does
@@ -685,18 +598,16 @@ def create_http_app(
             # notification. PMCP normally returns 400 for session-less POSTs that
             # aren't initialize, which causes the rmcp worker to abort. Accept
             # this specific notification as a no-op when no session ID is present.
-            if not request.headers.get("mcp-session-id"):
-                try:
-                    body = json.loads(body_bytes)
-                    if body.get("method") == "notifications/initialized":
-                        logger.debug(
-                            "handle_mcp [%s]: rmcp-compat accepted"
-                            " notifications/initialized without session ID",
-                            request_id,
-                        )
-                        return Response(status_code=202)
-                except Exception:
-                    pass
+            if (
+                not request.headers.get("mcp-session-id")
+                and body_method == "notifications/initialized"
+            ):
+                logger.debug(
+                    "handle_mcp [%s]: rmcp-compat accepted"
+                    " notifications/initialized without session ID",
+                    request_id,
+                )
+                return Response(status_code=202)
 
             # Replay the already-consumed body through the receive callable so the
             # session manager can still read it (for both session-bearing POSTs
@@ -725,22 +636,38 @@ def create_http_app(
                 response_started = True
             await original_send(message)
 
-        try:
-            await asyncio.wait_for(
-                session_manager.handle_request(
-                    request.scope, request.receive, tracking_send
-                ),
-                timeout=request_timeout,
+        # subscriptions/listen opens a long-lived stream by design (a
+        # subscription outlives request_timeout on any real client — that is
+        # the point of it). Wrapping it in the same wait_for as ordinary
+        # request/response POSTs silently truncates every subscription at
+        # request_timeout seconds: the client sees a healthy ack and
+        # notifications, then "ASGI callable returned without completing
+        # response" and an incomplete chunked body, with no
+        # SubscriptionsListenResult, on every default deployment (measured,
+        # IF-0-P3B-3). ListenHandler's own concurrency and per-stream backlog
+        # caps bound the exposure instead; the absolute-lifetime cap this
+        # exemption removes is deliberately not replaced (CHANGELOG.md).
+        if body_method == "subscriptions/listen":
+            await session_manager.handle_request(
+                request.scope, request.receive, tracking_send
             )
-        except asyncio.TimeoutError:
-            logger.warning(
-                "handle_mcp [%s]: request timed out after %ss",
-                request_id,
-                request_timeout,
-            )
-            if response_started:
-                return _NullResponse()
-            return Response("Gateway Timeout", status_code=504)
+        else:
+            try:
+                await asyncio.wait_for(
+                    session_manager.handle_request(
+                        request.scope, request.receive, tracking_send
+                    ),
+                    timeout=request_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "handle_mcp [%s]: request timed out after %ss",
+                    request_id,
+                    request_timeout,
+                )
+                if response_started:
+                    return _NullResponse()
+                return Response("Gateway Timeout", status_code=504)
         _inc("requests_ok")
         return _NullResponse()
 
@@ -752,9 +679,7 @@ def create_http_app(
         logger.info("Streamable-HTTP session manager stopped")
 
     routes = [
-        Route(
-            "/mcp", endpoint=handle_mcp, methods=["GET", "POST", "DELETE"], name="mcp"
-        ),
+        Route("/mcp", endpoint=handle_mcp, methods=["POST", "DELETE"], name="mcp"),
         Route("/health", endpoint=handle_health, methods=["GET"]),
         Route("/metrics", endpoint=handle_metrics, methods=["GET"]),
     ]

--- a/tests/mcp2x/test_catalog_publishers.py
+++ b/tests/mcp2x/test_catalog_publishers.py
@@ -1,0 +1,318 @@
+"""SL-3.1 — pin `ClientManager(catalog_events=...)`: the production catalog
+event publishers (roadmap Lane C).
+
+`ClientManager` mutates `_tools`/`_resources`/`_prompts` from six write sites
+(Context > "The publisher gap"). Five of them are sync mutators that call
+`CatalogEventSink.note_*`; `__init__` is exempt (no sink or subscriber can
+exist at construction). This module covers:
+
+  - the null-sink default (`ClientManager()` with no `catalog_events`
+    constructs and keeps working — the ~20 pre-P3B construction sites need
+    zero edits);
+  - each of `_index_tools` / `_index_resources` / `_index_prompts` /
+    `_remove_server_indexes` records exactly the right `note_*` calls,
+    including the "no-op index publishes nothing" and "never-connected
+    server publishes nothing" negatives;
+  - the integration half: a real `ClientManager` wired to a real
+    `BusCatalogEventSink` over a real `InMemorySubscriptionBus`, driven
+    through `connect_server`/`disconnect_server` against a real stdio
+    downstream — no test in this half calls `note_*` or `flush()` itself;
+  - the two regressions the board found: `refresh([])` (the
+    `_disconnect_all_unlocked` silent-clear hole) and the lost-wakeup race,
+    driven this time through the production mutators rather than the sink
+    directly (that's SL-1's own coverage).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from mcp.server.subscriptions import InMemorySubscriptionBus
+from mcp.shared.subscriptions import (
+    PromptsListChanged,
+    ResourcesListChanged,
+    ServerEvent,
+    ToolsListChanged,
+)
+
+from pmcp.client.manager import ClientManager
+from pmcp.subscriptions import BusCatalogEventSink, CatalogEventSink
+from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig
+from tests.runtime.harness import RT_FIXTURE_SRC
+
+POLL_ATTEMPTS = 100
+POLL_INTERVAL_S = 0.02
+
+
+async def _poll_until(predicate: Callable[[], bool]) -> None:
+    """Poll rather than assert-immediately-after-return: SL-3.2's two
+    `flush()` call sites are an ordering nicety, not the correctness
+    mechanism, and this suite must stay green with either resolved."""
+    for _ in range(POLL_ATTEMPTS):
+        if predicate():
+            return
+        await asyncio.sleep(POLL_INTERVAL_S)
+    assert predicate()  # final attempt — produces the real assertion failure
+
+
+class _RecordingSink:
+    """A `CatalogEventSink` that just records which `note_*` fired, in order."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def note_tools_changed(self) -> None:
+        self.calls.append("tools")
+
+    def note_resources_changed(self) -> None:
+        self.calls.append("resources")
+
+    def note_prompts_changed(self) -> None:
+        self.calls.append("prompts")
+
+    async def flush(self) -> None:  # pragma: no cover - not exercised here
+        pass
+
+
+class _GatedBus:
+    """A `SubscriptionBus` whose `publish` suspends on a test-controlled
+    `asyncio.Event` — same shape as SL-1's, reused here to prove the
+    lost-wakeup fix holds when driven through `ClientManager`'s own
+    mutators rather than the sink directly."""
+
+    def __init__(self) -> None:
+        self.published: list[ServerEvent] = []
+        self.gate = asyncio.Event()
+        self.entered = asyncio.Event()
+
+    async def publish(self, event: ServerEvent) -> None:
+        self.entered.set()
+        await self.gate.wait()
+        self.published.append(event)
+
+    def subscribe(self, listener: Callable[[ServerEvent], None]) -> Callable[[], None]:
+        return lambda: None
+
+
+def _stdio_fixture_config(
+    tmp_path: Path, name: str = "rt-fixture"
+) -> ResolvedServerConfig:
+    """The tests/runtime stdio fixture (one tool, one prompt), reused here
+    without editing SL-5's `tests/runtime/harness.py`. `sys.executable` is
+    the `.venv` interpreter under `uv run pytest`."""
+    fixture_py = tmp_path / "rt_fixture_server.py"
+    fixture_py.write_text(RT_FIXTURE_SRC)
+    return ResolvedServerConfig(
+        name=name,
+        source="project",
+        config=LocalMcpServerConfig(command=sys.executable, args=[str(fixture_py)]),
+    )
+
+
+# --- the null-sink default -------------------------------------------------
+
+
+def test_client_manager_with_no_catalog_events_constructs_with_a_null_sink() -> None:
+    manager = ClientManager()
+    assert isinstance(manager._catalog_events, CatalogEventSink)
+    # And every existing call still works: a no-op index on a fresh manager
+    # neither raises nor is a `_NullCatalogEventSink` special case.
+    assert manager._index_tools("s", []) == 0
+    assert manager._index_tools("s", [{"name": "t1"}]) == 1
+
+
+# --- _index_tools / _index_resources / _index_prompts ----------------------
+
+
+def test_index_tools_records_exactly_one_note_for_one_tool() -> None:
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+
+    indexed = manager._index_tools("s", [{"name": "t1", "description": "d"}])
+
+    assert indexed == 1
+    assert sink.calls == ["tools"]
+
+
+def test_index_resources_records_exactly_one_note_for_one_resource() -> None:
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+
+    count = manager._index_resources("s", [{"uri": "file:///a", "name": "r1"}])
+
+    assert count == 1
+    assert sink.calls == ["resources"]
+
+
+def test_index_prompts_records_exactly_one_note_for_one_prompt() -> None:
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+
+    count = manager._index_prompts("s", [{"name": "p1"}])
+
+    assert count == 1
+    assert sink.calls == ["prompts"]
+
+
+def test_index_tools_with_nothing_indexed_records_nothing() -> None:
+    """A no-op index must not publish — a level trigger that fires on
+    nothing trains clients to ignore it."""
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+
+    indexed = manager._index_tools("s", [])
+
+    assert indexed == 0
+    assert sink.calls == []
+
+
+def test_index_resources_and_prompts_with_nothing_indexed_record_nothing() -> None:
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+
+    assert manager._index_resources("s", []) == 0
+    assert manager._index_prompts("s", []) == 0
+    assert sink.calls == []
+
+
+# --- _remove_server_indexes --------------------------------------------
+
+
+def test_remove_server_indexes_records_all_three_kinds_that_were_present() -> None:
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+    manager._index_tools("s", [{"name": "t1"}])
+    manager._index_resources("s", [{"uri": "file:///a", "name": "r1"}])
+    manager._index_prompts("s", [{"name": "p1"}])
+    sink.calls.clear()
+
+    manager._remove_server_indexes("s")
+
+    assert set(sink.calls) == {"tools", "resources", "prompts"}
+    assert len(sink.calls) == 3
+
+
+def test_remove_server_indexes_never_connected_records_nothing() -> None:
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+
+    manager._remove_server_indexes("never-connected")
+
+    assert sink.calls == []
+
+
+def test_remove_server_indexes_only_notes_kinds_that_actually_shrank() -> None:
+    """Only tools were indexed for this server — removing it must not claim
+    resources or prompts changed too."""
+    sink = _RecordingSink()
+    manager = ClientManager(catalog_events=sink)
+    manager._index_tools("s", [{"name": "t1"}])
+    sink.calls.clear()
+
+    manager._remove_server_indexes("s")
+
+    assert sink.calls == ["tools"]
+
+
+# --- the integration half: a real bus, a real sink, real connect/disconnect
+
+
+async def test_connect_and_disconnect_publish_over_a_real_bus_no_manual_note_or_flush(
+    tmp_path: Path,
+) -> None:
+    bus = InMemorySubscriptionBus()
+    sink = BusCatalogEventSink(bus)
+    manager = ClientManager(catalog_events=sink)
+    published: list[ServerEvent] = []
+    bus.subscribe(published.append)
+
+    config = _stdio_fixture_config(tmp_path)
+    try:
+        errors = await manager.connect_server(config, retry=False)
+        assert errors == [], errors
+
+        await _poll_until(
+            lambda: any(isinstance(e, ToolsListChanged) for e in published)
+        )
+
+        published.clear()
+        disconnected, _cancelled, error = await manager.disconnect_server(
+            config.name, force=True
+        )
+        assert disconnected, error
+
+        await _poll_until(
+            lambda: any(isinstance(e, ToolsListChanged) for e in published)
+        )
+    finally:
+        await manager.disconnect_all()
+
+
+# --- the board-found regression: refresh([]) must still announce the clear
+
+
+async def test_refresh_with_empty_config_publishes_all_three_list_changed_events() -> (
+    None
+):
+    """`ClientManager.refresh([])` -> `_disconnect_all_unlocked()` +
+    `_connect_all_unlocked([])` (a no-op on an empty list). The wholesale
+    clear bypasses `_remove_server_indexes` entirely (it clears all three
+    dicts directly) — without SL-3.2's fix this empties every catalog and
+    publishes nothing, the exact listener-with-no-publishers failure this
+    phase exists to prevent."""
+    bus = InMemorySubscriptionBus()
+    sink = BusCatalogEventSink(bus)
+    manager = ClientManager(catalog_events=sink)
+    published: list[ServerEvent] = []
+    bus.subscribe(published.append)
+
+    manager._index_tools("s", [{"name": "t1"}])
+    manager._index_resources("s", [{"uri": "file:///a", "name": "r1"}])
+    manager._index_prompts("s", [{"name": "p1"}])
+    await sink.flush()
+    published.clear()
+
+    result = await manager.refresh([])
+
+    assert result == []
+
+    def _all_three_kinds_seen() -> bool:
+        kinds = {type(e) for e in published}
+        return {ToolsListChanged, ResourcesListChanged, PromptsListChanged} <= kinds
+
+    await _poll_until(_all_three_kinds_seen)
+
+
+# --- the board-found regression: the lost-wakeup race, via the mutators ----
+
+
+async def test_note_during_a_suspended_publish_via_index_methods_is_not_stranded() -> (
+    None
+):
+    """IF-0-P3B-1's drain-loop freeze, proven through `ClientManager`'s own
+    mutators rather than the sink directly (SL-1 already covers the sink in
+    isolation): `_index_tools` arms a drain that suspends inside
+    `bus.publish(...)`; while it is suspended, `_index_prompts` runs and
+    must not be stranded. No `flush()` call anywhere in this test."""
+    bus = _GatedBus()
+    sink = BusCatalogEventSink(bus)
+    manager = ClientManager(catalog_events=sink)
+
+    manager._index_tools("s", [{"name": "t1"}])
+    await bus.entered.wait()  # the drain is now suspended inside publish()
+
+    manager._index_prompts("s", [{"name": "p1"}])  # lands in the lost-wakeup window
+
+    bus.gate.set()  # release the first publish
+
+    await _poll_until(lambda: len(bus.published) >= 2)
+
+    assert bus.published == [ToolsListChanged(), PromptsListChanged()]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/mcp2x/test_catalog_publishers.py
+++ b/tests/mcp2x/test_catalog_publishers.py
@@ -16,7 +16,11 @@ exist at construction). This module covers:
   - the integration half: a real `ClientManager` wired to a real
     `BusCatalogEventSink` over a real `InMemorySubscriptionBus`, driven
     through `connect_server`/`disconnect_server` against a real stdio
-    downstream — no test in this half calls `note_*` or `flush()` itself;
+    downstream — no test in this half calls `note_*` or `flush()` itself,
+    and no production `ClientManager` code path calls `flush()` either
+    (grepping the module for a `flush(` call is empty): IF-0-P3B-1's
+    self-scheduling drain is the only thing that can deliver these events,
+    which is exactly what EC-P3B-4 needs to be proving;
   - the two regressions the board found: `refresh([])` (the
     `_disconnect_all_unlocked` silent-clear hole) and the lost-wakeup race,
     driven this time through the production mutators rather than the sink
@@ -49,9 +53,10 @@ POLL_INTERVAL_S = 0.02
 
 
 async def _poll_until(predicate: Callable[[], bool]) -> None:
-    """Poll rather than assert-immediately-after-return: SL-3.2's two
-    `flush()` call sites are an ordering nicety, not the correctness
-    mechanism, and this suite must stay green with either resolved."""
+    """Poll rather than assert-immediately-after-return: no production code
+    path calls `flush()`, so delivery here always goes through
+    `BusCatalogEventSink`'s self-scheduled drain, which is asynchronous
+    relative to the `note_*` call that armed it."""
     for _ in range(POLL_ATTEMPTS):
         if predicate():
             return

--- a/tests/mcp2x/test_get_retirement.py
+++ b/tests/mcp2x/test_get_retirement.py
@@ -1,0 +1,145 @@
+"""SL-4.1 — EC-P3B-3 route-table unit coverage: GET /mcp is retired.
+
+Covers IF-0-P3B-3's route-table half: the ``/mcp`` ``Route``'s ``methods``
+drops ``"GET"`` (``DELETE`` retained), Starlette answers a bare ``GET /mcp``
+with ``405`` and ``Allow: POST, DELETE`` rather than the hang measured spike
+2b found (pmcp's own rmcp-compat pre-session keep-alive branch answering a
+session-less GET with an infinite SSE stream before the session manager ever
+saw the request). ``/health`` and ``/metrics`` are separate ``Route``
+objects and must be structurally untouched by the retirement.
+
+This module drives ``create_http_app`` directly with Starlette's
+``TestClient`` (synchronous, in-process) — it does not need a real session
+manager or a live event loop, unlike ``tests/mcp2x/test_listen_over_http.py``
+(SL-4.2), which proves the timeout-exemption and client-close halves of
+IF-0-P3B-3 over a real uvicorn server.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+
+def _make_client() -> TestClient:
+    """A ``create_http_app`` TestClient with the session manager mocked out.
+
+    Mirrors ``tests/test_http_dos.py``'s ``_make_contract_client`` — this
+    module owns no production code, only route-table and diagnostics
+    evidence for ``src/pmcp/transport/http.py`` (SL-4-owned).
+    """
+    from pmcp.transport.http import create_http_app
+
+    mock_server = MagicMock()
+    mock_server.create_initialization_options = MagicMock(return_value={})
+
+    with patch(
+        "pmcp.transport.http.StreamableHTTPSessionManager",
+        autospec=True,
+    ) as mock_manager:
+        instance = mock_manager.return_value
+        instance.run.return_value.__aenter__ = AsyncMock(return_value=None)
+        instance.run.return_value.__aexit__ = AsyncMock(return_value=False)
+        instance.handle_request = AsyncMock(return_value=None)
+
+        app = create_http_app(mock_server)
+        client = TestClient(
+            app, base_url="http://127.0.0.1", raise_server_exceptions=False
+        )
+        client.app = app  # type: ignore[attr-defined]  # stash for route-table assertions
+        return client
+
+
+class TestGetRetired:
+    """GET /mcp answers 405 with Allow rather than hanging."""
+
+    def test_get_mcp_is_405(self) -> None:
+        client = _make_client()
+        response = client.get(
+            "/mcp",
+            headers={
+                "Accept": "text/event-stream",
+                "MCP-Protocol-Version": "2026-07-28",
+            },
+        )
+        assert response.status_code == 405
+
+    def test_get_mcp_allow_header_names_post_and_delete_not_get(self) -> None:
+        client = _make_client()
+        response = client.get("/mcp")
+        allow = response.headers["allow"]
+        allowed = {method.strip() for method in allow.split(",")}
+        assert "POST" in allowed, allow
+        assert "DELETE" in allowed, allow
+        assert "GET" not in allowed, allow
+
+    def test_mcp_route_methods_is_exactly_post_delete(self) -> None:
+        """Not ``{"POST", "DELETE", "HEAD"}`` — Starlette only synthesises
+        HEAD alongside GET, so once GET is gone HEAD goes with it. Asserting
+        the exact set (not just "GET absent from a list") is what proves GET
+        is actually gone rather than merely unlisted."""
+        client = _make_client()
+        mcp_route = next(
+            route
+            for route in client.app.routes  # type: ignore[attr-defined]
+            if isinstance(route, Route) and route.path == "/mcp"
+        )
+        assert mcp_route.methods == {"POST", "DELETE"}, mcp_route.methods
+
+
+class TestHealthAndMetricsSurviveRetirement:
+    """/health and /metrics are separate Route objects, untouched by SL-4."""
+
+    def test_health_still_200_with_expected_shape(self) -> None:
+        client = _make_client()
+        response = client.get("/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert "version" in body
+        assert body["transport"] == "http"
+        assert "gateway_diagnostics" in body
+
+    def test_metrics_still_200_prometheus_content_type(self) -> None:
+        client = _make_client()
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        assert "text/plain" in response.headers["content-type"]
+
+
+class TestDiagnosticsLiteral:
+    """IF-0-P3B-3's session_compatibility diagnostics key change."""
+
+    def test_pre_session_get_key_gone_get_stream_retired(self) -> None:
+        client = _make_client()
+        diagnostics = client.app.state.gateway_diagnostics  # type: ignore[attr-defined]
+        assert "pre_session_get" not in diagnostics.session_compatibility
+        assert diagnostics.session_compatibility["get_stream"] == "retired"
+
+    def test_health_body_reflects_the_same_diagnostics(self) -> None:
+        client = _make_client()
+        body = client.get("/health").json()
+        session_compat = body["gateway_diagnostics"]["session_compatibility"]
+        assert "pre_session_get" not in session_compat
+        assert session_compat["get_stream"] == "retired"
+
+
+class TestKeepaliveSymbolsRemoved:
+    """The deleted DoS-guard module-level state must actually be gone, not
+    just unreferenced — a rename or a stray reintroduction would defeat a
+    grep-only check."""
+
+    def test_keepalive_module_symbols_no_longer_exist(self) -> None:
+        from pmcp.transport import http as http_mod
+
+        for name in (
+            "_keepalive_active",
+            "_DEFAULT_MAX_KEEPALIVE_STREAMS",
+            "_DEFAULT_KEEPALIVE_MAX_SECONDS",
+            "_KEEPALIVE_HEARTBEAT_SECONDS",
+        ):
+            assert not hasattr(http_mod, name), (
+                f"{name} still exists on pmcp.transport.http"
+            )

--- a/tests/mcp2x/test_listen_over_http.py
+++ b/tests/mcp2x/test_listen_over_http.py
@@ -1,0 +1,296 @@
+"""SL-4.2 — IF-0-P3B-4 over the deployed HTTP wire, plus the two regressions
+measured spike 2 found and IF-0-P3B-3 exists to fix.
+
+Runs pmcp's own ``create_http_app`` under uvicorn's programmatic ``Server``
+API as an in-process background task -- mirrors
+``tests/runtime/fake_remote.py``'s ``run_fake_remote`` (SL-5-owned; read
+only, not imported, since it serves a downstream ``MCPServer`` rather than
+``create_http_app``) -- with a real ``ListenHandler`` + real
+``InMemorySubscriptionBus`` the test also holds a reference to, so it can
+drive ``bus.publish(...)`` directly without needing a ``ClientManager``
+(SL-3's job) in the loop.
+
+Two tests are the regression evidence and use the exact function names the
+acceptance commands select with ``-k``:
+
+- ``test_timeout_exemption_keeps_stream_alive`` — the app is built with
+  ``request_timeout=3``; on today's code (before SL-4.3) the stream is
+  killed at exactly 3s with a truncated chunked body (measured spike 2).
+  This asserts the stream is still alive and still delivering past t>8s.
+- ``test_client_close_ends_subscription`` — EC-P3B-2's HTTP client-close
+  half, proven observably: with ``max_subscriptions=1``, closing the first
+  subscription's connection must free its slot so a second subscription is
+  acked. Asserted through public wire behaviour (the second subscription's
+  ack), never by reading the SDK-private ``ListenHandler._streams`` — a
+  rename there would give a false red rather than a true one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import socket
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import uvicorn
+from mcp.server import Server
+from mcp.server.subscriptions import InMemorySubscriptionBus, ListenHandler
+from mcp.shared.inbound import MCP_METHOD_HEADER, MCP_PROTOCOL_VERSION_HEADER
+from mcp.shared.subscriptions import SUBSCRIPTION_ID_META_KEY, ToolsListChanged
+from mcp.types import CLIENT_CAPABILITIES_META_KEY, PROTOCOL_VERSION_META_KEY
+from mcp.types.version import LATEST_MODERN_VERSION
+
+from pmcp.transport.http import create_http_app
+
+pytestmark = pytest.mark.asyncio
+
+
+def _alloc_port() -> int:
+    """A real ephemeral-port allocator — never a hardcoded literal."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _listen_envelope(
+    *, notifications: dict[str, bool], request_id: int = 1
+) -> tuple[dict[str, str], dict]:
+    """Build the IF-0-P3B-4 wire envelope for a subscriptions/listen POST.
+
+    ``notifications`` is passed in wire (camelCase) form, per IF-0-P3B-4 —
+    only JSON test payloads use the alias; pmcp's own Python source
+    constructs ``SubscriptionFilter`` with field names.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        # Both media types required: subscriptions/listen 406s without SSE
+        # accept regardless of json_response (IF-0-P3B-4).
+        "Accept": "application/json, text/event-stream",
+        MCP_PROTOCOL_VERSION_HEADER: LATEST_MODERN_VERSION,
+        MCP_METHOD_HEADER: "subscriptions/listen",
+    }
+    body = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "subscriptions/listen",
+        "params": {
+            "notifications": notifications,
+            "_meta": {
+                PROTOCOL_VERSION_META_KEY: LATEST_MODERN_VERSION,
+                CLIENT_CAPABILITIES_META_KEY: {},
+            },
+        },
+    }
+    return headers, body
+
+
+@dataclass
+class RunningListenApp:
+    base_url: str
+    bus: InMemorySubscriptionBus
+    listen_handler: ListenHandler
+
+
+@contextlib.asynccontextmanager
+async def _run_listen_app(
+    *, request_timeout: int = 60, max_subscriptions: int = 1024
+) -> AsyncIterator[RunningListenApp]:
+    """Serve ``create_http_app(<Server with on_subscriptions_listen>)`` on a
+    spare port as a background asyncio task on the caller's own event loop,
+    for the duration of the ``async with`` block."""
+    bus = InMemorySubscriptionBus()
+    listen_handler = ListenHandler(bus, max_subscriptions=max_subscriptions)
+    server = Server("sl4-listen-test", on_subscriptions_listen=listen_handler)
+    app = create_http_app(server, request_timeout=request_timeout)
+    port = _alloc_port()
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", lifespan="on"
+    )
+    uv_server = uvicorn.Server(config)
+    task = asyncio.create_task(uv_server.serve())
+    try:
+        for _ in range(200):
+            if uv_server.started:
+                break
+            await asyncio.sleep(0.05)
+        else:
+            raise RuntimeError("listen app never started")
+        yield RunningListenApp(
+            base_url=f"http://127.0.0.1:{port}", bus=bus, listen_handler=listen_handler
+        )
+    finally:
+        uv_server.should_exit = True
+        await task
+
+
+async def _next_data_frame(lines: AsyncIterator[str], *, timeout: float = 10.0) -> dict:
+    """Read the next ``data:`` frame from an SSE line iterator, skipping
+    ``: ping`` comment lines and blank lines (IF-0-P3B-4)."""
+
+    async def _read() -> dict:
+        async for line in lines:
+            if line.startswith("data:"):
+                return json.loads(line[len("data:") :].strip())  # noqa: E203
+        raise AssertionError("stream ended before a data: frame arrived")
+
+    return await asyncio.wait_for(_read(), timeout=timeout)
+
+
+async def _first_message(response: httpx.Response, *, timeout: float = 10.0) -> dict:
+    """The first decoded JSON-RPC message of a listen response, regardless
+    of whether it committed to SSE (a live stream) or resolved as plain
+    JSON (an immediate kernel-dispatch error, e.g. subscription limit)."""
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        return await _next_data_frame(response.aiter_lines(), timeout=timeout)
+    content = await asyncio.wait_for(response.aread(), timeout=timeout)
+    return json.loads(content)
+
+
+class TestListenDuplexOverHttp:
+    """IF-0-P3B-4: ack first, then a matching bus.publish is delivered,
+    stamped with the request's subscriptionId."""
+
+    async def test_ack_is_first_frame_with_subscription_id(self) -> None:
+        async with _run_listen_app() as running:
+            headers, body = _listen_envelope(
+                notifications={"toolsListChanged": True}, request_id=42
+            )
+            async with (
+                httpx.AsyncClient(timeout=None) as client,
+                client.stream(
+                    "POST", f"{running.base_url}/mcp", headers=headers, json=body
+                ) as response,
+            ):
+                assert response.status_code == 200
+                assert "text/event-stream" in response.headers["content-type"]
+                frame = await _next_data_frame(response.aiter_lines())
+                assert frame["method"] == "notifications/subscriptions/acknowledged"
+                assert frame["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 42, frame
+
+    async def test_bus_publish_delivers_stamped_notification(self) -> None:
+        async with _run_listen_app() as running:
+            headers, body = _listen_envelope(
+                notifications={"toolsListChanged": True}, request_id=7
+            )
+            async with (
+                httpx.AsyncClient(timeout=None) as client,
+                client.stream(
+                    "POST", f"{running.base_url}/mcp", headers=headers, json=body
+                ) as response,
+            ):
+                lines = response.aiter_lines()
+                ack = await _next_data_frame(lines)
+                assert ack["method"] == "notifications/subscriptions/acknowledged"
+
+                await running.bus.publish(ToolsListChanged())
+
+                frame = await _next_data_frame(lines)
+                assert frame["method"] == "notifications/tools/list_changed"
+                assert frame["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 7
+
+    async def test_accept_json_only_is_406(self) -> None:
+        async with _run_listen_app() as running:
+            headers, body = _listen_envelope(notifications={"toolsListChanged": True})
+            headers["Accept"] = "application/json"
+            async with httpx.AsyncClient(timeout=None) as client:
+                response = await client.post(
+                    f"{running.base_url}/mcp", headers=headers, json=body
+                )
+            assert response.status_code == 406
+
+
+class TestTimeoutExemption:
+    """The measured spike 2 regression: request_timeout must not truncate
+    a subscriptions/listen stream."""
+
+    async def test_timeout_exemption_keeps_stream_alive(self) -> None:
+        """On today's (pre-SL-4.3) code this app kills the stream at exactly
+        3s with a truncated chunked body. With the exemption, the stream
+        must still be alive and still delivering a notification published
+        well past that timeout — asserted at t > 8s, per IF-0-P3B-3."""
+        async with _run_listen_app(request_timeout=3) as running:
+            headers, body = _listen_envelope(notifications={"toolsListChanged": True})
+            start = time.monotonic()
+            async with (
+                httpx.AsyncClient(timeout=None) as client,
+                client.stream(
+                    "POST", f"{running.base_url}/mcp", headers=headers, json=body
+                ) as response,
+            ):
+                assert response.status_code == 200
+                lines = response.aiter_lines()
+                ack = await _next_data_frame(lines)
+                assert ack["method"] == "notifications/subscriptions/acknowledged"
+
+                # Sleep well past request_timeout=3 before publishing, so a
+                # notification delivered afterward can only be explained by
+                # the stream having survived the timeout wrapper.
+                await asyncio.sleep(8.2)
+                await running.bus.publish(ToolsListChanged())
+
+                frame = await _next_data_frame(lines, timeout=5)
+                elapsed = time.monotonic() - start
+                assert elapsed > 8, elapsed
+                assert frame["method"] == "notifications/tools/list_changed"
+
+
+class TestClientCloseReleasesSlot:
+    """EC-P3B-2's HTTP client-close half, proven observably."""
+
+    async def test_client_close_ends_subscription(self) -> None:
+        async with _run_listen_app(max_subscriptions=1) as running:
+            headers_a, body_a = _listen_envelope(
+                notifications={"toolsListChanged": True}, request_id=1
+            )
+            client_a = httpx.AsyncClient(timeout=None)
+            try:
+                async with client_a.stream(
+                    "POST", f"{running.base_url}/mcp", headers=headers_a, json=body_a
+                ) as response_a:
+                    assert response_a.status_code == 200
+                    ack = await _next_data_frame(response_a.aiter_lines())
+                    assert ack["method"] == "notifications/subscriptions/acknowledged"
+            finally:
+                # A real disconnect, not just returning the connection to a
+                # pool: closing the whole client tears down the TCP
+                # connection so the server's watch_disconnect actually sees
+                # http.disconnect and cancels A's handler task, which is
+                # what frees the slot in ListenHandler's finally block.
+                await client_a.aclose()
+
+            headers_b, body_b = _listen_envelope(
+                notifications={"toolsListChanged": True}, request_id=2
+            )
+            deadline = time.monotonic() + 10.0
+            last: object = None
+            async with httpx.AsyncClient(timeout=None) as client_b:
+                while time.monotonic() < deadline:
+                    # Streamed, not `client_b.post(...)`: a successful ack
+                    # opens a live SSE stream that never completes on its
+                    # own, so a non-streaming call here would hang forever
+                    # rather than let this retry loop observe the ack and
+                    # move on. `_first_message` reads only the first frame.
+                    async with client_b.stream(
+                        "POST",
+                        f"{running.base_url}/mcp",
+                        headers=headers_b,
+                        json=body_b,
+                    ) as response_b:
+                        message = await _first_message(response_b, timeout=3.0)
+                        if (
+                            message.get("method")
+                            == "notifications/subscriptions/acknowledged"
+                        ):
+                            return
+                        last = message
+                    await asyncio.sleep(0.2)
+            pytest.fail(
+                "subscription B was never acked after A's client disconnect "
+                f"(max_subscriptions=1); last response was {last!r}"
+            )

--- a/tests/mcp2x/test_listen_registration.py
+++ b/tests/mcp2x/test_listen_registration.py
@@ -1,0 +1,371 @@
+"""SL-2.1 — pin IF-0-P3B-2: listen-handler registration, construction order,
+and shutdown.
+
+Drives `GatewayServer._server` over a real anyio memory-stream duplex using
+hand-built modern-envelope frames, exactly as measured spike 1 in the phase
+plan's Context did (`plans/phase-plan-v11-P3B.md`, "Measured spike 1") --
+this exercises the SDK's real dispatcher (era detection, request/response
+framing, `notifications/cancelled` cancellation), not a handler called
+directly, so the frame-by-frame assertions below are proof of the wired
+system rather than of the SDK in isolation.
+
+**Deliberately not covered here, and why**: IF-0-P3B-2 also calls for
+asserting `gw._client_manager` holds the same `CatalogEventSink` object as
+`gw._catalog_events` (identity). That requires `ClientManager.__init__` to
+accept a `catalog_events` keyword -- SL-3's interface
+(`ClientManager(catalog_events=...)`), owned file `src/pmcp/client/manager.py`,
+not this lane's. On this branch (based on `origin/exec/v11-p3b` at SL-1 only)
+that kwarg does not exist yet, so asserting it here would either edit a file
+this lane does not own or hard-fail this module for a reason outside this
+lane's control -- both wrong per the plan's single-writer rule. Reported to
+the orchestrator; to be added (one line in `server.py`'s `ClientManager(...)`
+call, one assertion here) once SL-3 merges into the integration branch, which
+must happen before SL-5 starts in any case. What *is* proven below instead:
+the bus, the sink, and the listen handler are constructed in the frozen
+order and the sink and the handler demonstrably share one bus (an event
+published through the sink reaches a stream opened via the handler) --
+i.e. everything IF-0-P3B-2 requires that does not need `ClientManager`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import anyio
+import mcp_types
+import pytest
+from mcp.server.subscriptions import InMemorySubscriptionBus, ListenHandler
+from mcp.shared.message import SessionMessage
+from mcp.shared.subscriptions import (
+    SUBSCRIPTION_ID_META_KEY,
+    PromptsListChanged,
+    ToolsListChanged,
+)
+from mcp.types import CLIENT_CAPABILITIES_META_KEY, PROTOCOL_VERSION_META_KEY
+from mcp.types.version import LATEST_MODERN_VERSION
+
+from pmcp.server import GatewayServer
+from pmcp.subscriptions import BusCatalogEventSink
+
+
+def _new_server() -> GatewayServer:
+    gw = GatewayServer()
+    gw._create_server(instructions="test instructions")
+    return gw
+
+
+def _modern_envelope(
+    request_id: int, method: str, params: dict[str, Any]
+) -> dict[str, Any]:
+    """A `subscriptions/listen`-shaped modern-era frame (IF-0-P3B-4): both
+    `_meta` keys the 2026-07-28 envelope requires, wire (camelCase)
+    `notifications` filter -- built as raw dicts, deliberately, so this test
+    exercises exactly what a real client sends rather than a Python-side
+    convenience the SDK never sees on the wire."""
+    p = dict(params)
+    p["_meta"] = {
+        PROTOCOL_VERSION_META_KEY: LATEST_MODERN_VERSION,
+        CLIENT_CAPABILITIES_META_KEY: {},
+    }
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": p}
+
+
+def _cancelled_notification(request_id: int) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "method": "notifications/cancelled",
+        "params": {"requestId": request_id},
+    }
+
+
+class DuplexSession:
+    """Send/receive helper bound to one `Server.run` duplex."""
+
+    def __init__(
+        self,
+        to_server_send: anyio.abc.ObjectSendStream[SessionMessage | Exception],
+        from_server_recv: anyio.abc.ObjectReceiveStream[SessionMessage],
+    ) -> None:
+        self._to_server_send = to_server_send
+        self._from_server_recv = from_server_recv
+
+    async def send(self, envelope: dict[str, Any]) -> None:
+        model = mcp_types.jsonrpc_message_adapter.validate_python(envelope)
+        await self._to_server_send.send(SessionMessage(message=model))
+
+    async def recv(self, timeout: float = 5.0) -> dict[str, Any]:
+        with anyio.fail_after(timeout):
+            msg = await self._from_server_recv.receive()
+        return msg.message.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+
+@asynccontextmanager
+async def duplex_session(gw: GatewayServer) -> AsyncIterator[DuplexSession]:
+    """Drive `gw._server` over a live anyio memory-stream duplex pair,
+    exactly as a real stdio transport would (`Server.run`), rather than
+    calling the registered handler directly -- this is what makes era
+    detection, `notifications/cancelled` cancellation, and result framing
+    the SDK's own dispatcher rather than an assumption this test makes
+    about it."""
+    assert gw._server is not None
+    to_server_send, to_server_recv = anyio.create_memory_object_stream[
+        SessionMessage | Exception
+    ](32)
+    from_server_send, from_server_recv = anyio.create_memory_object_stream[
+        SessionMessage
+    ](32)
+    async with anyio.create_task_group() as tg:
+
+        async def run() -> None:
+            await gw._server.run(  # type: ignore[union-attr]
+                to_server_recv,
+                from_server_send,
+                gw._server.create_initialization_options(),  # type: ignore[union-attr]
+            )
+
+        tg.start_soon(run)
+        try:
+            yield DuplexSession(to_server_send, from_server_recv)
+        finally:
+            tg.cancel_scope.cancel()
+
+
+# --- Registration: IF-0-P3B-2, through the P2 constructor form ------------
+
+
+async def test_listen_handler_registered_by_identity() -> None:
+    """Registered through `Server.__init__(on_subscriptions_listen=...)`
+    (the P2 IF-0-P2-1 constructor form, not `add_request_handler`): the
+    registered handler *is* `GatewayServer._listen_handler` -- identity, not
+    truthiness, per the P1 false-green lesson a `getattr` default would
+    reproduce."""
+    gw = _new_server()
+    assert gw._server is not None
+    entry = gw._server.get_request_handler("subscriptions/listen")
+    assert entry is not None, "no handler registered for subscriptions/listen"
+    assert entry.handler is gw._listen_handler
+    assert entry.params_type is mcp_types.SubscriptionsListenRequestParams
+
+
+# --- Construction order: IF-0-P3B-2 ----------------------------------------
+
+
+def test_bus_sink_and_listen_handler_constructed_with_correct_types() -> None:
+    gw = GatewayServer()
+    assert isinstance(gw._subscription_bus, InMemorySubscriptionBus)
+    assert isinstance(gw._catalog_events, BusCatalogEventSink)
+    assert isinstance(gw._listen_handler, ListenHandler)
+
+
+async def test_catalog_events_sink_and_listen_handler_share_one_bus() -> None:
+    """The bus is constructed once and shared: an event published through
+    `gw._catalog_events` (the sink SL-3 will wire `ClientManager` to) is
+    delivered on a stream opened through `gw._listen_handler` (the handler
+    registered on `gw._server`). This is IF-0-P3B-2's construction-order
+    guarantee proven the way that does not require `ClientManager`."""
+    gw = _new_server()
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            _modern_envelope(
+                1, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        ack = await duplex.recv()
+        assert ack["method"] == "notifications/subscriptions/acknowledged"
+
+        gw._catalog_events.note_tools_changed()
+        await gw._catalog_events.flush()
+
+        frame = await duplex.recv()
+        assert frame["method"] == "notifications/tools/list_changed"
+        assert frame["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 1
+
+
+# --- IF-0-P3B-4 duplex flow -------------------------------------------------
+
+
+async def test_ack_is_first_frame_and_stamped_with_request_id() -> None:
+    gw = _new_server()
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            _modern_envelope(
+                7, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        ack = await duplex.recv()
+        assert ack["method"] == "notifications/subscriptions/acknowledged"
+        assert ack["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 7
+
+        await gw._subscription_bus.publish(ToolsListChanged())
+        frame = await duplex.recv()
+        assert frame["method"] == "notifications/tools/list_changed"
+        assert frame["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 7
+
+
+async def test_unrequested_kind_is_never_delivered() -> None:
+    """A tools-only filter never receives a published `PromptsListChanged`."""
+    gw = _new_server()
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            _modern_envelope(
+                7, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        await duplex.recv()  # ack
+
+        await gw._subscription_bus.publish(PromptsListChanged())
+        # Nothing honored by subscription 7 was published; a second,
+        # honored publish is the proof that the first was skipped rather
+        # than merely slow -- if it had been (wrongly) queued, it would
+        # arrive here instead of the tools event.
+        await gw._subscription_bus.publish(ToolsListChanged())
+        frame = await duplex.recv()
+        assert frame["method"] == "notifications/tools/list_changed"
+
+
+async def test_two_concurrent_subscriptions_demultiplexed_by_id() -> None:
+    gw = _new_server()
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            _modern_envelope(
+                7, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        ack7 = await duplex.recv()
+        assert ack7["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 7
+
+        await duplex.send(
+            _modern_envelope(
+                9, "subscriptions/listen", {"notifications": {"promptsListChanged": True}}
+            )
+        )
+        ack9 = await duplex.recv()
+        assert ack9["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 9
+
+        await gw._subscription_bus.publish(ToolsListChanged())
+        frame7 = await duplex.recv()
+        assert frame7["method"] == "notifications/tools/list_changed"
+        assert frame7["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 7
+
+        await gw._subscription_bus.publish(PromptsListChanged())
+        frame9 = await duplex.recv()
+        assert frame9["method"] == "notifications/prompts/list_changed"
+        assert frame9["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 9
+
+
+async def test_cancelled_notification_ends_subscription() -> None:
+    """`notifications/cancelled` carrying the listen request id ends that
+    subscription with **no** result frame and no later delivery. A second,
+    live subscription proves the window: after cancelling id 1, publishing
+    both kinds yields exactly the second subscription's frame, meaning
+    nothing was queued for the cancelled one."""
+    gw = _new_server()
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            _modern_envelope(
+                1, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        await duplex.recv()  # ack id 1
+
+        await duplex.send(
+            _modern_envelope(
+                2, "subscriptions/listen", {"notifications": {"promptsListChanged": True}}
+            )
+        )
+        await duplex.recv()  # ack id 2
+
+        await duplex.send(_cancelled_notification(1))
+        # Let the cancellation land before publishing -- notifications and
+        # the cancellation share no explicit ordering guarantee otherwise.
+        await anyio.sleep(0.2)
+
+        await gw._subscription_bus.publish(ToolsListChanged())  # only id 1 wants this
+        await gw._subscription_bus.publish(PromptsListChanged())  # only id 2 wants this
+
+        frame = await duplex.recv()
+        assert frame["method"] == "notifications/prompts/list_changed"
+        assert frame["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 2
+        assert "id" not in frame, "a notification must not carry a JSON-RPC id"
+
+
+async def test_shutdown_sends_listen_result_before_close() -> None:
+    """`GatewayServer.shutdown()` calls `self._listen_handler.close()` as
+    its first statement; that ends every open stream gracefully, and the
+    final frame on the wire is the JSON-RPC response
+    `{"id": <subscription id>, "result": {..., "resultType": "complete"}}`."""
+    gw = _new_server()
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            _modern_envelope(
+                42, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        await duplex.recv()  # ack
+
+        await gw.shutdown()
+
+        final = await duplex.recv()
+        assert final.get("id") == 42
+        assert "method" not in final, "the terminal frame is a response, not a notification"
+        assert final["result"]["resultType"] == "complete"
+        assert final["result"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 42
+
+
+# --- subscriptions/listen is modern-era only --------------------------------
+
+
+async def test_handshake_era_listen_is_method_not_found() -> None:
+    """A `subscriptions/listen` with no modern `_meta` opens (and stays on)
+    the legacy handshake era, where `validate_client_request` raises
+    `KeyError` for the method -- `runner.py` turns that into
+    `METHOD_NOT_FOUND` (-32601)."""
+    gw = _new_server()
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "subscriptions/listen",
+                "params": {"notifications": {"toolsListChanged": True}},
+            }
+        )
+        response = await duplex.recv()
+        assert response.get("id") == 1
+        assert response["error"]["code"] == mcp_types.METHOD_NOT_FOUND
+
+
+# --- PMCP_MAX_LISTEN_STREAMS concurrency cap --------------------------------
+
+
+async def test_max_listen_streams_rejects_before_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`PMCP_MAX_LISTEN_STREAMS` is read at construction (`_env_int`,
+    default 64); with the cap at 1, a second concurrent listen is rejected
+    -- an error response, never an ack -- while the first stays open. This
+    is the deliberate one-for-one replacement for the
+    `PMCP_MAX_KEEPALIVE_STREAMS` DoS guard SL-4 deletes."""
+    monkeypatch.setenv("PMCP_MAX_LISTEN_STREAMS", "1")
+    gw = _new_server()
+    assert gw._listen_handler._max_subscriptions == 1
+
+    async with duplex_session(gw) as duplex:
+        await duplex.send(
+            _modern_envelope(
+                1, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        ack = await duplex.recv()
+        assert ack["method"] == "notifications/subscriptions/acknowledged"
+
+        await duplex.send(
+            _modern_envelope(
+                2, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+            )
+        )
+        rejection = await duplex.recv()
+        assert rejection.get("id") == 2
+        assert "error" in rejection, "the second listen must be rejected, not acked"

--- a/tests/mcp2x/test_listen_registration.py
+++ b/tests/mcp2x/test_listen_registration.py
@@ -9,22 +9,11 @@ framing, `notifications/cancelled` cancellation), not a handler called
 directly, so the frame-by-frame assertions below are proof of the wired
 system rather than of the SDK in isolation.
 
-**Deliberately not covered here, and why**: IF-0-P3B-2 also calls for
-asserting `gw._client_manager` holds the same `CatalogEventSink` object as
-`gw._catalog_events` (identity). That requires `ClientManager.__init__` to
-accept a `catalog_events` keyword -- SL-3's interface
-(`ClientManager(catalog_events=...)`), owned file `src/pmcp/client/manager.py`,
-not this lane's. On this branch (based on `origin/exec/v11-p3b` at SL-1 only)
-that kwarg does not exist yet, so asserting it here would either edit a file
-this lane does not own or hard-fail this module for a reason outside this
-lane's control -- both wrong per the plan's single-writer rule. Reported to
-the orchestrator; to be added (one line in `server.py`'s `ClientManager(...)`
-call, one assertion here) once SL-3 merges into the integration branch, which
-must happen before SL-5 starts in any case. What *is* proven below instead:
-the bus, the sink, and the listen handler are constructed in the frozen
-order and the sink and the handler demonstrably share one bus (an event
-published through the sink reaches a stream opened via the handler) --
-i.e. everything IF-0-P3B-2 requires that does not need `ClientManager`.
+Also pins IF-0-P3B-2's `ClientManager` wiring, completed once SL-3 landed
+`ClientManager(catalog_events=...)`: `gw._client_manager`'s sink is the
+*same object* as `gw._catalog_events` (identity, not a merely-truthy
+second sink wired to a different bus -- that is exactly how "a listener
+with no publishers" would reappear while every test still passes).
 """
 
 from __future__ import annotations
@@ -159,12 +148,22 @@ def test_bus_sink_and_listen_handler_constructed_with_correct_types() -> None:
     assert isinstance(gw._listen_handler, ListenHandler)
 
 
+def test_client_manager_shares_the_same_catalog_events_sink() -> None:
+    """`gw._client_manager` was constructed with `catalog_events=self._catalog_events`
+    (IF-0-P3B-2): its sink is the *same object* as `gw._catalog_events`, by
+    identity -- a second, merely-truthy sink wired to a different bus would
+    satisfy a truthiness check while silently reintroducing "a listener with
+    no publishers", the failure this phase exists to prevent."""
+    gw = GatewayServer()
+    assert gw._client_manager._catalog_events is gw._catalog_events
+
+
 async def test_catalog_events_sink_and_listen_handler_share_one_bus() -> None:
     """The bus is constructed once and shared: an event published through
-    `gw._catalog_events` (the sink SL-3 will wire `ClientManager` to) is
+    `gw._catalog_events` (the sink `ClientManager` publishes through) is
     delivered on a stream opened through `gw._listen_handler` (the handler
     registered on `gw._server`). This is IF-0-P3B-2's construction-order
-    guarantee proven the way that does not require `ClientManager`."""
+    guarantee proven end to end at the bus/handler level."""
     gw = _new_server()
     async with duplex_session(gw) as duplex:
         await duplex.send(
@@ -238,7 +237,9 @@ async def test_two_concurrent_subscriptions_demultiplexed_by_id() -> None:
 
         await duplex.send(
             _modern_envelope(
-                9, "subscriptions/listen", {"notifications": {"promptsListChanged": True}}
+                9,
+                "subscriptions/listen",
+                {"notifications": {"promptsListChanged": True}},
             )
         )
         ack9 = await duplex.recv()
@@ -272,7 +273,9 @@ async def test_cancelled_notification_ends_subscription() -> None:
 
         await duplex.send(
             _modern_envelope(
-                2, "subscriptions/listen", {"notifications": {"promptsListChanged": True}}
+                2,
+                "subscriptions/listen",
+                {"notifications": {"promptsListChanged": True}},
             )
         )
         await duplex.recv()  # ack id 2
@@ -300,7 +303,9 @@ async def test_shutdown_sends_listen_result_before_close() -> None:
     async with duplex_session(gw) as duplex:
         await duplex.send(
             _modern_envelope(
-                42, "subscriptions/listen", {"notifications": {"toolsListChanged": True}}
+                42,
+                "subscriptions/listen",
+                {"notifications": {"toolsListChanged": True}},
             )
         )
         await duplex.recv()  # ack
@@ -309,7 +314,9 @@ async def test_shutdown_sends_listen_result_before_close() -> None:
 
         final = await duplex.recv()
         assert final.get("id") == 42
-        assert "method" not in final, "the terminal frame is a response, not a notification"
+        assert "method" not in final, (
+            "the terminal frame is a response, not a notification"
+        )
         assert final["result"]["resultType"] == "complete"
         assert final["result"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 42
 

--- a/tests/mcp2x/test_subscription_contract.py
+++ b/tests/mcp2x/test_subscription_contract.py
@@ -1,0 +1,379 @@
+"""SL-1.1 — pin IF-0-P3B-1: the catalog event sink `src/pmcp/subscriptions.py`.
+
+Published on day 1 so SL-2, SL-3 and SL-5 develop against a real type rather
+than a reading of one. Covers the frozen shape end to end: the `Protocol`'s
+exact member set, `note_*` outside and inside a running loop, set-coalescing,
+fixed publish order, the deterministic lost-wakeup regression (a `note_*`
+landing while a publish is suspended), listener isolation against a raising
+bus, and the "no pmcp event type defined" AST guard.
+
+Also carries the CHANGELOG/version half of EC-P3B-6 (SL-1.3): the `##
+[2.0.0]` block, wherever it sits in the file, leads with `### Removed` and
+names both the breaking change (`GET` / `405`) and its replacement
+(`subscriptions/listen`), and the version strings in `pyproject.toml` and
+`src/pmcp/__init__.py` agree with it. The V6 shell greps in the phase plan's
+Verification section are the paired non-standalone half of this.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from mcp.shared.subscriptions import (
+    PromptsListChanged,
+    ResourcesListChanged,
+    ServerEvent,
+    ToolsListChanged,
+)
+
+from pmcp.subscriptions import BusCatalogEventSink, CatalogEventSink
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SUBSCRIPTIONS_MODULE = REPO_ROOT / "src" / "pmcp" / "subscriptions.py"
+
+
+class _RecordingBus:
+    """A minimal `SubscriptionBus` that just records what was published."""
+
+    def __init__(self) -> None:
+        self.published: list[ServerEvent] = []
+
+    async def publish(self, event: ServerEvent) -> None:
+        self.published.append(event)
+
+    def subscribe(self, listener: Callable[[ServerEvent], None]) -> Callable[[], None]:
+        return lambda: None
+
+
+class _GatedBus:
+    """A `SubscriptionBus` whose `publish` suspends on a test-controlled
+    `asyncio.Event`, so a test can land a `note_*` call inside the exact
+    window where the naive "snapshot, publish, exit" drain drops it."""
+
+    def __init__(self) -> None:
+        self.published: list[ServerEvent] = []
+        self.gate = asyncio.Event()
+        self.entered = asyncio.Event()
+
+    async def publish(self, event: ServerEvent) -> None:
+        self.entered.set()
+        await self.gate.wait()
+        self.published.append(event)
+
+    def subscribe(self, listener: Callable[[ServerEvent], None]) -> Callable[[], None]:
+        return lambda: None
+
+
+class _RaisingBus:
+    """A `SubscriptionBus` whose `publish` always raises."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def publish(self, event: ServerEvent) -> None:
+        self.calls += 1
+        raise RuntimeError("boom")
+
+    def subscribe(self, listener: Callable[[ServerEvent], None]) -> Callable[[], None]:
+        return lambda: None
+
+
+# --- IF-0-P3B-1: the Protocol's exact shape -------------------------------
+
+
+def test_catalog_event_sink_is_a_runtime_checkable_protocol_with_four_members() -> None:
+    assert getattr(CatalogEventSink, "_is_protocol", False) is True
+    assert getattr(CatalogEventSink, "_is_runtime_protocol", False) is True
+    members = {name for name in vars(CatalogEventSink) if not name.startswith("_")}
+    assert members == {
+        "note_tools_changed",
+        "note_resources_changed",
+        "note_prompts_changed",
+        "flush",
+    }
+
+
+def test_bus_catalog_event_sink_satisfies_the_protocol() -> None:
+    sink = BusCatalogEventSink(_RecordingBus())
+    assert isinstance(sink, CatalogEventSink)
+
+
+# --- note_* outside a running loop ----------------------------------------
+
+
+def test_note_outside_running_loop_does_not_raise_and_leaves_it_pending() -> None:
+    bus = _RecordingBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()  # no running loop here — must not raise
+
+    assert bus.published == []  # nothing delivered yet: still pending
+
+    asyncio.run(sink.flush())
+
+    assert bus.published == [ToolsListChanged()]
+
+
+# --- set semantics: N writes of one kind coalesce to one event -----------
+
+
+async def test_three_calls_of_one_kind_coalesce_to_one_published_event() -> None:
+    bus = _RecordingBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()
+    sink.note_tools_changed()
+    sink.note_tools_changed()
+    await sink.flush()
+
+    assert bus.published == [ToolsListChanged()]
+
+
+# --- flush() publish order --------------------------------------------
+
+
+async def test_flush_publishes_in_tools_resources_prompts_order() -> None:
+    bus = _RecordingBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_prompts_changed()
+    sink.note_tools_changed()
+    sink.note_resources_changed()
+    await sink.flush()
+
+    assert bus.published == [
+        ToolsListChanged(),
+        ResourcesListChanged(),
+        PromptsListChanged(),
+    ]
+
+
+async def test_flush_is_idempotent_and_a_noop_when_empty() -> None:
+    bus = _RecordingBus()
+    sink = BusCatalogEventSink(bus)
+
+    await sink.flush()
+    assert bus.published == []
+
+    sink.note_tools_changed()
+    await sink.flush()
+    await sink.flush()  # second call: nothing left to drain
+    assert bus.published == [ToolsListChanged()]
+
+
+# --- self-scheduling drain: the correctness mechanism, not flush() --------
+
+
+async def test_note_inside_running_loop_self_schedules_a_drain_with_no_flush_call() -> (
+    None
+):
+    bus = _RecordingBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()  # no flush() anywhere in this test
+    await asyncio.sleep(0.05)
+
+    assert bus.published == [ToolsListChanged()]
+
+
+# --- the deterministic lost-wakeup regression ------------------------------
+
+
+async def test_note_during_a_suspended_publish_is_not_stranded() -> None:
+    """IF-0-P3B-1's drain-loop freeze, proven deterministically.
+
+    A `note_tools_changed()` arms a drain, which pops `{ToolsListChanged}`
+    and suspends inside `bus.publish(...)` (held open by `bus.gate`). While
+    it is suspended, `note_prompts_changed()` runs — the exact lost-wakeup
+    window the plan names: the naive "snapshot, publish, exit" drain has
+    already popped its snapshot and has a live drain task, so this note
+    would decline to re-arm and its event would be stranded. Releasing the
+    gate must still deliver `PromptsListChanged`, and with **no `flush()`
+    call anywhere in this test** — only the self-scheduling drain loop can
+    be responsible for it.
+    """
+    bus = _GatedBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()
+    await bus.entered.wait()  # the drain is now suspended inside publish()
+
+    sink.note_prompts_changed()  # lands in the lost-wakeup window
+
+    bus.gate.set()  # release the first publish
+    # Give the drain loop room to re-check `_pending`, find the prompts
+    # event, and publish it too — no flush() call anywhere in this test.
+    for _ in range(50):
+        if len(bus.published) >= 2:
+            break
+        await asyncio.sleep(0.01)
+
+    assert bus.published == [ToolsListChanged(), PromptsListChanged()]
+
+
+def test_naive_snapshot_and_exit_drain_fails_the_lost_wakeup_regression() -> None:
+    """Proof the regression above is real: replay it against the naive shape
+    the plan describes (pop a snapshot, publish it, exit — no `while` loop,
+    flag cleared unconditionally after the one publish) and confirm it drops
+    the second event. This function is standalone (not a subclass of the
+    frozen sink) so it cannot accidentally exercise the fixed implementation.
+    """
+
+    class _NaiveSink:
+        def __init__(self, bus: _GatedBus) -> None:
+            self._bus = bus
+            self._pending: set[type] = set()
+            self._draining = False
+
+        def note_tools_changed(self) -> None:
+            self._note(ToolsListChanged)
+
+        def note_prompts_changed(self) -> None:
+            self._note(PromptsListChanged)
+
+        def _note(self, kind: type) -> None:
+            self._pending.add(kind)
+            if self._draining:
+                return
+            self._draining = True
+            asyncio.get_running_loop().create_task(self._drain())
+
+        async def _drain(self) -> None:
+            # The naive shape: one snapshot, one publish pass, then exit —
+            # no re-check of `_pending` after the `await` inside publish.
+            kinds, self._pending = self._pending, set()
+            for kind in (ToolsListChanged, ResourcesListChanged, PromptsListChanged):
+                if kind in kinds:
+                    await self._bus.publish(kind())
+            self._draining = False
+
+    async def run() -> list[ServerEvent]:
+        bus = _GatedBus()
+        naive = _NaiveSink(bus)
+        naive.note_tools_changed()
+        await bus.entered.wait()
+        naive.note_prompts_changed()  # sees `_draining is True`, declines to re-arm
+        bus.gate.set()
+        await asyncio.sleep(0.1)
+        return bus.published
+
+    published = asyncio.run(run())
+    # The naive shape drops the prompts event: it never sees a second drain.
+    assert published == [ToolsListChanged()]
+
+
+# --- a raising bus is isolated, and the sink keeps working afterward ------
+
+
+async def test_raising_bus_is_isolated_and_the_sink_still_works_afterward() -> None:
+    bus = _RaisingBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()
+    await asyncio.sleep(0.05)  # the drain must not propagate the exception
+
+    assert bus.calls == 1
+
+    # The drain's live flag must have been cleared despite the exception, or
+    # this second note is silently dropped (mistaken for "a drain is live").
+    sink.note_resources_changed()
+    await asyncio.sleep(0.05)
+
+    assert bus.calls == 2
+
+
+async def test_raising_bus_isolation_also_holds_for_flush() -> None:
+    bus = _RaisingBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()
+    await sink.flush()  # must not raise
+
+    assert bus.calls == 1
+
+
+# --- no pmcp event type is defined; the vocabulary is entirely SDK's ------
+
+
+def test_module_imports_the_sdk_vocabulary_and_defines_no_event_class_of_its_own() -> (
+    None
+):
+    tree = ast.parse(SUBSCRIPTIONS_MODULE.read_text())
+
+    imported_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in (
+            "mcp.shared.subscriptions",
+            "mcp.server.subscriptions",
+        ):
+            imported_names.update(alias.asname or alias.name for alias in node.names)
+
+    assert {
+        "ToolsListChanged",
+        "ResourcesListChanged",
+        "PromptsListChanged",
+    } <= imported_names
+
+    offending = [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef)
+        and not node.bases
+        and node.name.endswith("Changed")
+    ]
+    assert offending == [], f"module defines its own event class(es): {offending}"
+
+
+# --- EC-P3B-6: the release entry, wherever the [2.0.0] block sits --------
+
+
+def _changelog_2_0_0_block() -> str:
+    text = (REPO_ROOT / "CHANGELOG.md").read_text()
+    match = re.search(
+        r"^## \[2\.0\.0\][^\n]*\n(.*?)(?=^## \[|\Z)", text, re.DOTALL | re.MULTILINE
+    )
+    assert match, "CHANGELOG.md has no '## [2.0.0]' heading"
+    return match.group(1)
+
+
+def test_changelog_2_0_0_block_leads_with_removed_and_names_the_breaking_change() -> (
+    None
+):
+    body = _changelog_2_0_0_block()
+
+    subsections = re.findall(r"^### (\w+)", body, re.MULTILINE)
+    assert subsections, f"'## [2.0.0]' block has no ### subsections:\n{body}"
+    assert subsections[0] == "Removed", (
+        f"'## [2.0.0]' block's first subsection is {subsections[0]!r}, expected 'Removed' "
+        "(GET retirement must be the first thing a reader hits)"
+    )
+
+    removed_section = body.split("### ", 2)[1]  # the 'Removed' subsection's own text
+    assert "GET" in removed_section and "405" in removed_section, removed_section
+    assert "subscriptions/listen" in body, (
+        "the replacement must be named in the [2.0.0] block"
+    )
+
+
+def test_pyproject_and_init_version_strings_agree_with_the_changelog_heading() -> None:
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text()
+    init_text = (REPO_ROOT / "src" / "pmcp" / "__init__.py").read_text()
+
+    assert re.search(r'^version = "2\.0\.0"', pyproject_text, re.MULTILINE), (
+        pyproject_text
+    )
+    assert re.search(r'^__version__ = "2\.0\.0"', init_text, re.MULTILINE), init_text
+
+    # And the [2.0.0] block itself must exist (redundant with the test
+    # above, but this is the one place all three sites are checked together).
+    _changelog_2_0_0_block()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/mcp2x/test_subscription_contract.py
+++ b/tests/mcp2x/test_subscription_contract.py
@@ -377,3 +377,36 @@ def test_pyproject_and_init_version_strings_agree_with_the_changelog_heading() -
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+@pytest.mark.asyncio
+async def test_cancelled_drain_does_not_wedge_the_sink() -> None:
+    """A drain cancelled mid-publish must still clear `_draining`.
+
+    Without the `finally`, an un-cleared flag leaves every later `note_*`
+    seeing a live drain, declining to re-arm, and silently never publishing
+    again -- the lost-wakeup failure re-entering through cancellation rather
+    than through the snapshot-and-exit shape.
+    """
+    bus = _GatedBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()
+    await bus.entered.wait()  # drain is suspended inside publish
+
+    # Cancel the in-flight drain task, as an event-loop teardown would.
+    for task in list(sink._drain_tasks):
+        task.cancel()
+    await asyncio.gather(*sink._drain_tasks, return_exceptions=True)
+
+    assert sink._draining is False, "cancelled drain wedged the sink"
+
+    # And the sink still works: a fresh note re-arms and delivers.
+    bus.gate.set()
+    bus.published.clear()
+    sink.note_prompts_changed()
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if any(isinstance(e, PromptsListChanged) for e in bus.published):
+            break
+    assert any(isinstance(e, PromptsListChanged) for e in bus.published)

--- a/tests/mcp2x/test_subscription_contract.py
+++ b/tests/mcp2x/test_subscription_contract.py
@@ -380,6 +380,70 @@ if __name__ == "__main__":
 
 
 @pytest.mark.asyncio
+async def test_cancellation_before_the_drain_starts_does_not_wedge_the_sink() -> None:
+    """Cancelling during `_drain`'s initial yield must still clear the flag.
+
+    The first fix put `await asyncio.sleep(0)` *outside* the `try`, so a
+    cancellation landing on that yield skipped the `finally` entirely and
+    left `_draining` True forever with the event still pending.
+    """
+    bus = _GatedBus()
+    sink = BusCatalogEventSink(bus)
+
+    bus.gate.set()  # publish should not block once a drain finally runs
+    sink.note_tools_changed()
+    # Cancel before the task has run at all -- it is still at `sleep(0)`.
+    for task in list(sink._drain_tasks):
+        task.cancel()
+    await asyncio.gather(*sink._drain_tasks, return_exceptions=True)
+
+    # The property that matters is delivery, not the flag: the sink must
+    # re-arm itself and publish the still-pending event with no further
+    # `note_*` to prod it. (`_draining` may legitimately be True right here
+    # -- that is the *replacement* drain being live, not a wedge.)
+    for _ in range(100):
+        await asyncio.sleep(0.01)
+        if any(isinstance(e, ToolsListChanged) for e in bus.published):
+            break
+    assert any(isinstance(e, ToolsListChanged) for e in bus.published), (
+        f"pre-start cancellation stranded the event: {bus.published}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_noted_during_a_cancelled_drain_is_not_stranded() -> None:
+    """A note landing while a drain is in flight must still be delivered
+    even if that drain is then cancelled -- **without** a later unrelated
+    note to re-arm the sink.
+
+    The earlier version of this test issued a fresh note after cancelling,
+    which re-armed the drain and masked the stranding it claimed to rule
+    out. Nothing here notes anything after the cancellation.
+    """
+    bus = _GatedBus()
+    sink = BusCatalogEventSink(bus)
+
+    sink.note_tools_changed()
+    await bus.entered.wait()  # drain suspended inside publish
+
+    sink.note_prompts_changed()  # lands while the drain is in flight
+    for task in list(sink._drain_tasks):
+        task.cancel()
+    bus.gate.set()
+    await asyncio.gather(*sink._drain_tasks, return_exceptions=True)
+
+    # No further note_* -- the re-arm must come from the sink itself.
+    for _ in range(100):
+        await asyncio.sleep(0.01)
+        if any(isinstance(e, PromptsListChanged) for e in bus.published):
+            break
+    assert any(isinstance(e, PromptsListChanged) for e in bus.published), (
+        f"event noted during a cancelled drain was stranded: {bus.published}"
+    )
+    assert sink._draining is False
+
+
+@pytest.mark.asyncio
 async def test_cancelled_drain_does_not_wedge_the_sink() -> None:
     """A drain cancelled mid-publish must still clear `_draining`.
 

--- a/tests/runtime/harness.py
+++ b/tests/runtime/harness.py
@@ -24,14 +24,25 @@ Provides:
     one `text/event-stream` `data:` frame — IF-0-P2-4, Execution Notes >
     "EC-P2-6 must go over the deployed HTTP wire").
   - `RT_FIXTURE_SRC` — a real stdio `mcp.server.MCPServer` (2.0.0) exposing
-    one tool and one prompt, registered as the harness gateway's sole
-    `autoStart` downstream so `prompts/list`/`prompts/get` (which pmcp only
-    ever proxies from a live downstream — there is no built-in prompt) have
+    one tool, one prompt, and (SL-5.1) one resource, registered as the
+    harness gateway's sole `autoStart` downstream so `prompts/list`/
+    `prompts/get` and `resources/list`/`resources/read` (which pmcp only
+    ever proxies from a live downstream — there are no built-ins) have
     real typed content to exercise.
+  - `listen_envelope()` / `listen_stream()` (SL-5.1) — build and open an
+    IF-0-P3B-4 `subscriptions/listen` POST over the deployed HTTP wire,
+    yielding a `ListenStream` with `next_frame(timeout)` / `close()` for
+    incremental reads — `decode_modern_response` cannot be reused for a
+    listen stream because it reads a *complete* response and a listen
+    stream never completes on its own.
+  - `booted_gateway(..., request_timeout=<n>)` (SL-5.1) — appends
+    `--request-timeout <n>` to the boot command, for the V4b / EC-P3B-4
+    deployed-wire timeout-exemption regression.
 """
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import os
@@ -41,8 +52,8 @@ import socket
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterator
-from dataclasses import dataclass
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -77,6 +88,14 @@ def rt_echo(text: str) -> str:
 def rt_greeting(name: str) -> str:
     """Greet someone by name."""
     return f"Hello, {name}!"
+
+
+@mcp.resource("rt-fixture://greeting-card")
+def rt_greeting_card() -> str:
+    """A static resource, present (SL-5.1) so EC-P3B-4 has real resource
+    content to exercise -- before this the fixture exposed only a tool and
+    a prompt, leaving resources/list_changed with nothing to prove against."""
+    return "rt-fixture: a greeting card"
 
 
 if __name__ == "__main__":
@@ -140,13 +159,27 @@ def booted_gateway(
     *,
     extra_servers: dict[str, Any] | None = None,
     extra_allowlist: list[str] | None = None,
+    extra_servers_no_autostart: dict[str, Any] | None = None,
+    request_timeout: int | None = None,
 ) -> Iterator[BootedGateway]:
     """Boot one fully isolated gateway with the `rt-fixture` stdio downstream
     eagerly started, on a spare port never `:3344`.
 
     `extra_servers` / `extra_allowlist` let a caller (e.g. SL-4.5's mcp-1.x
     downstream) add another `mcpServers` entry to the same isolated boot
-    without duplicating the isolation plumbing.
+    without duplicating the isolation plumbing. `extra_servers_no_autostart`
+    (SL-5.1) is the same idea but for a server that must exist in config
+    and be allowlisted while starting out *disconnected* -- needed for
+    EC-P3B-4, where `gateway.connect_server` must be a real first connect
+    (a server already running via `autoStart` would make that call a no-op,
+    and no catalog mutation means no publish to prove against).
+
+    `request_timeout` (SL-5.1), when given, appends `--request-timeout <n>`
+    to the boot command (the flag exists at `src/pmcp/cli.py:232`, also
+    honoured as `PMCP_REQUEST_TIMEOUT`). Used by the V4b / EC-P3B-4 deployed-
+    wire regression: a `subscriptions/listen` stream must outlive this
+    timeout (IF-0-P3B-3's exemption), which a short `request_timeout` proves
+    directly rather than waiting out the 60s default.
 
     Guarantees, matching Execution Notes > "Runtime-step safety" and
     "Boot isolation requires all six controls together" verbatim:
@@ -199,9 +232,16 @@ def booted_gateway(
         }
         if extra_servers:
             servers.update(extra_servers)
+        if extra_servers_no_autostart:
+            servers.update(extra_servers_no_autostart)
         auto_start = sorted({"rt-fixture", *(extra_servers or {})})
         allowlist = sorted(
-            {"rt-fixture", *(extra_allowlist or []), *(extra_servers or {})}
+            {
+                "rt-fixture",
+                *(extra_allowlist or []),
+                *(extra_servers or {}),
+                *(extra_servers_no_autostart or {}),
+            }
         )
 
         config_path = work / "config.json"
@@ -243,6 +283,8 @@ def booted_gateway(
             "-l",
             "info",
         ]
+        if request_timeout is not None:
+            command.extend(["--request-timeout", str(request_timeout)])
         with open(boot_log, "w") as log_fh:
             proc = subprocess.Popen(
                 command,
@@ -350,6 +392,83 @@ def decode_modern_response(response: httpx.Response) -> dict[str, Any]:
         )
         return json.loads(data_lines[-1][len("data:") :].strip())  # noqa: E203
     return response.json()
+
+
+def listen_envelope(
+    *, notifications: dict[str, bool], request_id: int = 1
+) -> tuple[dict[str, str], dict[str, Any]]:
+    """IF-0-P3B-4 wire envelope for a `subscriptions/listen` POST, built on
+    top of `modern_envelope` with the JSON-RPC id overridden to
+    `request_id` so concurrent subscriptions (e.g. EC-P3B-4's A/B) can be
+    told apart by `SUBSCRIPTION_ID_META_KEY`. `notifications` is passed in
+    wire (camelCase) form -- pmcp's own Python source constructs
+    `SubscriptionFilter` with field names; only JSON test payloads use the
+    alias."""
+    headers, body = modern_envelope(
+        "subscriptions/listen", {"notifications": notifications}
+    )
+    body["id"] = request_id
+    return headers, body
+
+
+@dataclass
+class ListenStream:
+    """Incremental reader for one open `subscriptions/listen` SSE stream.
+
+    `decode_modern_response` cannot be reused here -- it reads a *complete*
+    response, and a listen stream never completes on its own.
+    """
+
+    response: httpx.Response
+    _lines: AsyncIterator[str] = field(repr=False)
+    _client: httpx.AsyncClient = field(repr=False)
+
+    async def next_frame(self, timeout: float = 10.0) -> dict[str, Any]:
+        """The next decoded `data:` payload, skipping `: ping` comment
+        lines (IF-0-P3B-4's 15s keepalive) and blank lines."""
+
+        async def _read() -> dict[str, Any]:
+            async for line in self._lines:
+                if line.startswith("data:"):
+                    return json.loads(line[len("data:") :].strip())  # noqa: E203
+            raise AssertionError("listen stream ended before a data: frame arrived")
+
+        return await asyncio.wait_for(_read(), timeout=timeout)
+
+    async def close(self) -> None:
+        """End the subscription from the client side (a real disconnect,
+        not a pooled return) -- idempotent."""
+        await self._client.aclose()
+
+
+@contextlib.asynccontextmanager
+async def listen_stream(
+    base_url: str,
+    *,
+    notifications: dict[str, bool],
+    timeout: float = 30.0,
+    request_id: int = 1,
+) -> AsyncIterator[ListenStream]:
+    """Open a `subscriptions/listen` POST against `<base_url>/mcp`
+    (IF-0-P3B-4) and yield an incremental `ListenStream` reader for the
+    duration of the `async with` block. `timeout` bounds each `next_frame`
+    read via `ListenStream`'s own default, not the connection's lifetime --
+    a listen stream is long-lived by design (IF-0-P3B-3)."""
+    headers, body = listen_envelope(notifications=notifications, request_id=request_id)
+    client = httpx.AsyncClient(timeout=None)
+    try:
+        async with client.stream(
+            "POST", f"{base_url}/mcp", headers=headers, json=body, timeout=timeout
+        ) as response:
+            assert response.status_code == 200, (response.status_code, response.text)
+            assert "text/event-stream" in response.headers.get("content-type", ""), (
+                response.headers.get("content-type")
+            )
+            yield ListenStream(
+                response=response, _lines=response.aiter_lines(), _client=client
+            )
+    finally:
+        await client.aclose()
 
 
 def modern_post(

--- a/tests/runtime/test_downstream_remote.py
+++ b/tests/runtime/test_downstream_remote.py
@@ -156,10 +156,20 @@ async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
             # has its own one-time socket cost (control connection +
             # standalone SSE listener), which is not what this proves.
             # What matters is that cycles 2-5 add nothing further — every
-            # count in socket_counts_by_cycle[1:] must equal the first.
+            # count in socket_counts_by_cycle[1:] must be no greater than
+            # the first. Not strict equality (SL-5 fix, inherited from P2):
+            # a late-closing socket from the *previous* cycle's teardown can
+            # still be in FIN_WAIT/closing when the *next* cycle's count is
+            # sampled, making a later sample transiently *lower* than an
+            # earlier one (observed under concurrent load: [11,11,11,11,9]).
+            # A strict `==` fails on that decrease and its own message then
+            # claims the count "grew", sending the next reader hunting a
+            # leak that isn't there. The property this proves is "no
+            # growth", not "no fluctuation" — `<=` is what that means.
             baseline = socket_counts_by_cycle[0]
-            assert all(count == baseline for count in socket_counts_by_cycle[1:]), (
-                f"socket count grew across reconnect cycles: {socket_counts_by_cycle}"
+            assert all(count <= baseline for count in socket_counts_by_cycle[1:]), (
+                "socket count grew across reconnect cycles (a leak): "
+                f"baseline={baseline}, counts={socket_counts_by_cycle}"
             )
     finally:
         # disconnect_server (not disconnect_all, whose concurrent gather of

--- a/tests/runtime/test_get_retired.py
+++ b/tests/runtime/test_get_retired.py
@@ -1,0 +1,122 @@
+"""SL-5.3 — EC-P3B-3 over the deployed HTTP wire.
+
+Measured spike 2b (`plans/phase-plan-v11-P3B.md`) found that on pre-P3B
+code, `GET /mcp` with `Accept: text/event-stream` hangs indefinitely rather
+than answering -- pmcp's own rmcp-compat keep-alive shim intercepted it
+before the request ever reached the session manager. IF-0-P3B-3 retires
+that shim entirely: `/mcp`'s `Route` no longer lists `GET`, so Starlette's
+own router answers `405` with `Allow: POST, DELETE` before any pmcp
+handler code runs at all.
+
+Every GET here uses a bounded `httpx` timeout -- the bound itself is part
+of the assertion, exactly as the plan's V2 shell step does with
+`curl --max-time 5`: on today's (pre-P3B) code this would time out rather
+than return promptly.
+"""
+
+from __future__ import annotations
+
+import httpx
+from mcp.types import CallToolResult
+
+from pmcp import __version__
+from tests.runtime.harness import BootedGateway, modern_post
+
+_GET_TIMEOUT = 5.0
+
+
+class TestGetRetired:
+    """`GET /mcp` answers 405 promptly, in every header combination a real
+    client might send, rather than hanging."""
+
+    def test_get_with_sse_accept_and_protocol_version_is_405(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        response = httpx.get(
+            gateway_on_spare_port.mcp_url,
+            headers={
+                "Accept": "text/event-stream",
+                "MCP-Protocol-Version": "2026-07-28",
+            },
+            timeout=_GET_TIMEOUT,
+        )
+        assert response.status_code == 405
+        assert "POST" in response.headers.get("allow", "")
+
+    def test_get_with_no_accept_header_is_405(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        response = httpx.get(gateway_on_spare_port.mcp_url, timeout=_GET_TIMEOUT)
+        assert response.status_code == 405
+        assert "POST" in response.headers.get("allow", "")
+
+    def test_get_with_an_mcp_session_id_header_is_405(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        """The retired pre-session shim only fired for a GET with *no*
+        session id (a real session-bound GET was legacy-only and reached
+        the session manager); after retirement, GET is 405 regardless."""
+        response = httpx.get(
+            gateway_on_spare_port.mcp_url,
+            headers={
+                "Accept": "text/event-stream",
+                "mcp-session-id": "does-not-exist",
+            },
+            timeout=_GET_TIMEOUT,
+        )
+        assert response.status_code == 405
+        assert "POST" in response.headers.get("allow", "")
+
+    def test_get_without_session_id_or_accept_is_405(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        response = httpx.get(
+            gateway_on_spare_port.mcp_url,
+            headers={"Accept": "application/json"},
+            timeout=_GET_TIMEOUT,
+        )
+        assert response.status_code == 405
+        assert "POST" in response.headers.get("allow", "")
+
+
+class TestHealthAndMetricsSurviveRetirement:
+    """`/health` and `/metrics` are separate `Route`s and are untouched by
+    the `/mcp` GET retirement."""
+
+    def test_health_reports_the_running_version(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        response = httpx.get(
+            f"{gateway_on_spare_port.base_url}/health", timeout=_GET_TIMEOUT
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["version"] == __version__
+
+    def test_metrics_reports_requests_total(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        response = httpx.get(
+            f"{gateway_on_spare_port.base_url}/metrics", timeout=_GET_TIMEOUT
+        )
+        assert response.status_code == 200
+        assert "text/plain" in response.headers.get("content-type", "")
+        assert "pmcp_requests_total" in response.text
+
+
+class TestPostStillWorksAfterRetirement:
+    """The route-table change did not break the live POST method path."""
+
+    def test_tools_call_still_succeeds(
+        self, gateway_on_spare_port: BootedGateway
+    ) -> None:
+        raw = modern_post(
+            gateway_on_spare_port.base_url,
+            "tools/call",
+            {"name": "gateway.health", "arguments": {}},
+            name="gateway.health",
+        )
+        assert "error" not in raw, raw
+        result = CallToolResult.model_validate(raw["result"])
+        assert result.is_error is False

--- a/tests/runtime/test_harness.py
+++ b/tests/runtime/test_harness.py
@@ -4,11 +4,21 @@
 name), so a command targeting only them verifies nothing — this is the
 collectable module SL-4.1 requires. Every other tests/runtime/ module
 depends on these guarantees holding.
+
+SL-5.1 adds three more sections below: the incremental `listen_stream`
+reader against a real booted gateway, `RT_FIXTURE_SRC` gaining a resource,
+and `booted_gateway(request_timeout=...)`.
 """
 
 from __future__ import annotations
 
-from tests.runtime.harness import INITIALIZED_RE, LIVE_GATEWAY_PORT, booted_gateway
+from tests.runtime.harness import (
+    INITIALIZED_RE,
+    LIVE_GATEWAY_PORT,
+    booted_gateway,
+    listen_stream,
+    modern_post,
+)
 
 
 def test_boot_never_binds_the_live_gateway_port() -> None:
@@ -48,3 +58,72 @@ def test_live_gateway_pid_and_children_are_unchanged_across_a_full_cycle() -> No
     import."""
     with booted_gateway():
         pass
+
+
+# --- SL-5.1: listen_stream() — an incremental SSE reader --------------------
+
+
+async def test_listen_stream_yields_the_ack_frame() -> None:
+    """Against a real booted gateway's `/mcp`, opening a subscription
+    returns a `ListenStream` whose first `next_frame()` is the
+    IF-0-P3B-4 ack, carrying the request's id as its subscriptionId."""
+    from mcp.shared.subscriptions import SUBSCRIPTION_ID_META_KEY
+
+    with booted_gateway() as gw:
+        async with listen_stream(
+            gw.base_url, notifications={"toolsListChanged": True}, request_id=91
+        ) as stream:
+            frame = await stream.next_frame()
+            assert frame["method"] == "notifications/subscriptions/acknowledged"
+            assert frame["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 91, frame
+            await stream.close()
+
+
+# --- SL-5.1: RT_FIXTURE_SRC gains a resource ---------------------------------
+
+
+def test_rt_fixture_exposes_a_resource() -> None:
+    """`RT_FIXTURE_SRC` must expose a resource (not just a tool and a
+    prompt) so EC-P3B-4 has real resource content to prove
+    `resources/list_changed` delivery against."""
+    with booted_gateway() as gw:
+        result = modern_post(gw.base_url, "resources/list")
+        resources = result["result"]["resources"]
+        assert resources, "RT_FIXTURE_SRC must expose at least one resource"
+
+
+# --- SL-5.1: booted_gateway(request_timeout=...) -----------------------------
+
+
+def test_booted_gateway_request_timeout_kwarg_reaches_the_command() -> None:
+    """`request_timeout` appends `--request-timeout <n>` to the boot
+    command (`src/pmcp/cli.py:232`) -- the flag the V4b regression needs to
+    force a short timeout and then prove a subscription outlives it."""
+    with booted_gateway(request_timeout=5) as gw:
+        assert "--request-timeout" in gw.command
+        idx = gw.command.index("--request-timeout")
+        assert gw.command[idx + 1] == "5"
+
+
+def test_booted_gateway_default_omits_request_timeout_flag() -> None:
+    """No `request_timeout` given -> no flag added; `pmcp` falls back to
+    its own default (60s) rather than the harness silently picking one."""
+    with booted_gateway() as gw:
+        assert "--request-timeout" not in gw.command
+
+
+def test_booted_gateway_tolerates_no_live_gateway() -> None:
+    """`booted_gateway()`'s `live_pid is None` tolerance must hold on a
+    runner with no `:3344` unit -- a hard live-gateway requirement here
+    would fail this whole module on CI (Execution Notes > "Everything in
+    tests/runtime/ must pass on a CI runner with no live gateway")."""
+    from tests.runtime.harness import _live_gateway_pid
+
+    live_pid = _live_gateway_pid()
+    with booted_gateway() as gw:
+        # Either there genuinely is no live gateway (CI), or there is one
+        # and the boot still succeeded without touching it -- both are
+        # this fixture working as designed.
+        assert gw.port != LIVE_GATEWAY_PORT
+    if live_pid is None:
+        assert _live_gateway_pid() is None

--- a/tests/runtime/test_publisher_coverage.py
+++ b/tests/runtime/test_publisher_coverage.py
@@ -156,6 +156,16 @@ def test_ast_guard_actually_finds_writes() -> None:
     assert _PUBLISHING_METHODS <= found_functions, (
         f"expected writes from {_PUBLISHING_METHODS}, saw {found_functions}"
     )
+    # __init__'s write must be seen too, specifically via ast.AnnAssign
+    # (its `self._tools: dict[...] = {}` is annotated) -- without that
+    # visitor method the exemption in the test below would be vacuous: it
+    # would never fire because __init__ would never appear as a writer at
+    # all. This is the exact hole the plan's ast.AnnAssign requirement
+    # exists to close.
+    assert "__init__" in found_functions, (
+        "AST walk never saw __init__ write to a catalog dict -- "
+        "visit_AnnAssign is broken and the __init__ exemption is vacuous"
+    )
 
 
 def test_every_catalog_write_is_in_a_publishing_mutator_or_init() -> None:

--- a/tests/runtime/test_publisher_coverage.py
+++ b/tests/runtime/test_publisher_coverage.py
@@ -1,0 +1,200 @@
+"""SL-5.4 — the AST honesty guard for IF-0-P3B-1's "self-scheduling is the
+correctness mechanism, not the flush call sites" claim (Execution Notes >
+Decision 2).
+
+`ClientManager` mutates `self._tools` / `self._resources` / `self._prompts`
+from exactly five publishing methods (`_index_tools`, `_index_resources`,
+`_index_prompts`, `_remove_server_indexes`, `_disconnect_all_unlocked`) plus
+the one deliberately-exempt `__init__` (no bus/sink exists at construction
+-- see `plans/phase-plan-v11-P3B.md`, Context > "The publisher gap").
+Rather than trusting that partition to stay accurate as `client/manager.py`
+grows, this module parses the file with `ast` and fails, naming the
+offending function, if a write to one of the three catalog dicts ever
+appears anywhere else. This is what keeps EC-P3B-4 true *after* the phase,
+not just on the day it was written -- modelled on P5's
+`test_credential_predicate_guard.py`.
+
+The two sets below are separate constants with a comment on the exemption
+specifically so that silencing a future failure by widening the allowlist
+is a visible, greppable edit rather than an invisible one.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MANAGER_PATH = REPO_ROOT / "src" / "pmcp" / "client" / "manager.py"
+
+_TARGET_ATTRS = {"_tools", "_resources", "_prompts"}
+
+# The five methods allowed to write to a catalog dict -- each of them must
+# also call a matching `self._catalog_events.note_*` (checked below).
+_PUBLISHING_METHODS = {
+    "_index_tools",
+    "_index_resources",
+    "_index_prompts",
+    "_remove_server_indexes",
+    "_disconnect_all_unlocked",
+}
+
+# The ONE exempt writer: `__init__`'s annotated empty-dict construction.
+# No bus, no sink, and no subscriber can exist yet at that point (IF-0-P3B-1),
+# so publishing there is not just unnecessary but impossible to do honestly.
+# Widening this set to silence a failure is exactly the mistake this test
+# exists to catch -- do not add a name here without a comment explaining why
+# the new writer genuinely cannot publish.
+_EXEMPT_METHODS = {"__init__"}
+
+
+def _self_attr_name(node: ast.AST) -> str | None:
+    """If `node` is `self._tools` / `self._resources` / `self._prompts`
+    (an `ast.Attribute` on `ast.Name('self')`), return the attr name."""
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+        and node.attr in _TARGET_ATTRS
+    ):
+        return node.attr
+    return None
+
+
+class _WriteFinder(ast.NodeVisitor):
+    """Walks the module tracking the enclosing function for every node, and
+    records: (a) every write to a catalog dict, attributed to its enclosing
+    function; (b) every `self._catalog_events.note_*(...)` call, also
+    attributed to its enclosing function."""
+
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, str]] = []
+        self.note_calls: dict[str, set[str]] = {}
+        self._func_stack: list[str] = []
+
+    def _current_func(self) -> str:
+        assert self._func_stack, (
+            "a write to a catalog dict outside any function -- module-level "
+            "state is not this guard's model and should not exist"
+        )
+        return self._func_stack[-1]
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            self._check_write_target(target)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        # Required for __init__'s annotated `self._tools: dict[...] = {}`
+        # (client/manager.py:497-499) to be matched at all -- without this
+        # visitor method the exemption above would be vacuous, because the
+        # one write __init__ makes would simply never be seen.
+        self._check_write_target(node.target)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._check_write_target(node.target)
+        self.generic_visit(node)
+
+    def _check_write_target(self, target: ast.AST) -> None:
+        attr = _self_attr_name(target)
+        if attr is not None:
+            self.writes.append((self._current_func(), attr))
+            return
+        if isinstance(target, ast.Subscript):
+            attr = _self_attr_name(target.value)
+            if attr is not None:
+                self.writes.append((self._current_func(), attr))
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in {"pop", "clear"}:
+            attr = _self_attr_name(func.value)
+            if attr is not None:
+                self.writes.append((self._current_func(), attr))
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr
+            in {"note_tools_changed", "note_resources_changed", "note_prompts_changed"}
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "_catalog_events"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "self"
+            and self._func_stack
+        ):
+            self.note_calls.setdefault(self._func_stack[-1], set()).add(func.attr)
+        self.generic_visit(node)
+
+
+def _parse_manager() -> _WriteFinder:
+    tree = ast.parse(MANAGER_PATH.read_text())
+    finder = _WriteFinder()
+    finder.visit(tree)
+    return finder
+
+
+def test_ast_guard_actually_finds_writes() -> None:
+    """A guard that silently matches nothing is worse than no guard --
+    pin that the walk finds the writes we know are there, so a refactor of
+    this test file itself can't turn it into a vacuous pass."""
+    finder = _parse_manager()
+    assert finder.writes, "AST walk over client/manager.py found zero writes"
+    found_functions = {func for func, _attr in finder.writes}
+    # Every publishing method must actually appear as a writer -- otherwise
+    # the offender-detection below would be trivially satisfied by a
+    # manager.py that stopped writing to the catalogs altogether.
+    assert _PUBLISHING_METHODS <= found_functions, (
+        f"expected writes from {_PUBLISHING_METHODS}, saw {found_functions}"
+    )
+
+
+def test_every_catalog_write_is_in_a_publishing_mutator_or_init() -> None:
+    """The honesty guard itself: every write to `self._tools` /
+    `self._resources` / `self._prompts` must be inside one of the five
+    publishing mutators, or `__init__` (the one named, commented exemption).
+    A new mutation path added anywhere else fails here with the offending
+    function's name."""
+    finder = _parse_manager()
+    offenders = [
+        (func, attr)
+        for func, attr in finder.writes
+        if func not in _PUBLISHING_METHODS and func not in _EXEMPT_METHODS
+    ]
+    assert not offenders, (
+        "write(s) to a catalog dict outside the five publishing mutators "
+        f"(or the exempt __init__): {offenders} -- either route the write "
+        "through a publishing mutator, or widen _PUBLISHING_METHODS with a "
+        "comment explaining why the new site is safe to skip"
+    )
+
+
+def test_each_publishing_mutator_calls_a_note_method() -> None:
+    """Every one of the five publishing mutators must call at least one
+    `self._catalog_events.note_*` -- a mutator that writes to a catalog dict
+    but calls no `note_*` is exactly the listener-with-no-publishers defect
+    this phase exists to prevent."""
+    finder = _parse_manager()
+    for method in sorted(_PUBLISHING_METHODS):
+        assert method in finder.note_calls, (
+            f"{method} writes to a catalog dict but never calls a "
+            "self._catalog_events.note_* method"
+        )
+
+
+def test_init_writes_no_note_call() -> None:
+    """`__init__` is exempt precisely because no sink/bus/subscriber exists
+    yet -- pin that it is not accidentally calling `note_*` either (which
+    would mean a real bus publish before `BusCatalogEventSink` is built,
+    the ordering IF-0-P3B-2 exists to prevent)."""
+    finder = _parse_manager()
+    assert finder.note_calls.get("__init__", set()) == set()

--- a/tests/runtime/test_subscriptions_e2e.py
+++ b/tests/runtime/test_subscriptions_e2e.py
@@ -1,0 +1,234 @@
+"""SL-5.2 — EC-P3B-4: the phase's headline end-to-end subscription
+acceptance, and the deployed-wire regression for the `request_timeout`
+truncation measured spike 2 found.
+
+Two subscriptions are opened over one booted gateway's deployed `/mcp`:
+
+- A, filtered to all three kinds (tools + resources + prompts). The
+  roadmap requires the client receive the *corresponding* notification for
+  a catalog mutation -- a tools-only assertion would let a broken
+  prompts/resources publisher ship, so every mutation below is checked
+  against all three kinds on A.
+- B, filtered to tools only, held open concurrently. This is the
+  filter-negative, kept on a *separate* subscription deliberately: folding
+  it into A would make "resources never arrives" double as this phase's
+  only resources coverage, which would pass against a completely broken
+  resources publisher.
+
+The catalog mutation is driven by real `gateway.connect_server` /
+`gateway.disconnect_server` / `gateway.refresh` tool calls over the same
+deployed wire (`modern_post`) against a *second* fixture downstream that
+starts configured and allowlisted but not auto-started, so
+`gateway.connect_server` is a genuine first connect rather than a no-op --
+`booted_gateway`'s `extra_servers_no_autostart` (SL-5.1) exists for exactly
+this. No test in this module calls `note_*`, `flush`, or `bus.publish`;
+the catalog mutation is the only trigger, which is what EC-P3B-4 requires.
+
+`gateway.refresh` is diff-based (`tools/handlers.py`, "Diff-based
+refresh"): a server that is lazy (never in `autoStart`) and currently
+disconnected is left alone by a bare refresh -- it is not proactively
+reconnected. To exercise refresh's own reconnect path honestly (rather
+than defeating the diff logic by pre-connecting), this module rewrites
+the isolated boot's on-disk `config.json` between the disconnect and
+refresh steps to add the second downstream to `autoStart`, modelling an
+operator who adds an autoStart entry and refreshes.
+
+The gateway is booted with `request_timeout=5` (SL-5.1's harness keyword)
+and an explicit sleep pushes the refresh step's notification past t=12s --
+IF-0-P3B-3's `subscriptions/listen` exemption from the `request_timeout`
+wrapper is what keeps the stream alive that long; on pre-P3B code (or a
+regression that drops the exemption) this module fails outright because
+the connection is truncated at t=5s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import time
+from pathlib import Path
+
+from mcp.shared.subscriptions import SUBSCRIPTION_ID_META_KEY
+from mcp.types import CallToolResult
+
+from tests.runtime.harness import (
+    REPO_ROOT,
+    RT_FIXTURE_SRC,
+    ListenStream,
+    booted_gateway,
+    listen_stream,
+    modern_post,
+)
+
+_SECOND_DOWNSTREAM = "rt-fixture-2"
+
+_ALL_THREE = {
+    "notifications/tools/list_changed",
+    "notifications/resources/list_changed",
+    "notifications/prompts/list_changed",
+}
+_TOOLS_ONLY = {"notifications/tools/list_changed"}
+
+
+def _call_tool(base_url: str, tool_name: str, arguments: dict) -> CallToolResult:
+    """Drive one `gateway.*` tool call over the deployed wire and require
+    it to have actually succeeded -- both the JSON-RPC layer (no `error`
+    key) and the CallToolResult layer (`isError` is not True), so a
+    lifecycle failure reported only via `isError` can't slip past a bare
+    `"error" not in raw` check."""
+    raw = modern_post(
+        base_url,
+        "tools/call",
+        {"name": tool_name, "arguments": arguments},
+        name=tool_name,
+    )
+    assert "error" not in raw, raw
+    result = CallToolResult.model_validate(raw["result"])
+    assert result.is_error is not True, result
+    return result
+
+
+async def _read_until(
+    stream: ListenStream, wanted: set[str], *, budget: float, log: list[dict]
+) -> dict[str, dict]:
+    """Read frames off `stream` until every method in `wanted` has been
+    seen at least once (or `budget` elapses), recording *every* frame
+    read -- including ones outside `wanted` -- into `log` so a caller can
+    later assert a negative (a kind that must never arrive) over the full
+    run, not just the window this particular call watched."""
+    deadline = time.monotonic() + budget
+    found: dict[str, dict] = {}
+    while len(found) < len(wanted):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        frame = await stream.next_frame(timeout=remaining)
+        log.append(frame)
+        method = frame.get("method")
+        if method in wanted and method not in found:
+            found[method] = frame
+    missing = wanted - found.keys()
+    assert not missing, (
+        f"timed out after {budget}s waiting for {missing}; "
+        f"frames seen so far: {[f.get('method') for f in log]}"
+    )
+    return found
+
+
+def _assert_stamped(frames: dict[str, dict], subscription_id: int) -> None:
+    for method, frame in frames.items():
+        assert frame["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == subscription_id, (
+            method,
+            frame,
+        )
+
+
+async def test_connect_disconnect_refresh_each_deliver_all_three_kinds() -> None:
+    with tempfile.TemporaryDirectory(prefix="pmcp-rt2-") as fixture_dir:
+        fixture_path = Path(fixture_dir) / "rt_fixture2.py"
+        fixture_path.write_text(RT_FIXTURE_SRC)
+        second_server = {
+            _SECOND_DOWNSTREAM: {
+                "command": str(REPO_ROOT / ".venv" / "bin" / "python"),
+                "args": [str(fixture_path)],
+            }
+        }
+
+        with booted_gateway(
+            request_timeout=5, extra_servers_no_autostart=second_server
+        ) as gw:
+            start = time.monotonic()
+            a_log: list[dict] = []
+            b_log: list[dict] = []
+
+            async with (
+                listen_stream(
+                    gw.base_url,
+                    notifications={
+                        "toolsListChanged": True,
+                        "resourcesListChanged": True,
+                        "promptsListChanged": True,
+                    },
+                    request_id=101,
+                ) as sub_a,
+                listen_stream(
+                    gw.base_url,
+                    notifications={"toolsListChanged": True},
+                    request_id=202,
+                ) as sub_b,
+            ):
+                ack_a = await sub_a.next_frame()
+                assert ack_a["method"] == "notifications/subscriptions/acknowledged"
+                assert ack_a["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 101
+
+                ack_b = await sub_b.next_frame()
+                assert ack_b["method"] == "notifications/subscriptions/acknowledged"
+                assert ack_b["params"]["_meta"][SUBSCRIPTION_ID_META_KEY] == 202
+
+                # --- connect_server: a real first connect --------------
+                # rt-fixture-2 is configured and allowlisted but never
+                # auto-started (extra_servers_no_autostart), so this is a
+                # genuine connect, not a no-op against an already-online
+                # server.
+                _call_tool(
+                    gw.base_url,
+                    "gateway.connect_server",
+                    {"server_name": _SECOND_DOWNSTREAM},
+                )
+                frames_a = await _read_until(sub_a, _ALL_THREE, budget=10.0, log=a_log)
+                _assert_stamped(frames_a, 101)
+                frames_b = await _read_until(sub_b, _TOOLS_ONLY, budget=10.0, log=b_log)
+                _assert_stamped(frames_b, 202)
+
+                # --- disconnect_server -----------------------------------
+                _call_tool(
+                    gw.base_url,
+                    "gateway.disconnect_server",
+                    {"server_name": _SECOND_DOWNSTREAM},
+                )
+                frames_a = await _read_until(sub_a, _ALL_THREE, budget=10.0, log=a_log)
+                _assert_stamped(frames_a, 101)
+                frames_b = await _read_until(sub_b, _TOOLS_ONLY, budget=10.0, log=b_log)
+                _assert_stamped(frames_b, 202)
+
+                # --- gateway.refresh --------------------------------------
+                # Refresh is diff-based and leaves an already-disconnected,
+                # never-autoStart server alone. Add it to autoStart on disk
+                # so refresh's diff sees it as newly eager and reconnects
+                # it -- the realistic "operator adds an autoStart entry and
+                # refreshes" path, rather than defeating the diff logic.
+                config_path = gw.work_dir / "config.json"
+                config = json.loads(config_path.read_text())
+                config["autoStart"] = sorted({*config["autoStart"], _SECOND_DOWNSTREAM})
+                config_path.write_text(json.dumps(config))
+
+                # Sleep well past request_timeout=5 before the mutation
+                # whose notification this test measures -- a notification
+                # that still arrives afterward can only be explained by
+                # subscriptions/listen surviving the request_timeout
+                # wrapper (IF-0-P3B-3), not by the read completing before
+                # the timeout fired.
+                await asyncio.sleep(13)
+
+                _call_tool(gw.base_url, "gateway.refresh", {})
+                frames_a = await _read_until(sub_a, _ALL_THREE, budget=10.0, log=a_log)
+                _assert_stamped(frames_a, 101)
+                frames_b = await _read_until(sub_b, _TOOLS_ONLY, budget=10.0, log=b_log)
+                _assert_stamped(frames_b, 202)
+
+                elapsed = time.monotonic() - start
+                assert elapsed > 12, (
+                    f"refresh's notification landed at {elapsed:.1f}s from "
+                    "subscription open -- expected > 12s, which is the "
+                    "deployed-wire proof that request_timeout=5 did not "
+                    "truncate the stream"
+                )
+
+            # Filter-negative, over the WHOLE run (all three mutations):
+            # B is tools-only and must never have received a resources or
+            # prompts notification -- kept separate from A specifically so
+            # this isn't A's only resources/prompts coverage.
+            b_methods = {frame.get("method") for frame in b_log}
+            assert "notifications/resources/list_changed" not in b_methods, b_log
+            assert "notifications/prompts/list_changed" not in b_methods, b_log

--- a/tests/test_http_dos.py
+++ b/tests/test_http_dos.py
@@ -1,20 +1,42 @@
-"""Transport DoS hardening tests for the HTTP transport (Phase P5A).
+"""Transport DoS hardening tests for the HTTP transport (Phase P5A / P3B).
 
 Covers:
-- pre-session keepalive SSE stream concurrency cap (503 when full) and slot
-  release when a stream closes;
-- pre-session keepalive stream absolute lifetime (deadline) so it cannot live
-  forever;
+- subscriptions/listen stream concurrency cap (rejected before ack when full)
+  and slot release when a stream's client connection closes -- the P3B
+  (SL-4) one-for-one replacement for the retired pre-session keepalive
+  concurrency cap this module used to test (IF-0-P3B-3: the pre-session GET
+  keep-alive shim, including its `PMCP_MAX_KEEPALIVE_STREAMS` concurrency
+  cap and `PMCP_KEEPALIVE_MAX_SECONDS` absolute lifetime, is retired
+  entirely -- see `plans/phase-plan-v11-P3B.md`, IF-0-P3B-3. The lifetime
+  cap is *deliberately not* replaced: a subscription is long-lived by
+  design, so there is no lifetime-deadline test here to re-point -- what
+  bounds exposure now is this concurrency cap, the SDK's own per-stream
+  `max_buffered_events` backlog cap, and `/mcp` auth-gating);
 - request-body size cap enforced *during the read* so a chunked / mislabeled
   POST cannot bypass the header-only Content-Length check.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
+import socket
+import time
+from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+import uvicorn
+from mcp.server import Server
+from mcp.server.subscriptions import InMemorySubscriptionBus, ListenHandler
+from mcp.shared.inbound import MCP_METHOD_HEADER, MCP_PROTOCOL_VERSION_HEADER
+from mcp.types import CLIENT_CAPABILITIES_META_KEY, PROTOCOL_VERSION_META_KEY
+from mcp.types.version import LATEST_MODERN_VERSION
 from starlette.testclient import TestClient
+
+from pmcp.transport.http import create_http_app
 
 
 def _make_contract_client(
@@ -52,40 +74,164 @@ def _make_contract_client(
         )
 
 
-class TestKeepaliveStreamCap:
-    """Concurrency cap and slot release for pre-session keepalive SSE streams."""
+def _alloc_port() -> int:
+    """A real ephemeral-port allocator -- never a hardcoded literal."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
 
-    def test_pre_session_stream_rejected_when_cap_reached(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from pmcp.transport import http as http_mod
 
-        monkeypatch.setenv("PMCP_MAX_KEEPALIVE_STREAMS", "2")
-        http_mod._keepalive_active["count"] = 2  # simulate two open streams
-        try:
-            client = _make_contract_client()
-            response = client.get("/mcp")  # pre-session GET (no mcp-session-id)
-            assert response.status_code == 503
-        finally:
-            http_mod._keepalive_active["count"] = 0
+def _listen_envelope(
+    *, notifications: dict[str, bool], request_id: int
+) -> tuple[dict[str, str], dict]:
+    """IF-0-P3B-4 wire envelope for a subscriptions/listen POST. Wire
+    (camelCase) `notifications` -- only JSON test payloads use the alias."""
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        MCP_PROTOCOL_VERSION_HEADER: LATEST_MODERN_VERSION,
+        MCP_METHOD_HEADER: "subscriptions/listen",
+    }
+    body = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "subscriptions/listen",
+        "params": {
+            "notifications": notifications,
+            "_meta": {
+                PROTOCOL_VERSION_META_KEY: LATEST_MODERN_VERSION,
+                CLIENT_CAPABILITIES_META_KEY: {},
+            },
+        },
+    }
+    return headers, body
 
-    def test_stream_releases_slot_after_deadline(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from pmcp.transport import http as http_mod
 
-        # Tiny lifetime so the infinite stream terminates quickly and the
-        # TestClient (which consumes the whole body) does not hang.
-        monkeypatch.setenv("PMCP_KEEPALIVE_MAX_SECONDS", "0.3")
-        http_mod._keepalive_active["count"] = 0
+async def _next_data_frame(lines: AsyncIterator[str], *, timeout: float = 10.0) -> dict:
+    """Next `data:` frame from an SSE line iterator, skipping `: ping`
+    comment lines and blanks (IF-0-P3B-4)."""
 
-        client = _make_contract_client()
-        response = client.get("/mcp")
+    async def _read() -> dict:
+        async for line in lines:
+            if line.startswith("data:"):
+                return json.loads(line[len("data:") :].strip())  # noqa: E203
+        raise AssertionError("stream ended before a data: frame arrived")
 
-        assert response.status_code == 200
-        assert "keep-alive" in response.text
-        # finally-block in the generator ran during body consumption.
-        assert http_mod._keepalive_active["count"] == 0
+    return await asyncio.wait_for(_read(), timeout=timeout)
+
+
+@contextlib.asynccontextmanager
+async def _run_listen_app(*, max_subscriptions: int) -> AsyncIterator[str]:
+    """Serve `create_http_app` over a real `ListenHandler(max_subscriptions=...)`
+    -- the deliberate SL-4 replacement for the retired pre-session keepalive
+    concurrency guard -- as a background asyncio task on a spare port, for
+    the duration of the `async with` block. Yields the base URL."""
+    bus = InMemorySubscriptionBus()
+    listen_handler = ListenHandler(bus, max_subscriptions=max_subscriptions)
+    server = Server("http-dos-test", on_subscriptions_listen=listen_handler)
+    app = create_http_app(server)
+    port = _alloc_port()
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", lifespan="on"
+    )
+    uv_server = uvicorn.Server(config)
+    task = asyncio.create_task(uv_server.serve())
+    try:
+        for _ in range(200):
+            if uv_server.started:
+                break
+            await asyncio.sleep(0.05)
+        else:
+            raise RuntimeError("listen app never started")
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        uv_server.should_exit = True
+        await task
+
+
+class TestListenStreamCap:
+    """Concurrency cap and slot release for `subscriptions/listen` streams
+    (`PMCP_MAX_LISTEN_STREAMS` -> `ListenHandler(max_subscriptions=...)`),
+    the one-for-one SL-4 replacement for this class's former pre-session
+    keepalive stream cap coverage -- see IF-0-P3B-3."""
+
+    async def test_listen_stream_rejected_when_cap_reached(self) -> None:
+        """With the cap at 1, a second concurrent listen -- opened while the
+        first is still live -- is rejected (a JSON-RPC error, never an ack)
+        over the real deployed HTTP wire, not just the in-process duplex."""
+        async with _run_listen_app(max_subscriptions=1) as base_url:
+            headers_a, body_a = _listen_envelope(
+                notifications={"toolsListChanged": True}, request_id=1
+            )
+            async with (
+                httpx.AsyncClient(timeout=None) as client_a,
+                client_a.stream(
+                    "POST", f"{base_url}/mcp", headers=headers_a, json=body_a
+                ) as response_a,
+            ):
+                assert response_a.status_code == 200
+                ack = await _next_data_frame(response_a.aiter_lines())
+                assert ack["method"] == "notifications/subscriptions/acknowledged"
+
+                headers_b, body_b = _listen_envelope(
+                    notifications={"toolsListChanged": True}, request_id=2
+                )
+                async with httpx.AsyncClient(timeout=10.0) as client_b:
+                    response_b = await client_b.post(
+                        f"{base_url}/mcp", headers=headers_b, json=body_b
+                    )
+                payload = response_b.json()
+                assert "error" in payload, (
+                    f"second listen must be rejected while the cap is full, not acked: {payload}"
+                )
+
+    async def test_listen_stream_releases_slot_after_client_close(self) -> None:
+        """Closing the first subscription's connection frees its slot, so a
+        second subscription -- previously rejected while the cap was full --
+        is acked once the first disconnects."""
+        async with _run_listen_app(max_subscriptions=1) as base_url:
+            headers_a, body_a = _listen_envelope(
+                notifications={"toolsListChanged": True}, request_id=1
+            )
+            client_a = httpx.AsyncClient(timeout=None)
+            try:
+                async with client_a.stream(
+                    "POST", f"{base_url}/mcp", headers=headers_a, json=body_a
+                ) as response_a:
+                    assert response_a.status_code == 200
+                    ack = await _next_data_frame(response_a.aiter_lines())
+                    assert ack["method"] == "notifications/subscriptions/acknowledged"
+            finally:
+                # A real disconnect (not a pooled return) so the server's
+                # watch_disconnect sees http.disconnect and frees the slot.
+                await client_a.aclose()
+
+            headers_b, body_b = _listen_envelope(
+                notifications={"toolsListChanged": True}, request_id=2
+            )
+            deadline = time.monotonic() + 10.0
+            async with httpx.AsyncClient(timeout=None) as client_b:
+                while time.monotonic() < deadline:
+                    async with client_b.stream(
+                        "POST", f"{base_url}/mcp", headers=headers_b, json=body_b
+                    ) as response_b:
+                        try:
+                            message = await asyncio.wait_for(
+                                _next_data_frame(response_b.aiter_lines()), timeout=3.0
+                            )
+                        except (TimeoutError, AssertionError):
+                            message = None
+                        if (
+                            message is not None
+                            and message.get("method")
+                            == "notifications/subscriptions/acknowledged"
+                        ):
+                            return
+                    await asyncio.sleep(0.2)
+            pytest.fail(
+                "subscription B was never acked after A's client disconnect "
+                "(max_subscriptions=1)"
+            )
 
 
 class TestBodySizeCap:

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -235,7 +235,8 @@ class TestHttpTransportRoutes:
         assert any("/mcp" in path for path in route_paths)
 
     def test_routes_use_correct_methods(self) -> None:
-        """/mcp endpoint should accept GET, POST, and DELETE."""
+        """/mcp endpoint accepts POST and DELETE only -- GET is retired
+        (IF-0-P3B-3): it now 405s instead of opening a keep-alive stream."""
         from pmcp.transport.http import create_http_app
 
         mock_server = MagicMock()
@@ -243,12 +244,13 @@ class TestHttpTransportRoutes:
 
         app = create_http_app(mock_server)
 
-        # Find the /mcp route and check it accepts GET and POST
+        # Find the /mcp route and check it accepts POST/DELETE, not GET.
         for route in app.routes:
             if hasattr(route, "path") and route.path == "/mcp":
                 if hasattr(route, "methods"):
-                    assert "GET" in route.methods
+                    assert "GET" not in route.methods
                     assert "POST" in route.methods
+                    assert "DELETE" in route.methods
 
 
 class TestHttpObservabilityContracts:

--- a/tests/test_transport_http.py
+++ b/tests/test_transport_http.py
@@ -209,7 +209,8 @@ class TestAuthGuardHttp:
     def test_metrics_counter_increments_on_401(self) -> None:
         before = _metrics["requests_401"]
         client = _make_app(auth_token="secret")
-        client.get("/mcp")  # GET with no session ID returns keep-alive SSE, skip
+        get_response = client.get("/mcp")  # GET is retired (IF-0-P3B-3): 405, no stream
+        assert get_response.status_code == 405
         client.post("/mcp", content=b"{}")  # no auth → 401
         assert _metrics["requests_401"] > before
 

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "1.22.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Executes roadmap v11 Phase 3B — the last phase, and the only one that changes observable client behaviour. **Ships as `2.0.0`, and carries P2's unreleased mcp-2.x port in the same bump** rather than an interim `1.23.0` (operator decision; recorded as a deviation from the roadmap's stated cadence).

Six lanes, disjoint file ownership verified with the scheduler's own `_patterns_overlap` before any work started. Every rebase across six lanes was conflict-free. `main` sees only this combined PR.

## BREAKING

- **`GET /mcp` is retired** — now `405` with `Allow: POST, DELETE`. `GET /health` and `GET /metrics` are unaffected.
- **`PMCP_MAX_KEEPALIVE_STREAMS` and `PMCP_KEEPALIVE_MAX_SECONDS` are gone.** `PMCP_MAX_LISTEN_STREAMS` (default 64) replaces the concurrency cap one-for-one. The absolute-lifetime cap is **deliberately not replaced** — a server that severs a subscription every N seconds is the defect this release fixes, not a property to preserve.

Retirement removes a channel pmcp **never wrote to**: no server-initiated notification existed anywhere in `src/`. What breaks is clients that *open* GET, not clients receiving anything over it. The replacement is `subscriptions/listen`, reachable only at `2026-07-28`.

## Two defects in shipped code, found by spiking rather than reading

- **`request_timeout` truncated every HTTP subscription.** All session-manager traffic was wrapped in `asyncio.wait_for(..., timeout=request_timeout)` (default 60). Measured at `request_timeout=3`: ack at t=0.1s, event at t=1.0s, truncated body at exactly t=3.0s. **A false-green generator** — an EC-P3B-4 test finishing inside 60s would pass while every real client lost its stream every minute. Now exempt, with regressions in-process *and* over the deployed wire.
- **`GET /mcp` hung**, which EC-P3B-3 forbids — a session-less GET got an infinite keep-alive stream before the session manager saw it. Reproduced as a genuinely hung pytest process, not inferred.

## The publisher seam

`ClientManager` mutates its catalogs in **sync** methods; the bus `publish` is **async**. Rather than patching nine async lifecycle entry points — and `gateway.refresh` doesn't even route through `ClientManager.refresh` — the sink is self-draining. Coverage is structural: an AST guard fails if a write to `_tools`/`_resources`/`_prompts` appears outside the publishing set, and it walks `ast.AnnAssign` so `__init__`'s exemption isn't vacuous.

Board review caught three design defects before execution, all fixed: **six write sites, not four** (`_disconnect_all_unlocked` cleared all three catalogs unannounced — reachable from `refresh([])`); a **lost-wakeup race** where a note arriving during an in-flight `await publish` stranded its event (guaranteed, not incidental — `InMemorySubscriptionBus.publish` ends with an explicit `anyio.lowlevel.checkpoint()`); and **EC-P3B-4 weakened to tools-only**, which would have let a broken prompts or resources publisher pass.

## Deviation from the plan, recorded

The plan mandated `flush()` at `_index_capabilities` and `disconnect_server` as an "ordering nicety". **Removed** — they sat on exactly the paths EC-P3B-4 drives, so the criterion could have passed with the self-scheduling drain broken. The 12 lane tests pass without them, which is the proof the drain delivers on production paths.

## Acceptance

EC-P3B-4 is driven purely by catalog mutation: subscription A (all three kinds) plus a separate subscription B (tools-only) for the filter-negative, driven by real `gateway.connect_server`/`disconnect_server`/`refresh` over the deployed `/mcp`. **No test in that module calls `note_*`, `flush`, or `bus.publish`** — the only occurrence is the docstring stating the guarantee.

Tests were themselves tested: the DoS cap proven to go red when raised, the AST guard proven to fire on an injected illegal write, and a timing margin widened after a 10s sleep measured 10.9s against a 12s bar.

Also fixes an **inherited flaky assertion** from P2 already on `main`: a socket-count check asserted strict equality while reporting "grew", so a late-closing socket failed it on a *decrease*.

## Verification

Full suite **2494 passed / 3 skipped / 0 failed**. `tests/runtime/` 39 passed under `-rs` with no SKIPPED. ruff, format, mypy (42 files) clean. Live gateway on `:3344` untouched throughout — pid and child set unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->