### PR TITLE
fix: honour tool annotations for risk, drop false failure hint on describe

### DIFF
--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -9,6 +9,7 @@ import logging
 import os
 from pathlib import Path
 import random
+import re
 import signal
 import string
 import time
@@ -319,34 +320,57 @@ def _generate_revision_id() -> str:
     return f"rev-{int(time.time() * 1000)}-{suffix}"
 
 
-def _infer_risk_hint(tool_name: str, description: str) -> RiskHint:
-    """Infer risk level from tool name/description."""
-    low_risk_patterns = ["read", "get", "list", "search", "query", "fetch", "describe"]
-    high_risk_patterns = [
-        "delete",
-        "remove",
-        "drop",
-        "execute",
-        "run",
-        "write",
-        "create",
-        "update",
-        "modify",
-        "send",
-        "post",
-        "put",
-    ]
+_LOW_RISK_WORDS = ("read", "get", "list", "search", "query", "fetch", "describe")
+_HIGH_RISK_WORDS = (
+    "delete",
+    "remove",
+    "drop",
+    "execute",
+    "run",
+    "write",
+    "create",
+    "update",
+    "modify",
+    "send",
+    "post",
+    "put",
+)
 
-    combined = f"{tool_name} {description}".lower()
+# Word-boundary, not substring. Plain `in` matching against a whole description
+# is why `resolve-library-id` -- a read-only docs lookup -- was classified HIGH
+# and told users it "may modify data": its description says "Source Reputation",
+# and "reputation" contains "put". Long descriptions make that near-certain for
+# almost any tool.
+_LOW_RISK_RE = re.compile(rf"\b({'|'.join(_LOW_RISK_WORDS)})\b")
+_HIGH_RISK_RE = re.compile(rf"\b({'|'.join(_HIGH_RISK_WORDS)})\b")
 
-    for pattern in high_risk_patterns:
-        if pattern in combined:
+
+def _infer_risk_hint(
+    tool_name: str,
+    description: str,
+    annotations: dict[str, Any] | None = None,
+) -> RiskHint:
+    """Infer risk level, preferring the server's own declaration.
+
+    MCP defines `ToolAnnotations` (`readOnlyHint`, `destructiveHint`) precisely
+    so a server can state this authoritatively. Those win over any guess we
+    make from the tool's prose: the server knows what its tool does and we are
+    pattern-matching English. The keyword heuristic below is only a fallback
+    for servers that declare nothing.
+    """
+    if annotations:
+        # destructive wins over read-only if a server sets both, since the
+        # unsafe reading is the safe default.
+        if annotations.get("destructiveHint") is True:
             return RiskHint.HIGH
-
-    for pattern in low_risk_patterns:
-        if pattern in combined:
+        if annotations.get("readOnlyHint") is True:
             return RiskHint.LOW
 
+    combined = f"{tool_name} {description}".lower()
+    if _HIGH_RISK_RE.search(combined):
+        return RiskHint.HIGH
+    if _LOW_RISK_RE.search(combined):
+        return RiskHint.LOW
     return RiskHint.MEDIUM
 
 
@@ -1180,7 +1204,9 @@ class ClientManager:
                 schema_dialect=_schema_dialect(input_schema, output_schema),
                 raw_metadata=_raw_metadata(tool, known_fields),
                 tags=_extract_tags(name, tool_name, description),
-                risk_hint=_infer_risk_hint(tool_name, description),
+                risk_hint=_infer_risk_hint(
+                    tool_name, description, tool.get("annotations")
+                ),
             )
 
             self._tools[tool_id] = tool_info

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -1724,7 +1724,13 @@ class GatewayTools:
             invoke_template=invoke_template,
             code_snippet=code_snippet,
             update_warning=update_warning,
-            feedback_hint=self._feedback_hint(),
+            # No feedback hint on a SUCCESSFUL describe. `_feedback_hint()`
+            # opens with "Technical failure detected", which is false here and
+            # was reaching every client on every successful describe. The
+            # convention is already correct on invoke's success path (it passes
+            # None); this site just did not follow it. Describe's own error
+            # paths below still emit it.
+            feedback_hint=None,
         )
 
     async def invoke(self, input_data: dict[str, Any]) -> InvokeOutput:

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -65,6 +65,66 @@ class TestHelperFunctions:
         """Test medium risk hint inference (default)."""
         assert _infer_risk_hint("process_item", "Process an item") == RiskHint.MEDIUM
 
