### PR TITLE
docs(specs): tick the exit criteria that actually shipped

### DIFF
--- a/specs/phase-plans-v10.md
+++ b/specs/phase-plans-v10.md
@@ -121,11 +121,11 @@ These are the narrowest contracts that unblock downstream phases. `/claude-plan-
 Make downstream servers actually recover from transient failure: fix the stdio reconnect `RecursionError` self-cancel, add remote (SSE/HTTP) auto-reconnect parity, and clean up failed connects so no stale ERROR client or leaked stderr task remains.
 
 **Exit criteria**
-- [ ] A real (non-mocked) integration test kills a live stdio server subprocess and asserts the manager returns it to `ONLINE` within the reconnect backoff — the test fails on today's code (`RecursionError`) and passes after the fix.
-- [ ] `_cancel_background_tasks` never cancels `asyncio.current_task()` (unit test asserts calling it from within a tracked task does not cancel that task).
-- [ ] A dropped remote (SSE/HTTP) server schedules a reconnect (parity with stdio); test drives `_read_sse`'s finally path.
-- [ ] A connect that fails at `initialize` leaves no entry in `_clients` and no live stderr reader task (test asserts both).
-- [ ] Full suite + ruff + mypy green; CHANGELOG "Fixed" entry.
+- [x] A real (non-mocked) integration test kills a live stdio server subprocess and asserts the manager returns it to `ONLINE` within the reconnect backoff — the test fails on today's code (`RecursionError`) and passes after the fix.
+- [x] `_cancel_background_tasks` never cancels `asyncio.current_task()` (unit test asserts calling it from within a tracked task does not cancel that task).
+- [x] A dropped remote (SSE/HTTP) server schedules a reconnect (parity with stdio); test drives `_read_sse`'s finally path.
+- [x] A connect that fails at `initialize` leaves no entry in `_clients` and no live stderr reader task (test asserts both).
+- [x] Full suite + ruff + mypy green; CHANGELOG "Fixed" entry.
 
 **Scope notes**
 - Single-writer file: `src/pmcp/client/manager.py` — all three fixes edit it; keep them in one lane to avoid conflicts. Second lane owns `tests/` (new `test_client_manager_reconnect.py` integration + unit tests) and can start against the fix's intended behavior.
@@ -161,11 +161,11 @@ Make downstream servers actually recover from transient failure: fix the stdio r
 Connect the already-implemented, already-tested OAuth resource-server auth mode and Origin/Host validation to the running server so operators can actually enable them; default posture rejects cross-origin browser requests (DNS-rebinding defense).
 
 **Exit criteria**
-- [ ] `GatewayServer` + CLI accept and pass `auth_mode`, `resource_server_*`, `required_scopes`, and `allowed_origins` to `create_http_app` (test asserts a resource-server-configured server actually validates a JWT and rejects an unsigned/aud-mismatched token end-to-end).
-- [ ] With no explicit config, a cross-origin browser `Origin` header is rejected 403 on `/mcp` (test), while same-origin / no-Origin (non-browser) requests pass; `Host` is validated.
-- [ ] `pmcp --help` documents the new flags; `PMCP_ALLOWED_ORIGINS` env honored.
-- [ ] No regression to `none` / `shared-secret` modes (existing auth tests pass unchanged).
-- [ ] Full suite + ruff + mypy green; CHANGELOG "Added/Fixed" + README auth section.
+- [x] `GatewayServer` + CLI accept and pass `auth_mode`, `resource_server_*`, `required_scopes`, and `allowed_origins` to `create_http_app` (test asserts a resource-server-configured server actually validates a JWT and rejects an unsigned/aud-mismatched token end-to-end).
+- [x] With no explicit config, a cross-origin browser `Origin` header is rejected 403 on `/mcp` (test), while same-origin / no-Origin (non-browser) requests pass; `Host` is validated.
+- [x] `pmcp --help` documents the new flags; `PMCP_ALLOWED_ORIGINS` env honored.
+- [x] No regression to `none` / `shared-secret` modes (existing auth tests pass unchanged).
+- [x] Full suite + ruff + mypy green; CHANGELOG "Added/Fixed" + README auth section.
 
 **Scope notes**
 - Publish IF-0-P2-1 (the `GatewayServer.__init__` signature + flag names) on day 1 so the three lanes start against the contract.
@@ -203,11 +203,11 @@ Connect the already-implemented, already-tested OAuth resource-server auth mode 
 Close the two paths where agent/registry-supplied data reaches code execution: validate the package identifier before it becomes `npx -y <name>`, and stop `auth_connect` from storing an arbitrary process-affecting env var (`LD_PRELOAD`/`NODE_OPTIONS`/`PATH`). Also scrub all feedback fields and lock the provision handoff (same file, same security theme).
 
 **Exit criteria**
-- [ ] `register_discovered_server`/`provision` reject a package name that isn't a valid npm/pypi identifier or that starts with `-` (test: `-g`, `../evil`, `a b` rejected; `@scope/name`, `name` accepted); the exact install command is surfaced for confirmation before execution.
-- [ ] `auth_connect` refuses to write an `env_var` not declared by the target server (or not on an allowlist) — test asserts `LD_PRELOAD` is rejected, the server's declared `env_var` is accepted.
-- [ ] `submit_feedback` runs `_scrub_sensitive_text` over `title`, `failed_tool_call`, and `subordinate_server` (test asserts a secret in each is redacted before the payload is built).
-- [ ] `provision_status` guards the `server_ready → adopt_process` handoff with a per-job lock/CAS and does not re-run a full `refresh` on repeat polls of a finished job (test: two concurrent polls adopt once).
-- [ ] Full suite + ruff + mypy green; CHANGELOG "Security/Fixed".
+- [x] `register_discovered_server`/`provision` reject a package name that isn't a valid npm/pypi identifier or that starts with `-` (test: `-g`, `../evil`, `a b` rejected; `@scope/name`, `name` accepted); the exact install command is surfaced for confirmation before execution.
+- [x] `auth_connect` refuses to write an `env_var` not declared by the target server (or not on an allowlist) — test asserts `LD_PRELOAD` is rejected, the server's declared `env_var` is accepted.
+- [x] `submit_feedback` runs `_scrub_sensitive_text` over `title`, `failed_tool_call`, and `subordinate_server` (test asserts a secret in each is redacted before the payload is built).
+- [x] `provision_status` guards the `server_ready → adopt_process` handoff with a per-job lock/CAS and does not re-run a full `refresh` on repeat polls of a finished job (test: two concurrent polls adopt once).
+- [x] Full suite + ruff + mypy green; CHANGELOG "Security/Fixed".
 
 **Scope notes**
 - Publish IF-0-P3-1 (`is_valid_package_name`, `env_var_allowed_for_server`) day 1.
@@ -243,12 +243,12 @@ Close the two paths where agent/registry-supplied data reaches code execution: v
 Stop leaking local credentials: take `secrets set` off the argv, create the secret directory `0700`, and resolve the case-insensitive policy match. Fold in the remaining `cli.py` UX findings (status eager-connect, doctor 401 disambiguation, env-override sentinels).
 
 **Exit criteria**
-- [ ] `pmcp secrets set <key>` reads the value via `getpass`/`--stdin` (positional value optional); test asserts no value on argv.
-- [ ] The secret directory (`~/.config/pmcp` / project) is created mode `0700` (test asserts dir bits, not just the `0600` file).
-- [ ] Policy allow/deny matching is case-sensitive (or the case-insensitivity is confirmed intentional and documented) — test pins the decision.
-- [ ] `pmcp status` with no gateway does NOT eagerly connect every server (defaults to the lazy/no-connect view); a flag opts into active probing.
-- [ ] `doctor` distinguishes 401/403 ("gateway up, needs auth") from unreachable; explicit `--flag` overrides the env-override magic-number sentinels (`==8`/`==60`).
-- [ ] Full suite + ruff + mypy green; CHANGELOG.
+- [x] `pmcp secrets set <key>` reads the value via `getpass`/`--stdin` (positional value optional); test asserts no value on argv.
+- [x] The secret directory (`~/.config/pmcp` / project) is created mode `0700` (test asserts dir bits, not just the `0600` file).
+- [x] Policy allow/deny matching is case-sensitive (or the case-insensitivity is confirmed intentional and documented) — test pins the decision.
+- [x] `pmcp status` with no gateway does NOT eagerly connect every server (defaults to the lazy/no-connect view); a flag opts into active probing.
+- [x] `doctor` distinguishes 401/403 ("gateway up, needs auth") from unreachable; explicit `--flag` overrides the env-override magic-number sentinels (`==8`/`==60`).
+- [x] Full suite + ruff + mypy green; CHANGELOG.
 
 **Scope notes**
 - Lanes are file-disjoint → 3 parallel lanes: (a) `cli.py` (secrets stdin + status/doctor/sentinels), (b) `env_store.py` (0700 dir), (c) `policy.py` (case decision).
@@ -283,10 +283,10 @@ Stop leaking local credentials: take `secrets set` off the argv, create the secr
 Bound the HTTP transport's resource usage: cap and time-limit the unauthenticated pre-session keepalive SSE streams, and enforce the body-size limit against chunked/unadvertised-length POSTs.
 
 **Exit criteria**
-- [ ] Concurrent pre-session keepalive streams are capped and have an idle deadline (test: N+1th stream is rejected or the stream closes after the deadline).
-- [ ] A chunked POST exceeding the 10 MB body cap is rejected while reading (test with no/false `content-length`), not just on the header.
-- [ ] `/health` + `/metrics` exposure decision documented (optionally bindable/gated on non-loopback).
-- [ ] Full suite + ruff + mypy green; CHANGELOG.
+- [x] Concurrent pre-session keepalive streams are capped and have an idle deadline (test: N+1th stream is rejected or the stream closes after the deadline).
+- [x] A chunked POST exceeding the 10 MB body cap is rejected while reading (test with no/false `content-length`), not just on the header.
+- [x] `/health` + `/metrics` exposure decision documented (optionally bindable/gated on non-loopback).
+- [x] Full suite + ruff + mypy green; CHANGELOG.
 
 **Scope notes**
 - Decompose into 2 lanes: (a) `src/pmcp/transport/http.py` implementation (keepalive-stream cap + idle deadline + streaming body-size enforcement) as the single writer of that file, and (b) `tests/` covering both limits (disjoint file, starts against the intended behavior).
@@ -319,11 +319,11 @@ Bound the HTTP transport's resource usage: cap and time-limit the unauthenticate
 Harden the outbound HTTP paths: disable redirects on JWKS/metadata fetches (SSRF), guard the registry response size during read (OOM), require https + a host allowlist for the private registry endpoint, and make the registry cache write atomic with tight perms.
 
 **Exit criteria**
-- [ ] JWKS fetch (`auth.py` aiohttp) and `fetch_json_metadata` (`auth.py` urlopen) use `allow_redirects=False` / a no-redirect opener and re-validate any target (test: a 302 to an internal host is not followed).
-- [ ] The registry client enforces the 2 MB cap during read (streamed / `Content-Length` pre-check), not after `resp.read()` (test: oversized response aborts early).
-- [ ] With `PMCP_REGISTRY_ALLOW_PRIVATE` on, a non-https or non-allowlisted `PMCP_REGISTRY_PRIVATE_ENDPOINT` is rejected (test).
-- [ ] Registry cache is written via temp + `os.replace` (atomic) with restrictive perms (test).
-- [ ] Full suite + ruff + mypy green; CHANGELOG.
+- [x] JWKS fetch (`auth.py` aiohttp) and `fetch_json_metadata` (`auth.py` urlopen) use `allow_redirects=False` / a no-redirect opener and re-validate any target (test: a 302 to an internal host is not followed).
+- [x] The registry client enforces the 2 MB cap during read (streamed / `Content-Length` pre-check), not after `resp.read()` (test: oversized response aborts early).
+- [x] With `PMCP_REGISTRY_ALLOW_PRIVATE` on, a non-https or non-allowlisted `PMCP_REGISTRY_PRIVATE_ENDPOINT` is rejected (test).
+- [x] Registry cache is written via temp + `os.replace` (atomic) with restrictive perms (test).
+- [x] Full suite + ruff + mypy green; CHANGELOG.
 
 **Scope notes**
 - File-disjoint from all other phases → parallel root (depends on none).
@@ -357,12 +357,12 @@ Harden the outbound HTTP paths: disable redirects on JWKS/metadata fetches (SSRF
 Clear the remaining MED/LOW robustness and quality findings across the manager, manifest overlay, config loader, and version checker, and de-flake the sleep-based subprocess tests.
 
 **Exit criteria**
-- [ ] `_tasks` registry evicts terminal (completed/failed/cancelled) records (TTL/LRU); `disconnect_server` inspects/cancels pending state under `_lifecycle_lock`; dead `managed.request_id` removed; `background_task` done-callback uses `pop(t, None)` (tests where practical).
-- [ ] Manifest overlay logs a prominent warning when an overlay entry shadows a shipped server by name, and `_find_project_manifest` keeps discovery within the resolved project root (no out-of-tree symlink follow).
-- [ ] Malformed `.mcp.json` parse errors are surfaced in `pmcp status` (not silently swallowed in `load_configs`); `find_project_root` does not resolve to `$HOME`.
-- [ ] Version-check URLs are `urllib.parse.quote`-escaped for pypi/cargo/docker.
-- [ ] `test_monitor_reads_stderr` and `test_monitor_keeps_last_20_lines` poll job state instead of `asyncio.sleep(0.3)` (no wall-clock race).
-- [ ] Full suite + ruff + mypy green; CHANGELOG.
+- [x] `_tasks` registry evicts terminal (completed/failed/cancelled) records (TTL/LRU); `disconnect_server` inspects/cancels pending state under `_lifecycle_lock`; dead `managed.request_id` removed; `background_task` done-callback uses `pop(t, None)` (tests where practical).
+- [x] Manifest overlay logs a prominent warning when an overlay entry shadows a shipped server by name, and `_find_project_manifest` keeps discovery within the resolved project root (no out-of-tree symlink follow).
+- [x] Malformed `.mcp.json` parse errors are surfaced in `pmcp status` (not silently swallowed in `load_configs`); `find_project_root` does not resolve to `$HOME`.
+- [x] Version-check URLs are `urllib.parse.quote`-escaped for pypi/cargo/docker.
+- [x] `test_monitor_reads_stderr` and `test_monitor_keeps_last_20_lines` poll job state instead of `asyncio.sleep(0.3)` (no wall-clock race).
+- [x] Full suite + ruff + mypy green; CHANGELOG.
 
 **Scope notes**
 - File-disjoint lanes → up to 5 parallel: (a) `manager.py` (after P1's IF-0-P1-1 — task/lifecycle stable), (b) `manifest/loader.py`, (c) `config/loader.py`, (d) `manifest/version_checker.py` + misc, (e) `tests/` de-flake.
@@ -405,12 +405,12 @@ Clear the remaining MED/LOW robustness and quality findings across the manager, 
 
 ## Acceptance Criteria
 
-- [ ] A killed downstream stdio server auto-recovers to ONLINE (the `RecursionError` is gone), and a dropped remote server reconnects — both proven by non-mocked integration tests.
-- [ ] An operator can enable OAuth resource-server auth and Origin validation via CLI/env and see them enforced end-to-end; the default posture rejects cross-origin browser requests.
-- [ ] An invalid/hostile package name is rejected before any `npx` execution, and `auth_connect` cannot store a non-declared process-affecting env var.
-- [ ] `secrets set` never places a credential on argv; the secret directory is `0700`.
-- [ ] Outbound JWKS/metadata/registry fetches don't follow redirects to internal hosts and can't OOM the gateway; the transport bounds keepalive streams and chunked bodies.
-- [ ] Full suite green (≥ current 2100 passing), ruff (lint+format) + mypy clean, at every phase's merge; the two known-flaky monitor tests are deterministic.
+- [x] A killed downstream stdio server auto-recovers to ONLINE (the `RecursionError` is gone), and a dropped remote server reconnects — both proven by non-mocked integration tests.
+- [x] An operator can enable OAuth resource-server auth and Origin validation via CLI/env and see them enforced end-to-end; the default posture rejects cross-origin browser requests.
+- [x] An invalid/hostile package name is rejected before any `npx` execution, and `auth_connect` cannot store a non-declared process-affecting env var.
+- [x] `secrets set` never places a credential on argv; the secret directory is `0700`.
+- [x] Outbound JWKS/metadata/registry fetches don't follow redirects to internal hosts and can't OOM the gateway; the transport bounds keepalive streams and chunked bodies.
+- [x] Full suite green (≥ current 2100 passing), ruff (lint+format) + mypy clean, at every phase's merge; the two known-flaky monitor tests are deterministic.
 
 ## Verification
 

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -111,11 +111,11 @@ Sequencing is constrained by a live hazard. Dependabot PR **#112** already propo
 Level `pmcp`'s CI up to the four guards already proven in `pangram-mcp`, so the cap raise in P2 cannot ship a package that installs but cannot run.
 
 **Exit criteria**
-- [ ] EC-P1-1 — A `min-version-smoke` job parses the declared `mcp` floor out of `pyproject.toml`, installs the built wheel pinned at exactly that version, and imports the gateway's startup modules; it fails if the floor is unsatisfiable or non-functional.
+- [x] EC-P1-1 — A `min-version-smoke` job parses the declared `mcp` floor out of `pyproject.toml`, installs the built wheel pinned at exactly that version, and imports the gateway's startup modules; it fails if the floor is unsatisfiable or non-functional.
 - [ ] EC-P1-2 — `.github/workflows/test.yml` gains a `schedule:` trigger and `workflow_dispatch`; a manually dispatched run passes on unchanged `main`.
-- [ ] EC-P1-3 — A test asserts `pmcp.__version__ == importlib.metadata.version("pmcp")`, failing if either drifts.
-- [ ] EC-P1-4 — The existing `install-smoke` job is unmodified and still passes, and PR #112 still fails only that job (the guard's behaviour is unchanged by this phase).
-- [ ] EC-P1-5 — Full suite, ruff, and mypy green; CHANGELOG entry under `### Changed`.
+- [x] EC-P1-3 — A test asserts `pmcp.__version__ == importlib.metadata.version("pmcp")`, failing if either drifts.
+- [x] EC-P1-4 — The existing `install-smoke` job is unmodified and still passes, and PR #112 still fails only that job (the guard's behaviour is unchanged by this phase).
+- [x] EC-P1-5 — Full suite, ruff, and mypy green; CHANGELOG entry under `### Changed`.
 
 **Scope notes**
 - Decompose into 2 lanes with disjoint files. `.github/workflows/test.yml` is a **single-writer file** — one lane owns it entirely; splitting the two job additions across lanes would serialize on conflicts.
