### PR TITLE
fix: per-client owner task for remote transport teardown (anyio cancel-scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Remote downstream transports (SSE, streamable HTTP) are now entered and
+  closed in a dedicated per-client owner task, fixing an anyio cancel-scope
+  task-ownership violation during teardown: the exit stack used to be
+  entered by the task that connected and closed by whichever task called
+  `disconnect_server` / `disconnect_all` / a reconnect, which anyio's
+  cancel scopes don't allow. This did not leak resources (the owned
+  `httpx2.AsyncClient` always closed), but the violation itself was real
+  and, in the one path where the entering task was still alive, surfaced as
+  a `CancelledError` escaping `disconnect_all()`.
+
 ## [2.0.0] - 2026-08-09
 
 ### Removed

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -1588,9 +1588,14 @@ class ClientManager:
             except asyncio.CancelledError:
                 pass
             except Exception as exc:
+                # exc_info, not just the message: this is by construction the
+                # hardest path here to reproduce (needs a caller cancelled
+                # *while* a forced owner unwind is independently failing), so
+                # the traceback matters if it's ever seen again.
                 logger.warning(
                     f"[{name}] remote transport failed to unwind while "
-                    f"escalating our caller's cancellation: {exc}"
+                    f"escalating our caller's cancellation: {exc}",
+                    exc_info=exc,
                 )
             raise
         # NOTE: no `except Exception` here, deliberately. A transport exit

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -64,17 +64,6 @@ logger = logging.getLogger(__name__)
 _TaskT = TypeVar("_TaskT", bound=asyncio.Task[Any])
 
 
