### PR TITLE
fix: gateway instructions on connect; identify the anyio teardown root cause

### DIFF
--- a/src/pmcp/summary/generator.py
+++ b/src/pmcp/summary/generator.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from pmcp.summary.template_fallback import template_summary
+from pmcp.summary.template_fallback import (
+    _no_downstream_tools_summary,
+    template_summary,
+)
 
 if TYPE_CHECKING:
     from pmcp.types import DescriptionsCache, ToolInfo
@@ -108,10 +111,10 @@ async def generate_capability_summary(
         Human-readable capability summary for MCP instructions
     """
     if not tools:
-        return (
-            "MCP Gateway: No tools currently available.\n"
-            "Use gateway.refresh to reload server configurations."
-        )
+        # Single source of truth with the template path -- both are reachable
+        # depending on whether a descriptions cache exists, and a client must
+        # not get different first impressions depending on cache state.
+        return _no_downstream_tools_summary(provisionable_categories)
 
     # 1. Try pre-built cache first
     if cache:

--- a/src/pmcp/summary/template_fallback.py
+++ b/src/pmcp/summary/template_fallback.py
@@ -44,6 +44,35 @@ CAPABILITY_KEYWORDS = {
 }
 
 
+def _no_downstream_tools_summary(provisionable_categories: str | None = None) -> str:
+    """Instructions when no downstream server has been indexed yet.
+
+    This is the first thing every client is told on connect, and with
+    `autoStart` empty -- the default, since downstream servers are lazy --
+    it is what a fresh gateway always sends. It previously read "No tools
+    currently available", which is wrong in the way that matters: the
+    gateway's own meta-tools are available, and they are how a client
+    reaches everything else. `gateway.refresh` was also the wrong next
+    step; it re-reads configuration rather than surfacing what is already
+    reachable on demand.
+    """
+    lines = [
+        "MCP Gateway: no downstream server is connected yet.",
+        "",
+        "This is normal. Downstream servers are lazy by default and start on "
+        "first use; the gateway's own tools are available right now and are "
+        "how you reach them:",
+        "  - gateway.catalog_search - find a capability across all known servers",
+        "  - gateway.describe - full schema for one tool before calling it",
+        "  - gateway.invoke - call a downstream tool (connects its server if needed)",
+        "  - gateway.request_capability - describe a need in plain language; "
+        "provisions a server if one is missing",
+    ]
+    if provisionable_categories:
+        lines += ["", f"Provisionable categories: {provisionable_categories}"]
+    return "\n".join(lines)
+
+
 def extract_capabilities(tools: list[ToolInfo]) -> list[str]:
     """Extract capability keywords from tool names and descriptions."""
     text = " ".join(f"{t.tool_name} {t.short_description}".lower() for t in tools)
@@ -100,10 +129,7 @@ def template_summary(
         provisionable_categories: If set, appended after default L0 trigger patterns
     """
     if not tools:
-        return (
-            "MCP Gateway: No tools currently available.\n"
-            "Use gateway.refresh to reload server configurations."
-        )
+        return _no_downstream_tools_summary(provisionable_categories)
 
     by_server = group_by_server(tools)
 

--- a/tests/runtime/test_downstream_remote.py
+++ b/tests/runtime/test_downstream_remote.py
@@ -30,6 +30,36 @@ and looks like an anyio/httpx2/uvicorn interaction rather than a pmcp bug;
 reported to the team lead rather than routed around silently. Keeping
 everything in one test function's one event loop avoids it and keeps the
 evidence real.
+
+DIAGNOSIS (2026-08-11, from an attempt to split this into four focused
+tests — the split was reverted, this is what it taught us). The constraint
+above is real and still holds; do not split this file without fixing the
+cause first. Two distinct symptoms, one root:
+
+  1. `disconnect_all()` in teardown fails outright with
+     `CancelledError: Cancelled via cancel scope <id> by <Task ...
+     _disconnect_all_unlocked.<locals>._shutdown_one() ...
+     cb=[gather.<locals>._done_callback()]`.
+  2. With one test per event loop, tests that run *after* a completed
+     connect-and-teardown fail their next connect with "SSE stream ended
+     without a response" — the cross-loop breakage described above.
+
+Root cause, now identified: `managed.sse_exit_stack` is entered in the
+task that performs the connect and closed in a *different* task —
+`_shutdown_one` under `asyncio.gather`, or a later loop's teardown. anyio
+cancel scopes are bound to the task that created them, so closing that
+stack elsewhere violates its invariant. It is not an httpx2 or uvicorn
+defect; it is pmcp entering a task-bound resource in one task and
+releasing it in another.
+
+The fix is therefore per-client task ownership of teardown: the task that
+owns a client's exit stack must be the one that closes it, on request.
+That is a connection-lifecycle restructuring affecting every client, which
+is why it stays deferred to its own phase rather than being patched in
+alongside unrelated work. Two things that do NOT fix it, both tried:
+swapping `disconnect_all()` for per-name `disconnect_server()` in teardown
+(symptom 2 remains), and assuming P2's leak fix resolved it (it fixed the
+leak, not the task-ownership violation).
 """
 
 from __future__ import annotations

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import pytest
 
 from pmcp.summary.template_fallback import (
@@ -132,9 +133,39 @@ class TestTemplateSummary:
         assert "matching CLI hints" in summary
 
     def test_handles_empty_tools(self) -> None:
+        """No downstream tools is the DEFAULT state, not an error state.
+
+        Downstream servers are lazy unless listed in `autoStart`, so this is
+        what a fresh gateway sends every client on connect. It must not claim
+        the gateway has nothing to offer -- the meta-tools are available and
+        are the route to everything else.
+        """
         summary = template_summary([])
-        assert "No tools currently available" in summary
-        assert "gateway.refresh" in summary
+        assert "no downstream server is connected yet" in summary
+        # Names the tools that DO work right now, and how to reach the rest.
+        assert "gateway.catalog_search" in summary
+        assert "gateway.invoke" in summary
+        assert "gateway.request_capability" in summary
+        # Must not tell the reader there is nothing here, nor point them at
+        # gateway.refresh, which re-reads config rather than surfacing what
+        # is already reachable on demand.
+        assert "No tools currently available" not in summary
+        assert "gateway.refresh" not in summary
+
+    def test_empty_tools_summary_matches_across_both_paths(self) -> None:
+        """The cached and template paths must give the same first impression.
+
+        Both are reachable depending on whether a descriptions cache exists;
+        a client should not be told different things about the gateway based
+        on cache state.
+        """
+        from pmcp.summary.generator import generate_capability_summary
+
+        template = template_summary([], provisionable_categories="browser, search")
+        generated = asyncio.run(
+            generate_capability_summary([], provisionable_categories="browser, search")
+        )
+        assert template == generated
 
     def test_includes_tool_counts(self) -> None:
         tools = [
@@ -186,7 +217,9 @@ class TestGenerateCapabilitySummary:
     @pytest.mark.asyncio
     async def test_handles_empty_tools(self) -> None:
         summary = await generate_capability_summary([])
-        assert "No tools" in summary
+        assert "no downstream server is connected yet" in summary
+        assert "gateway.catalog_search" in summary
+        assert "No tools" not in summary
 
     @pytest.mark.asyncio
     async def test_falls_back_to_template_if_llm_unavailable(self) -> None:


### PR DESCRIPTION
Two items, both found while investigating whether the P3B GET retirement broke Codex (it didn't — verified with a real `codex exec` handshake).

## 1. The gateway told every client it had no tools

On connect it advertised:

```
MCP Gateway: No tools currently available.
Use gateway.refresh to reload server configurations.
```

This is what a **fresh gateway always sends**, because downstream servers are lazy unless listed in `autoStart`, so `tools` is empty at startup. Observed in a real Codex handshake against the live gateway — and it's what this repo's own Claude sessions see too.

It's wrong in the way that matters: the ~26 `gateway.*` meta-tools are available right then and are the route to everything else. Telling a client there's nothing here invites it to give up on first contact. `gateway.refresh` was also the wrong next step — it re-reads configuration rather than surfacing what's already reachable on demand.

Replaced with an accurate message naming the tools that work right now. Both the cached and template paths returned this string independently; they now share one helper, with a test asserting they agree so a client can't get a different first impression depending on cache state.

## 2. Root cause of the anyio teardown constraint (docs only)

I attempted to split `test_downstream_remote.py`'s single large test into four focused ones, on the theory that P2's transport-leak fix had also resolved the cross-event-loop breakage. **It had not** — the split is reverted. What it established is now recorded, because the next person to try will otherwise repeat it.

Two symptoms, one root:

1. `disconnect_all()` in teardown fails with `CancelledError: Cancelled via cancel scope <id> by <Task _shutdown_one() ... cb=[gather._done_callback()]`.
2. One test per event loop: tests running after a completed connect-and-teardown fail their next connect with "SSE stream ended without a response".

**Root cause:** `managed.sse_exit_stack` is entered in the connect task and closed in a *different* task — `_shutdown_one` under `asyncio.gather`, or a later loop's teardown. anyio cancel scopes are bound to the task that created them. So this is **not** the httpx2/uvicorn interaction previously suspected; it's pmcp entering a task-bound resource in one task and releasing it in another.

That makes the fix per-client task ownership of teardown — a lifecycle restructuring touching every client, so it stays its own phase.

Recorded as tried-and-rejected so they aren't re-attempted: swapping `disconnect_all()` for per-name `disconnect_server()` (symptom 2 remains), and assuming P2's leak fix covered it (it fixed the leak, not the task-ownership violation).

## Verification

Full suite **2498 passed / 3 skipped / 0 failed**; ruff, format, mypy (42 files) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->