@@ -203,13 +203,13 @@ raises the cap but not the floor, so `min-version-smoke` still installs
 Raise `pmcp` onto `mcp` 2.x so it runs correctly on the new library and negotiates `2026-07-28` with clients, while continuing to serve every downstream server exactly as today. Behaviour-preserving: no new client-visible protocol features.
 
 **Exit criteria**
-- [ ] EC-P2-1 — A wheel built from this phase installs into a clean environment with no lockfile, resolves `mcp` 2.x, and `pmcp --version` succeeds — `install-smoke` and `min-version-smoke` both green.
-- [ ] EC-P2-2 — The gateway starts on HTTP and listens on its configured port with no `Fatal error` in the log (this is the check that catches the `'Server' object has no attribute 'list_tools'` class of break, which the unit suite cannot).
-- [ ] EC-P2-3 — Each of the six handlers is exercised **at the wire level** — a real request in, a validated typed result out — for `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`. Registry-presence assertions are explicitly **not** sufficient. `tools/call` is additionally tested with **invalid** arguments and must return a schema-validation error, proving the validation the removed decorators used to supply is still in place.
-- [ ] EC-P2-4 — A downstream server still on `mcp` 1.x connects through the 2.x gateway over the **handshake** path and serves a real tool call; the negotiated version for that server is a `HANDSHAKE_PROTOCOL_VERSIONS` member (≤ `2025-11-25`), not `2026-07-28`.
-- [ ] EC-P2-5 — A **modern-era** request carrying `io.modelcontextprotocol/protocolVersion: 2026-07-28` in `_meta` is accepted and answered, and the SDK's default `server/discover` returns correct `supported_versions` and `capabilities`. Validating the SDK default is sufficient — `DiscoverResult` carries only `supported_versions`, `capabilities`, and `instructions`, so there is no aggregated inventory to add.
-- [ ] EC-P2-6 — **The six proxied handlers work under a modern envelope, exercised over the deployed HTTP wire** — POSTed to the running gateway's `/mcp` on a spare port, not via stdio or direct dispatch: a modern `tools/list` returns the aggregated catalog, a modern `tools/call` succeeds, and a modern `tools/call` with invalid arguments returns a schema-validation error. The envelope must be complete (`_meta` carrying both `protocolVersion` and `clientCapabilities`) with matching HTTP routing headers, since the session manager selects the modern handler from the protocol-version header. A stdio-only or direct-dispatch test can pass while `/mcp` is broken.
-- [ ] EC-P2-7 — **An authenticated remote downstream over Streamable HTTP still connects and serves a tool call**, proving the rebuilt `http_client` carries headers. Additionally: a **redirected** downstream still resolves (proving `follow_redirects=True`), and repeated disconnect/reconnect cycles leak no httpx2 clients (proving exit-stack ownership). stdio-only verification does not satisfy this.
+- [x] EC-P2-1 — A wheel built from this phase installs into a clean environment with no lockfile, resolves `mcp` 2.x, and `pmcp --version` succeeds — `install-smoke` and `min-version-smoke` both green.
+- [x] EC-P2-2 — The gateway starts on HTTP and listens on its configured port with no `Fatal error` in the log (this is the check that catches the `'Server' object has no attribute 'list_tools'` class of break, which the unit suite cannot).
+- [x] EC-P2-3 — Each of the six handlers is exercised **at the wire level** — a real request in, a validated typed result out — for `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`. Registry-presence assertions are explicitly **not** sufficient. `tools/call` is additionally tested with **invalid** arguments and must return a schema-validation error, proving the validation the removed decorators used to supply is still in place.
+- [x] EC-P2-4 — A downstream server still on `mcp` 1.x connects through the 2.x gateway over the **handshake** path and serves a real tool call; the negotiated version for that server is a `HANDSHAKE_PROTOCOL_VERSIONS` member (≤ `2025-11-25`), not `2026-07-28`.
+- [x] EC-P2-5 — A **modern-era** request carrying `io.modelcontextprotocol/protocolVersion: 2026-07-28` in `_meta` is accepted and answered, and the SDK's default `server/discover` returns correct `supported_versions` and `capabilities`. Validating the SDK default is sufficient — `DiscoverResult` carries only `supported_versions`, `capabilities`, and `instructions`, so there is no aggregated inventory to add.
+- [x] EC-P2-6 — **The six proxied handlers work under a modern envelope, exercised over the deployed HTTP wire** — POSTed to the running gateway's `/mcp` on a spare port, not via stdio or direct dispatch: a modern `tools/list` returns the aggregated catalog, a modern `tools/call` succeeds, and a modern `tools/call` with invalid arguments returns a schema-validation error. The envelope must be complete (`_meta` carrying both `protocolVersion` and `clientCapabilities`) with matching HTTP routing headers, since the session manager selects the modern handler from the protocol-version header. A stdio-only or direct-dispatch test can pass while `/mcp` is broken.
+- [x] EC-P2-7 — **An authenticated remote downstream over Streamable HTTP still connects and serves a tool call**, proving the rebuilt `http_client` carries headers. Additionally: a **redirected** downstream still resolves (proving `follow_redirects=True`), and repeated disconnect/reconnect cycles leak no httpx2 clients (proving exit-stack ownership). stdio-only verification does not satisfy this.
 - [ ] EC-P2-8 — Full suite green, ruff/mypy clean, CHANGELOG accurate about which eras are served, and PR #112 resolved per the Execution Notes.
 
 **Scope notes**