-def _is_cancel_scope_task_mismatch_error(exc: BaseException) -> bool:
-    """Return True for benign anyio cancel-scope task mismatch during shutdown."""
-    msg = str(exc).lower()
-    return (
-        "cancel scope" in msg
-        and "different task" in msg
-        and "entered" in msg
-        and "exit" in msg
-    )
-
-
 class _NullCatalogEventSink:
     """No-op `CatalogEventSink` used when `ClientManager` is constructed with
     no `catalog_events` (IF-0-P3B-2's default). Keeps every pre-P3B
@@ -475,14 +464,24 @@ class ManagedClient:
     config: ResolvedServerConfig
     process: asyncio.subprocess.Process | None = None
     is_remote: bool = False
-    sse_exit_stack: AsyncExitStack | None = None
     write_stream: Any | None = None
     # The httpx2.AsyncClient pmcp owns for a streamable-HTTP downstream (mcp
     # 2.0.0's streamable_http_client() takes a caller-supplied client and does
     # not close it — see IF-0-P2-2). None for SSE and stdio downstreams, which
-    # don't take one. Entered into sse_exit_stack, so it closes with the
-    # transport; exposed here so tests (and callers) can assert `.is_closed`.
+    # don't take one. Entered into the transport owner task's exit stack (see
+    # `transport_owner_task`), so it closes with the transport; exposed here
+    # so tests (and callers) can assert `.is_closed`.
     remote_http_client: httpx2.AsyncClient | None = None
+    # The task that entered this remote client's transport exit stack and
+    # will close it, on request via `transport_shutdown`. anyio cancel scopes
+    # are bound to the task that created them, so the stack must be entered
+    # and unwound in the same task — this task. None for stdio clients, which
+    # have no exit stack.
+    transport_owner_task: asyncio.Task[None] | None = None
+    # Graceful-teardown signal the owner task parks on (`await shutdown.wait()`)
+    # after publishing its streams. Set by `_close_remote_transport` to ask the
+    # owner to unwind its own stack, in its own task.
+    transport_shutdown: asyncio.Event | None = None
     status: ServerStatus = field(
         default_factory=lambda: ServerStatus(
             name="",
@@ -861,16 +860,16 @@ class ClientManager:
 
             try:
                 if managed.is_remote:
-                    if managed.sse_exit_stack is not None:
-                        try:
-                            await managed.sse_exit_stack.aclose()
-                        except RuntimeError as e:
-                            if _is_cancel_scope_task_mismatch_error(e):
-                                logger.debug(
-                                    f"[{name}] Ignoring SSE shutdown cancel-scope mismatch: {e}"
-                                )
-                            else:
-                                raise
+                    # _close_remote_transport never swallows a genuine
+                    # transport-exit failure -- that's deliberate, so it can
+                    # still reach the `except Exception` below and return
+                    # (False, cancelled, str(e)) rather than reporting a
+                    # broken teardown as a successful disconnect. A timeout
+                    # that escalates to cancel is logged there and returns
+                    # normally: the transport is closed either way, and
+                    # `False` here would make a dead-peer disconnect look
+                    # like a refusal to the caller.
+                    await self._close_remote_transport(name, managed)
                 else:
                     await _terminate_process_tree(managed.process, name)
             except Exception as e:
@@ -1458,6 +1457,121 @@ class ClientManager:
             remote_http_client=http_client,
         )
 
+    async def _own_remote_transport(
+        self,
+        name: str,
+        transport_context: Any,
+        remote_http_client: httpx2.AsyncClient | None,
+        ready: asyncio.Future[tuple[Any, Any]],
+        shutdown: asyncio.Event,
+    ) -> None:
+        """Own a remote client's transport for its whole lifetime: enter its
+        exit stack here, park here, and unwind it here.
+
+        anyio cancel scopes are bound to the task that creates them, so the
+        task that enters this stack is the only task that may ever close it.
+        This task exists so that task is always this one -- never a caller of
+        `disconnect_server` / `_disconnect_all_unlocked` / `_cleanup_client`
+        running in some other task.
+        """
+        try:
+            async with AsyncExitStack() as stack:
+                # LIFO: client entered first so it closes last, preserving
+                # the ordering this code documented before this change --
+                # transport closes first, the owned httpx2 client last, and
+                # a failure entering the transport still closes the client
+                # we already own rather than leaking it.
+                if remote_http_client is not None:
+                    await stack.enter_async_context(remote_http_client)
+                transport = await stack.enter_async_context(transport_context)
+                ready.set_result(transport[:2])
+                await shutdown.wait()
+        except BaseException as exc:
+            if not ready.done():
+                # Pre-handoff failure: the connect caller is the one waiting
+                # on `ready`, so hand it the exception rather than raising
+                # into a task nobody is awaiting yet. The `async with` above
+                # has already unwound whatever it entered.
+                ready.set_exception(exc)
+                return
+            # Post-handoff failure: do NOT swallow. `_close_remote_transport`
+            # awaits this task and re-raises what it raises, which is what
+            # keeps `disconnect_server`'s (False, cancelled, str(e)) contract
+            # reachable.
+            raise
+
+    def _on_transport_owner_done(
+        self, name: str, shutdown: asyncio.Event, task: asyncio.Task[None]
+    ) -> None:
+        """Log an owner task that exits before anyone asked it to.
+
+        Without this, a transport that dies while parked at
+        `await shutdown.wait()` is invisible until someone disconnects, and
+        the loop separately logs "Task exception was never retrieved".
+        Reading `task.exception()` here does not consume it: a later
+        `_close_remote_transport` awaiting this task still re-raises the
+        real failure.
+        """
+        if task.cancelled() or shutdown.is_set():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                f"[{name}] remote transport owner exited unexpectedly: {exc}"
+            )
+
+    async def _close_remote_transport(
+        self, name: str, managed: ManagedClient, timeout: float = 5.0
+    ) -> None:
+        """Signal a remote client's transport owner task to unwind its stack
+        and wait for it. The single entry point for all three close sites
+        (`disconnect_server`, `_disconnect_all_unlocked._shutdown_one`,
+        `_cleanup_client`) -- each decides for itself whether a failure here
+        should propagate or be swallowed; this method never swallows on
+        their behalf.
+
+        Idempotent: setting the shutdown event twice, awaiting an already-
+        finished owner, or being called for a client with no owner (stdio)
+        all return without effect.
+        """
+        task, shutdown = managed.transport_owner_task, managed.transport_shutdown
+        if task is None or shutdown is None:
+            return
+        shutdown.set()
+        if task.done():
+            return
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout)
+        except asyncio.TimeoutError:
+            # The 5s budget bounds this graceful wait only, not the
+            # escalation below: the gather() after cancel() is itself
+            # unbounded, and an __aexit__ that ignores cancellation hangs
+            # there -- the same hang class as today's dead-peer teardown,
+            # neither introduced nor removed by this method.
+            logger.warning(
+                f"[{name}] remote transport did not close within {timeout}s; cancelling"
+            )
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        except asyncio.CancelledError:
+            # NOT the same case as the timeout above. The shield keeps the
+            # owner alive, so a CancelledError here is *our caller* being
+            # cancelled, not the owner. Escalate to the owner so its stack
+            # still unwinds, then re-raise: swallowing it would suppress
+            # cancellation of whatever task is running disconnect_server /
+            # _shutdown_one, which is the exact cancellation-correctness
+            # class this fix exists to fix.
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise
+        # NOTE: no `except Exception` here, deliberately. A transport exit
+        # that genuinely fails must propagate, or disconnect_server's
+        # `except Exception -> return (False, cancelled, str(e))` can never
+        # fire and a broken teardown would report as a successful
+        # disconnect. The swallow belongs at the two call sites that
+        # legitimately must not fail -- _shutdown_one and _cleanup_client --
+        # not here.
+
     async def _connect_remote_stream(
         self,
         config: ResolvedServerConfig,
@@ -1488,31 +1602,46 @@ class ClientManager:
 
         logger.info(f"Connecting to remote MCP server via {transport_name}: {name}")
 
-        remote_stack = AsyncExitStack()
-        # Enter the owned httpx2 client before the transport: AsyncExitStack
-        # unwinds LIFO, so on cleanup the transport closes first and the client
-        # last, and if entering the transport itself raises, the except below
-        # still closes (rather than leaks) the client we already own.
-        if remote_http_client is not None:
-            await remote_stack.enter_async_context(remote_http_client)
-        try:
-            transport = await remote_stack.enter_async_context(transport_context)
-        except Exception:
-            await remote_stack.aclose()
-            raise
-        read_stream, write_stream = transport[:2]
-
-        managed = ManagedClient(
-            config=config,
-            process=None,
-            is_remote=True,
-            sse_exit_stack=remote_stack,
-            write_stream=write_stream,
-            status=status,
-            resolved_remote_headers=resolved_headers,
-            remote_http_client=remote_http_client,
+        ready: asyncio.Future[tuple[Any, Any]] = (
+            asyncio.get_running_loop().create_future()
         )
-        self._clients[name] = managed
+        shutdown = asyncio.Event()
+        owner_task = self._track_background_task(
+            asyncio.create_task(
+                self._own_remote_transport(
+                    name, transport_context, remote_http_client, ready, shutdown
+                )
+            ),
+            name,
+        )
+        owner_task.add_done_callback(
+            lambda t: self._on_transport_owner_done(name, shutdown, t)
+        )
+
+        try:
+            read_stream, write_stream = await ready
+            managed = ManagedClient(
+                config=config,
+                process=None,
+                is_remote=True,
+                write_stream=write_stream,
+                status=status,
+                resolved_remote_headers=resolved_headers,
+                remote_http_client=remote_http_client,
+                transport_owner_task=owner_task,
+                transport_shutdown=shutdown,
+            )
+            self._clients[name] = managed
+        except BaseException:
+            # BaseException, not Exception: cancellation is the case that
+            # bites here, and it is a BaseException. Cancel rather than
+            # signal-and-wait -- a cancelled caller must not linger, and the
+            # peer reaps its own session on timeout. The owner's `async
+            # with` unwinds in the owner, as always -- never touch its stack
+            # from this task.
+            owner_task.cancel()
+            await asyncio.gather(owner_task, return_exceptions=True)
+            raise
 
         try:
             managed.read_task = self._track_background_task(
@@ -1546,7 +1675,7 @@ class ClientManager:
                     await asyncio.shield(managed.read_task)
                 except (asyncio.CancelledError, Exception):
                     pass
-            await remote_stack.aclose()
+            await self._close_remote_transport(name, managed)
             # Drop the stale ERROR client so it can't be found as a live
             # connection on the next connect attempt.
             if self._clients.get(name) is managed:
@@ -2042,18 +2171,14 @@ class ClientManager:
                     except (asyncio.TimeoutError, asyncio.CancelledError):
                         pass
 
-                # Close transport
+                # Close transport. _close_remote_transport itself never
+                # swallows a genuine transport-exit failure; the swallow
+                # belongs here -- this loop runs under `asyncio.gather`
+                # across every connected client, and one client's teardown
+                # failure must not abort the others' or the wholesale
+                # shutdown budget (issue #79/1c).
                 if managed.is_remote:
-                    if managed.sse_exit_stack is not None:
-                        try:
-                            await managed.sse_exit_stack.aclose()
-                        except RuntimeError as e:
-                            if _is_cancel_scope_task_mismatch_error(e):
-                                logger.debug(
-                                    f"[{name}] Ignoring SSE shutdown cancel-scope mismatch: {e}"
-                                )
-                            else:
-                                raise
+                    await self._close_remote_transport(name, managed)
                 else:
                     await _terminate_process_tree(managed.process, name)
             except Exception as e:
@@ -2130,20 +2255,13 @@ class ClientManager:
             # IF-0-P2-2, would also leak the owned httpx2.AsyncClient. Guarded
             # the same way as the two explicit-disconnect close sites
             # (`disconnect_server`, `_disconnect_all_unlocked`), but this
-            # function's contract is "never raises", so an unmatched error is
-            # logged and swallowed here rather than re-raised.
-            if managed.sse_exit_stack is not None:
-                try:
-                    await managed.sse_exit_stack.aclose()
-                except RuntimeError as e:
-                    if _is_cancel_scope_task_mismatch_error(e):
-                        logger.debug(
-                            f"[{name}] Ignoring SSE shutdown cancel-scope mismatch: {e}"
-                        )
-                    else:
-                        logger.warning(f"[{name}] Error closing remote transport: {e}")
-                except Exception as e:
-                    logger.warning(f"[{name}] Error closing remote transport: {e}")
+            # function's contract is "never raises" (for non-cancellation
+            # failures -- `_close_remote_transport` itself never swallows, so
+            # an unmatched error is logged and swallowed here instead).
+            try:
+                await self._close_remote_transport(name, managed)
+            except Exception as e:
+                logger.warning(f"[{name}] Error closing remote transport: {e}")
         else:
             await _terminate_process_tree(managed.process, name)
         self._clients.pop(name, None)

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -1539,30 +1539,59 @@ class ClientManager:
             return
         shutdown.set()
         if task.done():
+            # The owner already exited -- possibly with a genuine failure it
+            # was carrying (the crash-while-parked case `_on_transport_owner_done`
+            # only logs). Retrieve, don't discard: a cancelled owner closed
+            # cleanly enough to report as closed, but a real exception must
+            # still reach `disconnect_server`'s (False, cancelled, str(e)).
+            if not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    raise exc
             return
         try:
             await asyncio.wait_for(asyncio.shield(task), timeout)
         except asyncio.TimeoutError:
             # The 5s budget bounds this graceful wait only, not the
-            # escalation below: the gather() after cancel() is itself
+            # escalation below: awaiting the cancelled owner is itself
             # unbounded, and an __aexit__ that ignores cancellation hangs
             # there -- the same hang class as today's dead-peer teardown,
-            # neither introduced nor removed by this method.
+            # neither introduced nor removed by this method. Timeout-as-
+            # success is deliberate (a dead peer must not read as "disconnect
+            # refused"), but that only covers the timeout itself -- a genuine
+            # failure surfacing *while* the owner unwinds under our cancel
+            # must still propagate, so only the CancelledError our own
+            # cancel() causes is swallowed below.
             logger.warning(
                 f"[{name}] remote transport did not close within {timeout}s; cancelling"
             )
             task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         except asyncio.CancelledError:
             # NOT the same case as the timeout above. The shield keeps the
             # owner alive, so a CancelledError here is *our caller* being
             # cancelled, not the owner. Escalate to the owner so its stack
-            # still unwinds, then re-raise: swallowing it would suppress
-            # cancellation of whatever task is running disconnect_server /
-            # _shutdown_one, which is the exact cancellation-correctness
-            # class this fix exists to fix.
+            # still unwinds, then re-raise the caller's own cancellation --
+            # swallowing it would suppress cancellation of whatever task is
+            # running disconnect_server / _shutdown_one, which is the exact
+            # cancellation-correctness class this fix exists to fix. A
+            # genuine failure surfacing from the owner during this forced
+            # unwind can't also be raised (the caller's own CancelledError
+            # takes precedence, per the same reasoning), but is logged rather
+            # than silently dropped.
             task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.warning(
+                    f"[{name}] remote transport failed to unwind while "
+                    f"escalating our caller's cancellation: {exc}"
+                )
             raise
         # NOTE: no `except Exception` here, deliberately. A transport exit
         # that genuinely fails must propagate, or disconnect_server's

--- a/tests/runtime/fake_remote.py
+++ b/tests/runtime/fake_remote.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 
 import uvicorn
 from mcp.server import MCPServer
+from sse_starlette.sse import AppStatus
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse
@@ -109,3 +110,10 @@ async def run_fake_remote(
     finally:
         server.should_exit = True
         await task
+        # sse_starlette.sse.AppStatus.should_exit is a process-global class
+        # attribute, latched True by its uvicorn-shutdown signal handler and
+        # never reset. Left alone, every SSE stream created afterwards — in
+        # any event loop, against any server — terminates immediately, which
+        # poisons whichever test runs next. This is the one site that resets
+        # it; nothing else in the repo should.
+        AppStatus.should_exit = False

--- a/tests/runtime/test_downstream_remote.py
+++ b/tests/runtime/test_downstream_remote.py
@@ -15,51 +15,36 @@ so this must run in-process rather than through a booted gateway subprocess
 — the "no mocks" bar applies to the fake remote peer, not to how the
 gateway code runs.
 
-All five properties below share ONE `run_fake_remote` lifecycle inside ONE
-test function, rather than one `run_fake_remote` per test — empirically,
-not a style choice: a real streamable-http client connection that fully
-establishes its standalone SSE listener and is then torn down leaves
-something in anyio's process-global task/cancel-scope bookkeeping that
-breaks the *next independent* event loop's uvicorn server (reproduced with
-`git bisect`-style isolation — a connect-only cycle, or a second server
-with no client at all, does not trigger it; only a fully connected-then-
-disconnected client followed by a *separate* `asyncio.run()`/event-loop
-boundary does). That is orthogonal to anything IF-0-P2-2 changed — it
-reproduces with a plain, non-redirected, non-authenticated connect too —
-and looks like an anyio/httpx2/uvicorn interaction rather than a pmcp bug;
-reported to the team lead rather than routed around silently. Keeping
-everything in one test function's one event loop avoids it and keeps the
-evidence real.
+Four independent properties, four independent tests, each with its own
+`ClientManager`, its own `run_fake_remote(alloc_port(), ...)`, and a
+`disconnect_all()` teardown. This file used to cram all four into one test
+function sharing one `run_fake_remote` lifecycle, to dodge two bugs that
+made splitting it fail:
 
-DIAGNOSIS (2026-08-11, from an attempt to split this into four focused
-tests — the split was reverted, this is what it taught us). The constraint
-above is real and still holds; do not split this file without fixing the
-cause first. Two distinct symptoms, one root:
-
-  1. `disconnect_all()` in teardown fails outright with
+  1. `disconnect_all()` in teardown raised
      `CancelledError: Cancelled via cancel scope <id> by <Task ...
      _disconnect_all_unlocked.<locals>._shutdown_one() ...
-     cb=[gather.<locals>._done_callback()]`.
-  2. With one test per event loop, tests that run *after* a completed
-     connect-and-teardown fail their next connect with "SSE stream ended
-     without a response" — the cross-loop breakage described above.
+     cb=[gather.<locals>._done_callback()]`. Root cause: the remote
+     transport's exit stack was entered in the task that performed the
+     connect and closed in a *different* task — `_shutdown_one` under
+     `asyncio.gather`, or a later loop's teardown. anyio cancel scopes are
+     bound to the task that created them, so closing that stack elsewhere
+     violated its invariant. Fixed in `src/pmcp/client/manager.py`: a
+     long-lived per-client owner task now enters and unwinds the transport
+     in itself, so ownership never crosses a task boundary.
+  2. Independently, tests run *after* a completed connect-and-teardown
+     failed their next connect with "SSE stream ended without a response".
+     This was not a pmcp bug: `sse_starlette.sse.AppStatus.should_exit` is a
+     process-global class attribute, latched `True` the first time any
+     uvicorn server in the process shuts down and never reset, so every SSE
+     stream created afterwards — in any loop, against any server —
+     terminates immediately. Fixed in `tests/runtime/fake_remote.py`'s
+     `run_fake_remote` `finally:` block, which is the one place that resets
+     it.
 
-Root cause, now identified: `managed.sse_exit_stack` is entered in the
-task that performs the connect and closed in a *different* task —
-`_shutdown_one` under `asyncio.gather`, or a later loop's teardown. anyio
-cancel scopes are bound to the task that created them, so closing that
-stack elsewhere violates its invariant. It is not an httpx2 or uvicorn
-defect; it is pmcp entering a task-bound resource in one task and
-releasing it in another.
-
-The fix is therefore per-client task ownership of teardown: the task that
-owns a client's exit stack must be the one that closes it, on request.
-That is a connection-lifecycle restructuring affecting every client, which
-is why it stays deferred to its own phase rather than being patched in
-alongside unrelated work. Two things that do NOT fix it, both tried:
-swapping `disconnect_all()` for per-name `disconnect_server()` in teardown
-(symptom 2 remains), and assuming P2's leak fix resolved it (it fixed the
-leak, not the task-ownership violation).
+These two causes are unrelated — the earlier "two symptoms, one root"
+framing in this docstring was wrong. Both are fixed now, independently, and
+the file is split.
 """
 
 from __future__ import annotations