+    def test_risk_words_match_on_word_boundaries_not_substrings(self) -> None:
+        """A risk word inside a longer word must not count.
+
+        Observed against a real server: context7's `resolve-library-id` is a
+        read-only documentation lookup, and its description contains "Source
+        Reputation". Plain substring matching found "put" inside "reputation"
+        and classified the tool HIGH, which then told users through
+        `gateway.describe` that it "may modify data or have side effects".
+        Long descriptions make that near-certain for almost any tool.
+        """
+        assert (
+            _infer_risk_hint(
+                "resolve-library-id",
+                "Each result includes Source Reputation and Benchmark Score.",
+            )
+            != RiskHint.HIGH
+        )
+        # A few more of the same shape, so this is not a one-word fix.
+        assert _infer_risk_hint("summarize", "Produces a runnable summary") != (
+            RiskHint.HIGH
+        )
+        assert _infer_risk_hint("inspect", "Reads the input schema") != RiskHint.HIGH
+        # Genuine whole-word matches must still be caught.
+        assert _infer_risk_hint("delete_file", "Delete a file") == RiskHint.HIGH
+        assert _infer_risk_hint("post_message", "Post a message") == RiskHint.HIGH
+
+    def test_server_tool_annotations_win_over_the_keyword_guess(self) -> None:
+        """MCP `ToolAnnotations` are authoritative; our heuristic is a fallback.
+
+        A server declaring `readOnlyHint`/`destructiveHint` knows what its own
+        tool does. Guessing from English prose and overriding that declaration
+        is how a read-only lookup ends up labelled destructive.
+        """
+        # readOnly wins even when the prose screams high risk.
+        assert (
+            _infer_risk_hint(
+                "delete_everything",
+                "Delete and remove and drop all data",
+                {"readOnlyHint": True},
+            )
+            == RiskHint.LOW
+        )
+        # destructive wins even when the prose looks safe.
+        assert (
+            _infer_risk_hint("list_items", "List all items", {"destructiveHint": True})
+            == RiskHint.HIGH
+        )
+        # Both set: the unsafe reading is the safe default.
+        assert (
+            _infer_risk_hint(
+                "thing", "does a thing", {"readOnlyHint": True, "destructiveHint": True}
+            )
+            == RiskHint.HIGH
+        )
+        # Absent or unrelated annotations fall through to the heuristic.
+        assert _infer_risk_hint("read_file", "Read a file", None) == RiskHint.LOW
+        assert (
+            _infer_risk_hint("read_file", "Read a file", {"title": "x"}) == RiskHint.LOW
+        )
+
     def test_extract_tags(self) -> None:
         """Test tag extraction."""
         tags = _extract_tags("github", "create_issue", "Create a GitHub issue")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2216,6 +2216,22 @@ class TestDescribe:
         assert result.schema_dialect == "https://json-schema.org/draft/2020-12/schema"
 
     @pytest.mark.asyncio
+    async def test_successful_describe_carries_no_failure_feedback_hint(
+        self, gateway_tools: GatewayTools
+    ) -> None:
+        """A successful describe must not claim a technical failure occurred.
+
+        `_feedback_hint()` opens with "Technical failure detected", and this
+        site emitted it unconditionally, so every successful describe told the
+        client something had gone wrong. `invoke`'s success path already passed
+        None; this one simply did not follow the convention. Describe's own
+        error paths still emit the hint, which is where it belongs.
+        """
+        result = await gateway_tools.describe({"tool_id": "github::create_issue"})
+
+        assert result.feedback_hint is None
+
+    @pytest.mark.asyncio
     async def test_describe_uses_default_schema_dialect_when_schema_omits_marker(
         self, gateway_tools: GatewayTools
     ) -> None:


### PR DESCRIPTION
Two user-visible bugs, found while checking whether a context7 `2.1.2 → 4.0.0` update needed anything from this repo. **It doesn't** — the manifest is unpinned (`npx -y @upstash/context7-mcp`), so a respawn already gets 4.0.0. But looking turned these up, and both affect every user on every call.

## 1. Risk inference ignored the server's own annotations, and matched substrings

context7's `resolve-library-id` is a read-only documentation lookup that explicitly declares:

```json
{"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true}
```

pmcp classified it **HIGH** risk and told users through `gateway.describe` that it *"may modify data or have side effects"*. Why:

```
matched 'put' inside: ...'ult includes source reputation and benchmar'
```

**"Reputation" contains "put".** Matching risk words as substrings against a whole description makes that near-certain for almost any tool.

MCP defines `ToolAnnotations` precisely so a server can state this authoritatively. Those now win over the keyword guess — the server knows what its tool does; we were pattern-matching English and overriding it. The heuristic stays as a fallback for servers that declare nothing, but matches on **word boundaries**. Destructive beats read-only if a server sets both, since the unsafe reading is the safe default.

**Not a security change:** policy does not gate on `risk_hint` — verified, no references in `policy.py`. It drives display and `catalog_search` filtering.

## 2. Successful `describe` claimed a technical failure

`_feedback_hint()` opens with *"Technical failure detected"* and `describe` emitted it unconditionally, so **every successful describe told the client something had gone wrong.**

`invoke`'s success path already passed `None` — the convention was right, this site just didn't follow it. I audited all 25 call sites: the other 24 are genuine failure paths (`ok=False` or missing-auth) and are left alone.

## Verification

Three regression tests, each **proven to catch its defect** — reverting only the source turns all three red, restoring turns them green:

```
FAILED test_risk_words_match_on_word_boundaries_not_substrings
FAILED test_server_tool_annotations_win_over_the_keyword_guess
FAILED test_successful_describe_carries_no_failure_feedback_hint
```

Worth noting the heuristic had tests before this, and they all still pass — they just never covered the substring case or the annotations. A green suite wasn't evidence the behaviour was right.

Full suite **2508 passed / 3 skipped / 0 failed**; ruff, format, mypy (42 files) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->