@@ -381,12 +381,12 @@ plus findings surfaced only during execution.
 Implement `subscriptions/listen` and retire the HTTP GET endpoint it replaces, which is the one part of this migration that changes observable client behaviour.
 
 **Exit criteria**
-- [ ] EC-P3B-1 — `subscriptions/listen` is registered through the IF-0-P2-2 shape, honours the `notifications` filter, sends `notifications/subscriptions/acknowledged` as the first message carrying `io.modelcontextprotocol/subscriptionId` in `_meta`, and never sends a notification type the client did not request.
-- [ ] EC-P3B-2 — Cancellation works from both sides: a client closing the stream (HTTP) or sending `notifications/cancelled` (stdio) ends the subscription, and a server-initiated close sends the empty `subscriptions/listen` response before closing.
-- [ ] EC-P3B-3 — The HTTP GET path on `/mcp` is retired without breaking `/health` or `/metrics`, and a client using the old GET flow receives a defined error rather than a hang.
-- [ ] EC-P3B-4 — **A real catalog mutation delivers a notification end to end.** Calling `gateway.connect_server` / `disconnect_server` / `refresh` — which mutate the tool, resource, and prompt indexes in `ClientManager` — causes a subscribed client to receive the corresponding `notifications/*/list_changed`. A synthetic test that fires the publisher directly does **not** satisfy this criterion.
-- [ ] EC-P3B-5 — Gateway starts, a downstream tool call still succeeds, and a client with no subscription is unaffected; full suite, ruff, mypy green.
-- [ ] EC-P3B-6 — CHANGELOG documents the GET retirement as a breaking client-visible change, released as a **major version**.
+- [x] EC-P3B-1 — `subscriptions/listen` is registered through the IF-0-P2-2 shape, honours the `notifications` filter, sends `notifications/subscriptions/acknowledged` as the first message carrying `io.modelcontextprotocol/subscriptionId` in `_meta`, and never sends a notification type the client did not request.
+- [x] EC-P3B-2 — Cancellation works from both sides: a client closing the stream (HTTP) or sending `notifications/cancelled` (stdio) ends the subscription, and a server-initiated close sends the empty `subscriptions/listen` response before closing.
+- [x] EC-P3B-3 — The HTTP GET path on `/mcp` is retired without breaking `/health` or `/metrics`, and a client using the old GET flow receives a defined error rather than a hang.
+- [x] EC-P3B-4 — **A real catalog mutation delivers a notification end to end.** Calling `gateway.connect_server` / `disconnect_server` / `refresh` — which mutate the tool, resource, and prompt indexes in `ClientManager` — causes a subscribed client to receive the corresponding `notifications/*/list_changed`. A synthetic test that fires the publisher directly does **not** satisfy this criterion.
+- [x] EC-P3B-5 — Gateway starts, a downstream tool call still succeeds, and a client with no subscription is unaffected; full suite, ruff, mypy green.
+- [x] EC-P3B-6 — CHANGELOG documents the GET retirement as a breaking client-visible change, released as a **major version**.
 
 **Scope notes**
 - **A listener with no publishers is the failure mode to design against.** `subscriptions/listen` lives in `src/pmcp/server.py`, but the events that should drive it originate in `src/pmcp/client/manager.py`, where tools/resources/prompts are indexed and removed (around `:1099`). Without an explicit event path from those mutations to the subscription, handler-level tests pass while live `connect_server` / disconnect / refresh deliver nothing. Define the publisher interface **before** the listener.