@@ -87,25 +72,23 @@ def _config(
 
 
 @pytest.mark.asyncio
-async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
+async def test_ec_p2_7_configured_headers_reach_peer() -> None:
+    """Headers set by IF-0-P2-2's httpx2.AsyncClient construction really
+    reach the peer: the fake remote 401s without the exact configured
+    Authorization value, so a successful connect + real gateway.invoke
+    proves the rebuilt client carries them, not just that a mock recorded a
+    kwarg."""
     manager = ClientManager()
-    connected_names: list[str] = []
     try:
         async with run_fake_remote(
             alloc_port(), expected_auth_value=AUTH_VALUE
         ) as remote:
-            # 1. Headers set by IF-0-P2-2's httpx2.AsyncClient construction
-            #    really reach the peer: the fake remote 401s without the
-            #    exact configured Authorization value, so a successful
-            #    connect + real gateway.invoke proves the rebuilt client
-            #    carries them, not just that a mock recorded a kwarg.
             errors = await manager.connect_server(
                 _config(
                     "fr-auth", remote.mcp_url, headers={"Authorization": AUTH_VALUE}
                 )
             )
             assert errors == []
-            connected_names.append("fr-auth")
             assert manager.is_server_online("fr-auth") is True
 
             gateway_tools = GatewayTools(
@@ -120,15 +103,25 @@ async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
             assert result.ok is True
             content = result.result["content"]  # type: ignore[index]
             assert content[0]["text"] == "fr-echo:wire-proof"
+    finally:
+        await manager.disconnect_all()
 
-            # 2. Negative case: without this, (1) would be hollow — a fake
-            #    remote that accepts everything can't prove headers matter.
-            #    Confirms the 401 gate is live, not dead code.
+
+@pytest.mark.asyncio
+async def test_ec_p2_7_auth_gate_rejects_missing_and_wrong_header() -> None:
+    """Negative case: without this, the positive header-carrying test would
+    be hollow — a fake remote that accepts everything can't prove headers
+    matter. Confirms the 401 gate is live, not dead code, both for a
+    missing Authorization header and for the wrong value."""
+    manager = ClientManager()
+    try:
+        async with run_fake_remote(
+            alloc_port(), expected_auth_value=AUTH_VALUE
+        ) as remote:
             errors = await manager.connect_server(_config("fr-noauth", remote.mcp_url))
             assert errors != []
             assert manager.is_server_online("fr-noauth") is False
 
-            # 2b. Wrong value, not just absent.
             errors = await manager.connect_server(
                 _config(
                     "fr-wrongauth",
@@ -137,11 +130,22 @@ async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
                 )
             )
             assert errors != []
+            assert manager.is_server_online("fr-wrongauth") is False
+    finally:
+        await manager.disconnect_all()
 
-            # 3. Proves follow_redirects=True (IF-0-P2-2): the configured
-            #    URL points at /relocated, which 307s to /mcp. httpx2's own
-            #    default is follow_redirects=False, so this fails if pmcp
-            #    ever drops the explicit override.
+
+@pytest.mark.asyncio
+async def test_ec_p2_7_follows_redirects() -> None:
+    """Proves follow_redirects=True (IF-0-P2-2): the configured URL points
+    at /relocated, which 307s to /mcp. httpx2's own default is
+    follow_redirects=False, so this fails if pmcp ever drops the explicit
+    override."""
+    manager = ClientManager()
+    try:
+        async with run_fake_remote(
+            alloc_port(), expected_auth_value=AUTH_VALUE
+        ) as remote:
             errors = await manager.connect_server(
                 _config(
                     "fr-redirect",
@@ -150,24 +154,30 @@ async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
                 )
             )
             assert errors == []
-            connected_names.append("fr-redirect")
             assert manager.is_server_online("fr-redirect") is True
+    finally:
+        await manager.disconnect_all()
 
-            # 4. The leak proof. Calls the private `_connect_streamable_http`
-            #    directly (not the public `connect_server`, whose
-            #    singleflight guard short-circuits as a no-op when the
-            #    server is already ONLINE — manager.py:580-581 — and so
-            #    never reaches the reconnect branch at all): each call finds
-            #    `name in self._clients` from the previous iteration and
-            #    takes `_connect_remote_stream`'s "existing live connection"
-            #    branch, which calls `_cleanup_client` — the method
-            #    IF-0-P2-2 taught to close `managed.sse_exit_stack` (and
-            #    therefore the owned `httpx2.AsyncClient`) for remote
-            #    clients; before this phase it did not.
+
+@pytest.mark.asyncio
+async def test_ec_p2_7_reconnect_does_not_leak_transports() -> None:
+    """The leak proof. Calls the private `_connect_streamable_http` directly
+    (not the public `connect_server`, whose singleflight guard short-circuits
+    as a no-op when the server is already ONLINE, and so never reaches the
+    reconnect branch at all): each call finds `name in self._clients` from
+    the previous iteration and takes `_connect_remote_stream`'s "existing
+    live connection" branch, which calls `_cleanup_client` — the method
+    IF-0-P2-2 taught to close the remote transport (and therefore the owned
+    `httpx2.AsyncClient`) for remote clients; before that phase it did not."""
+    manager = ClientManager()
+    prior_clients: list[object] = []
+    try:
+        async with run_fake_remote(
+            alloc_port(), expected_auth_value=AUTH_VALUE
+        ) as remote:
             reconnect_config = _config(
                 "fr-reconnect", remote.mcp_url, headers={"Authorization": AUTH_VALUE}
             )
-            prior_clients = []
             socket_counts_by_cycle = []
             for _ in range(5):
                 await manager._connect_streamable_http(reconnect_config)
@@ -175,11 +185,10 @@ async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
                 assert managed.remote_http_client is not None
                 prior_clients.append(managed.remote_http_client)
                 socket_counts_by_cycle.append(open_socket_fd_count())
-            connected_names.append("fr-reconnect")
 
             for closed_client in prior_clients[:-1]:
-                assert closed_client.is_closed is True
-            assert prior_clients[-1].is_closed is False
+                assert closed_client.is_closed is True  # type: ignore[attr-defined]
+            assert prior_clients[-1].is_closed is False  # type: ignore[attr-defined]
 
             # Compare against the count right after the FIRST cycle, not
             # before it: establishing this server's very first connection
@@ -202,14 +211,8 @@ async def test_ec_p2_7_headers_redirect_and_reconnect_leak() -> None:
                 f"baseline={baseline}, counts={socket_counts_by_cycle}"
             )
     finally:
-        # disconnect_server (not disconnect_all, whose concurrent gather of
-        # every managed client's shutdown can trip anyio's cross-task
-        # cancel-scope guard — see the module docstring) closes each
-        # connected client explicitly.
-        for name in connected_names:
-            if manager.is_server_online(name):
-                await manager.disconnect_server(name, force=True)
+        await manager.disconnect_all()
 
-    # The final reconnect-cycle client is closed too, by the disconnect
+    # The final reconnect-cycle client is closed too, by disconnect_all
     # above rather than by a further reconnect.
-    assert prior_clients[-1].is_closed is True
+    assert prior_clients[-1].is_closed is True  # type: ignore[attr-defined]

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -627,62 +627,179 @@ class TestDisconnectAll:
 
     @pytest.mark.asyncio
     async def test_disconnect_all_closes_remote_stack(self) -> None:
-        """Test that disconnect_all closes remote SSE transports."""
+        """disconnect_all signals a remote client's transport owner task and
+        waits for it to unwind, rather than closing an exit stack directly
+        from a foreign task (the anyio cancel-scope task-ownership fix)."""
         manager = ClientManager()
         status = ServerStatus(
             name="remote", status=ServerStatusEnum.ONLINE, tool_count=0
         )
 
-        sse_stack = MagicMock()
-        sse_stack.aclose = AsyncMock()
+        shutdown = asyncio.Event()
+
+        async def owner() -> None:
+            await shutdown.wait()
+
+        owner_task = asyncio.create_task(owner())
 
         managed = ManagedClient(
             config=MagicMock(),
             process=None,
             is_remote=True,
-            sse_exit_stack=sse_stack,
             write_stream=MagicMock(),
             status=status,
+            transport_owner_task=owner_task,
+            transport_shutdown=shutdown,
         )
         manager._clients["remote"] = managed
         manager._servers["remote"] = status
 
         await manager.disconnect_all()
 
-        sse_stack.aclose.assert_awaited_once()
+        assert shutdown.is_set()
+        assert owner_task.done()
 
     @pytest.mark.asyncio
-    async def test_disconnect_all_ignores_cancel_scope_task_mismatch(self) -> None:
-        """Benign anyio cancel-scope mismatch should not be logged as warning."""
+    async def test_close_remote_transport_escalates_to_cancel_on_timeout(self) -> None:
+        """An owner task that ignores the graceful shutdown signal past the
+        timeout budget is cancelled directly; _close_remote_transport still
+        returns normally (the transport is closed either way) and logs a
+        WARNING rather than raising."""
         manager = ClientManager()
         status = ServerStatus(
             name="remote", status=ServerStatusEnum.ONLINE, tool_count=0
         )
+        shutdown = asyncio.Event()
+        cancelled = asyncio.Event()
 
-        sse_stack = MagicMock()
-        sse_stack.aclose = AsyncMock(
-            side_effect=RuntimeError(
-                "Attempted to exit cancel scope in a different task than it was entered in"
-            )
-        )
+        async def stubborn_owner() -> None:
+            # Ignores `shutdown` entirely -- only a direct task.cancel() ends
+            # this, which is exactly the escalation being tested.
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
 
+        owner_task = asyncio.create_task(stubborn_owner())
         managed = ManagedClient(
             config=MagicMock(),
             process=None,
             is_remote=True,
-            sse_exit_stack=sse_stack,
             write_stream=MagicMock(),
             status=status,
+            transport_owner_task=owner_task,
+            transport_shutdown=shutdown,
+        )
+
+        with patch("pmcp.client.manager.logger.warning") as mock_warning:
+            await manager._close_remote_transport("remote", managed, timeout=0.05)
+
+        assert cancelled.is_set()
+        assert owner_task.done()
+        mock_warning.assert_called_once()
+        assert "did not close within" in mock_warning.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_disconnect_server_reports_failure_when_transport_exit_raises(
+        self,
+    ) -> None:
+        """A transport owner whose stack exit raises must be reported as a
+        failed disconnect -- `(False, cancelled, "<msg>")` -- not
+        `(True, ...)`. Without this, `disconnect_server`'s
+        `except Exception -> return (False, cancelled, str(e))` contract is
+        unenforced no matter what the design says."""
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name="remote",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http", url="http://example.invalid/mcp"
+            ),
+        )
+        status = ServerStatus(
+            name="remote", status=ServerStatusEnum.ONLINE, tool_count=0
+        )
+        shutdown = asyncio.Event()
+
+        async def raising_owner() -> None:
+            await shutdown.wait()
+            raise RuntimeError("transport exit boom")
+
+        owner_task = asyncio.create_task(raising_owner())
+        managed = ManagedClient(
+            config=config,
+            process=None,
+            is_remote=True,
+            write_stream=MagicMock(),
+            status=status,
+            transport_owner_task=owner_task,
+            transport_shutdown=shutdown,
         )
         manager._clients["remote"] = managed
         manager._servers["remote"] = status
 