@@ -527,11 +527,11 @@ Top Interface-Freeze Gates section (item 1).
 Move the first-party `pangram-mcp` server off the removed `FastMCP` API onto `MCPServer`, raising its `mcp` cap, and prove it is reachable from both a 1.x and a 2.x gateway.
 
 **Exit criteria**
-- [ ] EC-PG-1 — `src/pangram_mcp/server.py` uses `MCPServer` instead of `mcp.server.fastmcp.FastMCP`; the `analyze` tool keeps its `ToolAnnotations` and its input/output contract is byte-identical.
-- [ ] EC-PG-2 — `pyproject.toml` declares a two-sided `mcp` bound whose floor is verified by installing at exactly that floor (not by reading source), and all four guards from IF-0-P1-1 pass.
-- [ ] EC-PG-3 — The **currently published 1.x** `pmcp` gateway connects to the ported server and `pangram::analyze` returns a live classification — this is the test of Assumption 6; if it fails, PG gains a dependency on P2 and the roadmap is amended.
+- [x] EC-PG-1 — `src/pangram_mcp/server.py` uses `MCPServer` instead of `mcp.server.fastmcp.FastMCP`; the `analyze` tool keeps its `ToolAnnotations` and its input/output contract is byte-identical.
+- [x] EC-PG-2 — `pyproject.toml` declares a two-sided `mcp` bound whose floor is verified by installing at exactly that floor (not by reading source), and all four guards from IF-0-P1-1 pass.
+- [x] EC-PG-3 — The **currently published 1.x** `pmcp` gateway connects to the ported server and `pangram::analyze` returns a live classification — this is the test of Assumption 6; if it fails, PG gains a dependency on P2 and the roadmap is amended.
 - [ ] EC-PG-4 — After P2 lands, the 2.x gateway also connects and serves `pangram::analyze`.
-- [ ] EC-PG-5 — Published to PyPI; `uvx pangram-mcp` starts clean from a cold cache.
+- [x] EC-PG-5 — Published to PyPI; `uvx pangram-mcp` starts clean from a cold cache.
 
 **Scope notes**
 - Decompose into 2 lanes with disjoint files. Lane A owns `src/pangram_mcp/server.py` (the API port). Lane B owns `pyproject.toml` + `tests/` (bound raise, floor bisection, drift test).
@@ -568,10 +568,10 @@ Move the first-party `pangram-mcp` server off the removed `FastMCP` API onto `MC
 Let a manifest entry express "credential required for the vendor endpoint, optional for a self-hosted one", removing the placeholder-secret workaround that #114 documents.
 
 **Exit criteria**
-- [ ] EC-P5-1 — A manifest entry can declare that its credential is optional under a named condition, and the requirement is evaluated by **one shared predicate** that every enforcement path calls — not re-implemented per call site.
-- [ ] EC-P5-2 — A server whose credential is genuinely required still fails closed at **every** gate; no server becomes reachable without auth that was not already.
-- [ ] EC-P5-3 — With the new field in use, an operator reaches a self-hosted endpoint with **no placeholder credential** anywhere, and it works through **all six consumers**: eager startup, provision/install, lifecycle connect, `pmcp secrets check` diagnostics, and capability discovery (`gateway.catalog_search` / `gateway.request_capability` must not report the server as key-missing or advise `auth_connect`). Passing only the connect path does not satisfy this.
-- [ ] EC-P5-4 — Existing manifest entries are unaffected (the field is optional and defaults to today's behaviour); full suite, ruff, mypy green.
+- [x] EC-P5-1 — A manifest entry can declare that its credential is optional under a named condition, and the requirement is evaluated by **one shared predicate** that every enforcement path calls — not re-implemented per call site.
+- [x] EC-P5-2 — A server whose credential is genuinely required still fails closed at **every** gate; no server becomes reachable without auth that was not already.
+- [x] EC-P5-3 — With the new field in use, an operator reaches a self-hosted endpoint with **no placeholder credential** anywhere, and it works through **all six consumers**: eager startup, provision/install, lifecycle connect, `pmcp secrets check` diagnostics, and capability discovery (`gateway.catalog_search` / `gateway.request_capability` must not report the server as key-missing or advise `auth_connect`). Passing only the connect path does not satisfy this.
+- [x] EC-P5-4 — Existing manifest entries are unaffected (the field is optional and defaults to today's behaviour); full suite, ruff, mypy green.
 
 **Scope notes**
 - **`requires_api_key` is enforced in FIVE independent places** — eager startup (`src/pmcp/config/loader.py`, around `:1038`), install (`src/pmcp/manifest/installer.py` `check_api_key`, around `:541`), lifecycle connect (`src/pmcp/tools/handlers.py`, around `:3200`), provisioning (`src/pmcp/tools/handlers.py`, around `:4058`), **diagnostics** (`src/pmcp/cli_commands/secrets.py`, around `:93` — `pmcp secrets check`), and **capability discovery** (`_get_server_env_metadata`, `src/pmcp/tools/handlers.py:3355`, consumed at `:1403`, `:3643`, `:3730`, `:3840` — this is what makes `gateway.catalog_search` and `gateway.request_capability` report a server as key-missing and tell operators to run `gateway.auth_connect`) — spanning 6 files and ~26 references. Successive review rounds found this list at four, then five, then six; each time the omitted consumer would have kept demanding the placeholder while every other path was fixed. Patching a subset produces a server that connects manually but fails auto-start, provisioning, or diagnostics. **Centralize first, then consume — and enumerate by grepping, not from memory.**
@@ -650,8 +650,8 @@ Let a manifest entry express "credential required for the vendor endpoint, optio
 Finish the one item from `specs/phase-plans-v10.md` Phase 6 that never landed, so the closed v10 roadmap has no silent leftovers.
 
 **Exit criteria**
-- [ ] EC-P6CLEAN-1 — `tests/test_manifest.py:1775` polls job state instead of `asyncio.sleep(0.3)`; the test passes with no wall-clock dependency and does not regress under load.
-- [ ] EC-P6CLEAN-2 — Full suite, ruff, and mypy green; CHANGELOG entry recording that this closes out v10 P6.
+- [x] EC-P6CLEAN-1 — `tests/test_manifest.py:1775` polls job state instead of `asyncio.sleep(0.3)`; the test passes with no wall-clock dependency and does not regress under load.
+- [x] EC-P6CLEAN-2 — Full suite, ruff, and mypy green; CHANGELOG entry recording that this closes out v10 P6.
 
 **Scope notes**
 - **Single lane, justified.** This is one test-file change; a second lane would contend on the same file for no benefit. This is the preamble/cleanup exception to the ≥2-lane rule, not an oversight.

--- a/specs/phase-plans-v11.md
+++ b/specs/phase-plans-v11.md
@@ -112,7 +112,7 @@ Level `pmcp`'s CI up to the four guards already proven in `pangram-mcp`, so the 
 
 **Exit criteria**
 - [x] EC-P1-1 — A `min-version-smoke` job parses the declared `mcp` floor out of `pyproject.toml`, installs the built wheel pinned at exactly that version, and imports the gateway's startup modules; it fails if the floor is unsatisfiable or non-functional.
-- [ ] EC-P1-2 — `.github/workflows/test.yml` gains a `schedule:` trigger and `workflow_dispatch`; a manually dispatched run passes on unchanged `main`.
+- [x] EC-P1-2 — `.github/workflows/test.yml` gains a `schedule:` trigger and `workflow_dispatch`; a manually dispatched run passes on unchanged `main`.
 - [x] EC-P1-3 — A test asserts `pmcp.__version__ == importlib.metadata.version("pmcp")`, failing if either drifts.
 - [x] EC-P1-4 — The existing `install-smoke` job is unmodified and still passes, and PR #112 still fails only that job (the guard's behaviour is unchanged by this phase).
 - [x] EC-P1-5 — Full suite, ruff, and mypy green; CHANGELOG entry under `### Changed`.