-        with patch("pmcp.client.manager.logger.warning") as mock_warning:
-            await manager.disconnect_all()
+        ok, _cancelled, error = await manager.disconnect_server("remote", force=True)
 
-        assert manager._clients == {}
-        assert manager._servers == {}
-        mock_warning.assert_not_called()
+        assert ok is False
+        assert error is not None
+        assert "transport exit boom" in error
+
+    @pytest.mark.asyncio
+    async def test_connect_cancelled_during_ownership_transfer_leaves_no_owner(
+        self,
+    ) -> None:
+        """Cancelling the connect task while it is parked at `await ready`
+        (the owner task already alive and entering the transport, but
+        `ManagedClient` not yet published) must not park a live,
+        unreferenced owner task. Regression for the ownership-transfer guard
+        in `_connect_remote_stream` -- proven red without it during
+        development (reverting `except BaseException` to `except Exception`
+        there leaves the owner orphaned and this test fails)."""
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name="remote",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http", url="http://example.invalid/mcp"
+            ),
+        )
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        class _HangingTransport:
+            async def __aenter__(self) -> tuple[Any, Any]:
+                entered.set()
+                await release.wait()
+                return (MagicMock(), MagicMock())
+
+            async def __aexit__(self, *exc_info: Any) -> None:
+                return None
+
+        connect_task = asyncio.create_task(
+            manager._connect_remote_stream(
+                config, _HangingTransport(), transport_name="test"
+            )
+        )
+        await entered.wait()
+
+        connect_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await connect_task
+
+        # Owner-task discard runs as a done-callback scheduled via
+        # call_soon, not synchronously when the task completes -- yield once
+        # so it has run before asserting.
+        await asyncio.sleep(0)
+
+        owner_tasks = [
+            t
+            for t in manager._background_tasks
+            if manager._background_task_servers.get(t) == "remote"
+        ]
+        assert owner_tasks == []
+        assert "remote" not in manager._clients
 
     @pytest.mark.asyncio
     async def test_disconnect_all_uses_stable_client_snapshot(self) -> None:

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -746,6 +746,112 @@ class TestDisconnectAll:
         assert "transport exit boom" in error
 
     @pytest.mark.asyncio