@@ -210,7 +210,7 @@ Raise `pmcp` onto `mcp` 2.x so it runs correctly on the new library and negotiat
 - [x] EC-P2-5 — A **modern-era** request carrying `io.modelcontextprotocol/protocolVersion: 2026-07-28` in `_meta` is accepted and answered, and the SDK's default `server/discover` returns correct `supported_versions` and `capabilities`. Validating the SDK default is sufficient — `DiscoverResult` carries only `supported_versions`, `capabilities`, and `instructions`, so there is no aggregated inventory to add.
 - [x] EC-P2-6 — **The six proxied handlers work under a modern envelope, exercised over the deployed HTTP wire** — POSTed to the running gateway's `/mcp` on a spare port, not via stdio or direct dispatch: a modern `tools/list` returns the aggregated catalog, a modern `tools/call` succeeds, and a modern `tools/call` with invalid arguments returns a schema-validation error. The envelope must be complete (`_meta` carrying both `protocolVersion` and `clientCapabilities`) with matching HTTP routing headers, since the session manager selects the modern handler from the protocol-version header. A stdio-only or direct-dispatch test can pass while `/mcp` is broken.
 - [x] EC-P2-7 — **An authenticated remote downstream over Streamable HTTP still connects and serves a tool call**, proving the rebuilt `http_client` carries headers. Additionally: a **redirected** downstream still resolves (proving `follow_redirects=True`), and repeated disconnect/reconnect cycles leak no httpx2 clients (proving exit-stack ownership). stdio-only verification does not satisfy this.
-- [ ] EC-P2-8 — Full suite green, ruff/mypy clean, CHANGELOG accurate about which eras are served, and PR #112 resolved per the Execution Notes.
+- [x] EC-P2-8 — Full suite green, ruff/mypy clean, CHANGELOG accurate about which eras are served, and PR #112 resolved per the Execution Notes.
 
 **Scope notes**
 - **The two eras are the design.** `mcp_types.version` splits them explicitly: `HANDSHAKE_PROTOCOL_VERSIONS = (2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25)` versus `MODERN_PROTOCOL_VERSIONS = (2026-07-28,)`. `2026-07-28` **cannot be requested through `initialize`** — it is reached via per-request `_meta` plus `server/discover`. Therefore: **do not raise `PREFERRED_PROTOCOL_VERSION` to `2026-07-28`.** That constant governs the downstream *handshake* ladder and its ceiling of `2025-11-25` is correct. Upstream (serving clients) and downstream (calling servers) are different eras and must be kept separate in both code and tests.
@@ -530,7 +530,7 @@ Move the first-party `pangram-mcp` server off the removed `FastMCP` API onto `MC
 - [x] EC-PG-1 — `src/pangram_mcp/server.py` uses `MCPServer` instead of `mcp.server.fastmcp.FastMCP`; the `analyze` tool keeps its `ToolAnnotations` and its input/output contract is byte-identical.
 - [x] EC-PG-2 — `pyproject.toml` declares a two-sided `mcp` bound whose floor is verified by installing at exactly that floor (not by reading source), and all four guards from IF-0-P1-1 pass.
 - [x] EC-PG-3 — The **currently published 1.x** `pmcp` gateway connects to the ported server and `pangram::analyze` returns a live classification — this is the test of Assumption 6; if it fails, PG gains a dependency on P2 and the roadmap is amended.
-- [ ] EC-PG-4 — After P2 lands, the 2.x gateway also connects and serves `pangram::analyze`.
+- [x] EC-PG-4 — After P2 lands, the 2.x gateway also connects and serves `pangram::analyze`.
 - [x] EC-PG-5 — Published to PyPI; `uvx pangram-mcp` starts clean from a cold cache.
 
 **Scope notes**

--- a/specs/phase-plans-v9.md
+++ b/specs/phase-plans-v9.md
@@ -157,24 +157,24 @@ Fold in the cheap unmet 2025-11-25 MUST/SHOULD items and stand up a tracked
 PMCP's transport and task-brokering surfaces.
 
 **Exit criteria**
-- [ ] Streamable HTTP returns **HTTP 403** for an invalid/disallowed `Origin`
+- [x] Streamable HTTP returns **HTTP 403** for an invalid/disallowed `Origin`
   header; a request with a bad `Origin` is rejected (test fails on HEAD). [PR #1439]
-- [ ] Tool input-validation failures are returned as **tool-execution errors**
+- [x] Tool input-validation failures are returned as **tool-execution errors**
   (result with `isError`/error envelope) rather than JSON-RPC protocol errors, so
   the model can self-correct. [SEP-1303]
-- [ ] Insufficient scope at runtime returns **403** with
+- [x] Insufficient scope at runtime returns **403** with
   `WWW-Authenticate: error="insufficient_scope", scope="…"`. [SEP-835]
-- [ ] PMCP advertises **JSON Schema 2020-12** as the default schema dialect where
+- [x] PMCP advertises **JSON Schema 2020-12** as the default schema dialect where
   it surfaces schema dialect metadata. [SEP-1613]
-- [ ] Tool/resource/prompt **icons** (when provided by a downstream server) are
+- [x] Tool/resource/prompt **icons** (when provided by a downstream server) are
   passed through `gateway.catalog_search`/`describe` discovery metadata. [SEP-973]
-- [ ] `SPEC_COMPLIANCE.md` exists with: target revision (2025-11-25), a
+- [x] `SPEC_COMPLIANCE.md` exists with: target revision (2025-11-25), a
   per-requirement compliance table, a **draft-revision impact/migration
   assessment** (stateless/no-session transport, tasks→extension with `tasks/list`
   removed and `tasks/result`→`tasks/get` polling + `tasks/update`, MRTR,
   `resultType`, `server/discover`, `CacheableResult`, DCR→CIMD), and a tracking
   checklist for adopting the next stable revision.
-- [ ] `ruff`, `mypy`, full `pytest` (TMPDIR outside `/tmp`) green.
+- [x] `ruff`, `mypy`, full `pytest` (TMPDIR outside `/tmp`) green.
 
 **Scope notes**
 - Lanes: (a) `transport/http.py` — Origin 403 + `insufficient_scope` 403 step-up
@@ -213,15 +213,15 @@ Add `updated_since` delta sync to the registry client so a refresh fetches only
 servers changed since the last sync and merges them into the cache.
 
 **Exit criteria**
-- [ ] The registry cache persists a `last_synced_at` RFC3339 timestamp.
-- [ ] When a timestamp exists, the client issues `GET /v0/servers?updated_since=…`
+- [x] The registry cache persists a `last_synced_at` RFC3339 timestamp.
+- [x] When a timestamp exists, the client issues `GET /v0/servers?updated_since=…`
   and **merges** returned entries (add/update; dedup to latest) into the cached
   set rather than replacing it (test with a recorded delta fixture, fails on HEAD).
-- [ ] No timestamp (cold cache) or a server/HTTP error falls back to the existing
+- [x] No timestamp (cold cache) or a server/HTTP error falls back to the existing
   full paginated fetch; failure degrades to the current cache, never crashes.
-- [ ] Pagination (`metadata.nextCursor`) and the size bound from v8 still apply to
+- [x] Pagination (`metadata.nextCursor`) and the size bound from v8 still apply to
   the delta fetch.
-- [ ] `ruff`, `mypy`, full `pytest` green; tests use recorded fixtures (no live
+- [x] `ruff`, `mypy`, full `pytest` green; tests use recorded fixtures (no live
   network).
 
 **Scope notes**
@@ -260,16 +260,16 @@ own private MCP servers — without changing default behavior.
 - [ ] A single config flag (env var + config field), default **OFF**, gates the
   feature; with it off, registry behavior is byte-identical to pre-v9 (public
   registry only, GA schema fields only) — asserted by a flag-off regression test.
-- [ ] With the flag ON, PMCP can be pointed at a configured private/custom
+- [x] With the flag ON, PMCP can be pointed at a configured private/custom
   registry endpoint (in addition to or instead of the public one) and parses its
   `/v0/servers` response.
-- [ ] With the flag ON, the parser tolerates draft/non-GA `server.json` schema
+- [x] With the flag ON, the parser tolerates draft/non-GA `server.json` schema
   fields (preserves unknown fields in `raw`, surfaces known draft fields) instead
   of dropping or erroring on them; with the flag OFF, unknown/draft fields are
   ignored as today.
-- [ ] Private endpoints and draft tolerance are documented as a debugging feature
+- [x] Private endpoints and draft tolerance are documented as a debugging feature
   with an explicit "not for production discovery" caveat.
-- [ ] `ruff`, `mypy`, full `pytest` green; tests cover both flag states.
+- [x] `ruff`, `mypy`, full `pytest` green; tests cover both flag states.
 
 **Scope notes**
 - Lanes: (a) `config/loader.py` — the opt-in flag + private endpoint config
@@ -306,12 +306,12 @@ Cut v1.15.0: version bump, CHANGELOG, README/`SPEC_COMPLIANCE.md` wiring, and th
 full release gate.
 
 **Exit criteria**
-- [ ] `__version__` and `pyproject.toml` bumped to `1.15.0`; `uv.lock` synced.
-- [ ] CHANGELOG `[1.15.0]` entry covers: MCP 2025-11-25 spec fold-ins (with SEP/PR
+- [x] `__version__` and `pyproject.toml` bumped to `1.15.0`; `uv.lock` synced.
+- [x] CHANGELOG `[1.15.0]` entry covers: MCP 2025-11-25 spec fold-ins (with SEP/PR
   references), registry `updated_since` incremental sync, and the opt-in
   private-registry/draft-schema flag (default off).
-- [ ] README links `SPEC_COMPLIANCE.md` and documents the private-registry flag.
-- [ ] Full release gate passes: `ruff check`, `ruff format --check`, `mypy
+- [x] README links `SPEC_COMPLIANCE.md` and documents the private-registry flag.
+- [x] Full release gate passes: `ruff check`, `ruff format --check`, `mypy
   src/pmcp`, `pytest -q` (TMPDIR outside `/tmp`), `uv build`, `git diff --check`.
 
 **Scope notes**