+    async def test_disconnect_server_reports_failure_when_owner_already_crashed(
+        self,
+    ) -> None:
+        """An owner that crashes *before* anyone asks it to shut down (the
+        crash-while-parked case `_on_transport_owner_done` only logs) must
+        still surface its exception the next time `disconnect_server` looks
+        -- not be silently treated as "already closed, nothing to report"
+        just because `task.done()` is already True by the time we check.
+        Board-review regression: `_close_remote_transport`'s early
+        `if task.done(): return` used to discard the result entirely."""
+        manager = ClientManager()
+        config = ResolvedServerConfig(
+            name="remote",
+            source="custom",
+            config=RemoteMcpServerConfig(
+                type="streamable-http", url="http://example.invalid/mcp"
+            ),
+        )
+        status = ServerStatus(
+            name="remote", status=ServerStatusEnum.ONLINE, tool_count=0
+        )
+        shutdown = asyncio.Event()
+
+        async def crashing_owner() -> None:
+            # Crashes immediately, without ever waiting on `shutdown` --
+            # simulates the transport dying while parked, before anyone
+            # asked it to close.
+            raise RuntimeError("owner crashed while parked")
+
+        owner_task = asyncio.create_task(crashing_owner())
+        # Let the owner actually finish before touching it, so `task.done()`
+        # is already True when `_close_remote_transport` looks -- exercising
+        # the early-return branch, not the awaited-task branch covered by
+        # test_disconnect_server_reports_failure_when_transport_exit_raises.
+        for _ in range(10):
+            if owner_task.done():
+                break
+            await asyncio.sleep(0)
+        assert owner_task.done()
+
+        managed = ManagedClient(
+            config=config,
+            process=None,
+            is_remote=True,
+            write_stream=MagicMock(),
+            status=status,
+            transport_owner_task=owner_task,
+            transport_shutdown=shutdown,
+        )
+        manager._clients["remote"] = managed
+        manager._servers["remote"] = status
+
+        ok, _cancelled, error = await manager.disconnect_server("remote", force=True)
+
+        assert ok is False
+        assert error is not None
+        assert "owner crashed while parked" in error
+
+    @pytest.mark.asyncio
+    async def test_close_remote_transport_propagates_failure_during_timeout_escalation(
+        self,
+    ) -> None:
+        """A transport-exit failure that surfaces while the owner unwinds
+        under our own escalating `task.cancel()` (the timeout branch) must
+        still propagate -- only the CancelledError our own cancel() causes
+        may be swallowed. Distinct from the timeout-as-success contract,
+        which stays (see test_close_remote_transport_escalates_to_cancel_on_timeout):
+        that covers a *clean* forced unwind; this covers one that fails.
+        Board-review regression: the escalation used to run under
+        `asyncio.gather(task, return_exceptions=True)`, which discarded
+        genuine failures indistinguishably from the expected CancelledError."""
+        manager = ClientManager()
+        status = ServerStatus(
+            name="remote", status=ServerStatusEnum.ONLINE, tool_count=0
+        )
+        shutdown = asyncio.Event()
+
+        async def owner_that_fails_on_cancel() -> None:
+            # Ignores `shutdown` entirely, so the graceful wait always times
+            # out. When escalated via task.cancel(), raises a genuine
+            # failure instead of letting CancelledError propagate --
+            # simulating __aexit__ swallowing the cancellation and
+            # surfacing its own error, e.g. a broken connection encountered
+            # during forced unwind.
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise RuntimeError("transport failed to unwind under cancel") from None
+
+        owner_task = asyncio.create_task(owner_that_fails_on_cancel())
+        managed = ManagedClient(
+            config=MagicMock(),
+            process=None,
+            is_remote=True,
+            write_stream=MagicMock(),
+            status=status,
+            transport_owner_task=owner_task,
+            transport_shutdown=shutdown,
+        )
+
+        with pytest.raises(
+            RuntimeError, match="transport failed to unwind under cancel"
+        ):
+            await manager._close_remote_transport("remote", managed, timeout=0.05)
+
+    @pytest.mark.asyncio
     async def test_connect_cancelled_during_ownership_transfer_leaves_no_owner(
         self,
     ) -> None:


### PR DESCRIPTION
Implements the merged plan (#136). Makes the task that *enters* a downstream client's transport exit stack the task that *closes* it.

## This is NOT a leak fix

Stated first so it isn't misread. P2 already fixed the leak — `AsyncExitStack` keeps unwinding past a raising callback, so the owned `httpx2` client still closes today (`is_closed is True`, socket FDs flat at 5 across six cycles). What was broken is the transport's anyio task group never running `__aexit__`: a **silent invariant violation**, swallowed at DEBUG on the normal path. It only failed loudly where the entering task was still alive.

## Two bugs, only one of them ours

The diagnosis previously on `main` said "two symptoms, one root". That was wrong:

1. **pmcp's** — `sse_exit_stack` entered in the connect task, closed in another (`_shutdown_one` under `gather`, or a later loop). anyio cancel scopes are task-bound. **This PR.**
2. **`sse_starlette`'s** — `AppStatus.should_exit` is a process-global class attribute set by `handle_exit` and never reset, so after the first uvicorn shutdown in a process every later SSE stream dies immediately, in any loop, against any server. Fixed with a one-line reset in the test harness; no dependency bump.

The wrong docstring is rewritten here.

## The proof, and why the order matters

Landing the harness fix **first** and leaving `manager.py` untouched must still show the real bug. Verified independently by me on the committed diff:

```
$ git checkout de83cc0 -- src/pmcp/client/manager.py   # harness fix + split still in place
$ uv run pytest tests/runtime/test_downstream_remote.py -q -p no:randomly
FAILED ... test_ec_p2_7_reconnect_does_not_leak_transports
1 failed, 3 passed

E  asyncio.exceptions.CancelledError: Cancelled via cancel scope 73845131da90 by
   <Task ... ClientManager._disconnect_all_unlocked.<locals>._shutdown_one()
   running at ...manager.py:2049> cb=[gather.<locals>._done_callback() ...]
```

Restore → `4 passed`. Had that gone fully green, the harness fix would have masked the bug it was meant to isolate and the whole exercise would be self-certifying.

## The guard is `BaseException`, and that is tested

Cancellation is a `BaseException`, and the ownership-transfer window is exactly where it bites: cancel between `ready` resolving and publication, and a live owner parks forever. The executor proved the distinction rather than asserting it — swapping to `except Exception` orphans the owner and `test_connect_cancelled_during_ownership_transfer_leaves_no_owner` catches it.

## Contract preserved, and enforced by test

`disconnect_server` maps a raising teardown to `(False, cancelled, str(e))` at `manager.py:876-878`. Swallowing close failures in the owner would have made that branch unreachable — a failed transport exit reporting as a clean disconnect. The swallow lives only at the two call sites that legitimately must not fail (`_shutdown_one`, `_cleanup_client`), and `test_disconnect_server_reports_failure_when_transport_exit_raises` gates it.

## Deleted coverage, deliberately

`test_disconnect_all_ignores_cancel_scope_task_mismatch` is removed: it pinned the swallow this PR deletes. Not a coverage loss — the replacement tests assert the new contract.

## Known: a load-correlated flake, neither caused nor fixed here

Under heavy concurrent load on a shared box, `test_ec_p2_7_reconnect_does_not_leak_transports` can fail with `RemoteProtocolError: peer closed connection … incomplete chunked read`, surfacing as `SSE stream ended without a response`. Flagging it because that is the **same user-facing message** as bug 2 above, so a recurrence invites the wrong diagnosis.

It is a different cause: same event loop, same peer, first connect inside the test's own loop — not the cross-loop case the `AppStatus` reset addresses, and no cancel-scope mismatch logged. Observed ~1/19 by the executor and once by me immediately after three back-to-back suite runs; **not reproduced in 12 consecutive random-order runs or two clean full-suite runs**.

## Verification

Full suite **2503 passed / 3 skipped / 0 failed**, run twice. `tests/runtime/test_downstream_remote.py` green across 3 sequential + 12 random-order runs. `grep -rn "sse_exit_stack\|_is_cancel_scope_task_mismatch_error" src/ tests/` → empty. ruff, format, mypy (42 files) clean. Live gateway on `:3344` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->