@@ -362,14 +362,14 @@ full release gate.
 
 ## Acceptance Criteria
 
-- [ ] PMCP satisfies the folded-in 2025-11-25 MUST/SHOULD items, and
+- [x] PMCP satisfies the folded-in 2025-11-25 MUST/SHOULD items, and
   `SPEC_COMPLIANCE.md` tracks per-requirement status plus a draft-revision
   migration assessment — each with adversarial tests / cited SEPs.
-- [ ] Registry refresh can sync incrementally via `updated_since`, merging deltas
+- [x] Registry refresh can sync incrementally via `updated_since`, merging deltas
   into the cache and degrading to a full fetch on cold cache or error.
-- [ ] An opt-in default-OFF flag enables private/custom registries and
+- [x] An opt-in default-OFF flag enables private/custom registries and
   draft-schema tolerance for debugging, with flag-off behavior provably unchanged.
-- [ ] Full release gate passes and `__version__ == 1.15.0`.
+- [x] Full release gate passes and `__version__ == 1.15.0`.
 
 ## Verification
 


### PR DESCRIPTION
v9, v10 and v11 had **0 of 97** exit criteria ticked despite the work having shipped — v11's six phases are all merged and released as pmcp 2.0.0. Roadmaps v1–v6 were ticked; the practice lapsed after v6.

Not cosmetic: a planning agent read v11 during the P3B work and had to reason about what was real, because the document claimed nothing was done.

## 96 of 97 ticked, each against evidence

A test that exercises it, code at a path actually read in this tree (**not** the line numbers written in the roadmaps — those have drifted), a merged diff, or the published artifact. Explicitly not accepted: the roadmap saying it was planned, or a commit message asserting something its diff doesn't show.

Only checkbox characters changed. `git diff` on these three files contains nothing but `- [ ]` → `- [x]`.

## Three were unmet when the audit ran — closed for real, not ticked optimistically

- **EC-P1-2** wanted *"a manually dispatched run passes on unchanged `main`"*. The only prior `workflow_dispatch` had run on a release branch, not `main`. Dispatched `test.yml` on `main` (`b387f06`) → [run 31508106075](https://github.com/Consiliency/pmcp/actions/runs/31508106075), success.
- **EC-P2-8** required #112 closed *"with a comment pointing at this roadmap"*; the only comment was dependabot's auto-reply. [Comment posted](https://github.com/Consiliency/pmcp/pull/112#issuecomment-5255356495).
- **EC-PG-4** wanted the 2.x gateway serving `pangram::analyze` — deferred by design until P2 landed, then never run. Verified against the live 2.0.0 gateway: `connect_server` took pangram `lazy → online`, and `invoke` returned a live classification from the Pangram API.

## One left unticked, because it is genuinely unmet

**v9 PRIVREG criterion 1** wants the private-registry opt-in as *"env var + config field"*. Only `PMCP_REGISTRY_ALLOW_PRIVATE` was ever built; `config/loader.py` has no registry surface at all. Filed as #139 rather than ticked — a wrongly-ticked criterion is a false claim that future planning would trust.

## Judgment calls, flagged not buried

Several criteria drifted from what shipped and were ticked on the stronger reading — e.g. EC-P6CLEAN-1 says "polls job state" where the fix `await`s the monitor task directly (strictly stronger, and the criterion's real requirement was "no wall-clock dependency"); EC-P5-3 says "six consumers" where seven exist and all seven are proven. Each is recorded in the audit rather than silently resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->