### PR TITLE
chore: v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-11
+
 ### Fixed
+- `gateway.describe` no longer claims a technical failure on success. The
+  feedback hint it emitted opens with "Technical failure detected", and it
+  was attached unconditionally, so every *successful* describe told the
+  client something had gone wrong. `invoke`'s success path already passed
+  none; this site did not follow that convention. All 25 hint call sites
+  were audited -- the other 24 are genuine failure paths and are unchanged.
+- Tool risk classification now honours the server's own MCP
+  `ToolAnnotations`. A tool declaring `readOnlyHint` / `destructiveHint`
+  states this authoritatively; PMCP was overriding that with a keyword
+  guess. The fallback heuristic also matched risk words as *substrings*
+  against the whole description, so context7's read-only
+  `resolve-library-id` was classified high-risk and reported as one that
+  "may modify data" -- because its description says "Source Reputation",
+  and "reputation" contains "put". The fallback now matches on word
+  boundaries. Risk is advisory (display and `catalog_search` filtering);
+  policy does not gate on it, so this is not a security change.
+- A gateway with no downstream server connected no longer tells clients it
+  has no tools. Downstream servers are lazy unless listed in `autoStart`,
+  so "MCP Gateway: No tools currently available" was what a fresh gateway
+  sent *every* client on connect, while its own ~26 meta-tools were
+  available and were the route to everything else. The message now says no
+  downstream server is connected yet, that this is normal, and names the
+  tools that do work. Both the cached and template paths share one helper
+  so the first impression cannot differ by cache state.
 - Remote downstream transports (SSE, streamable HTTP) are now entered and
   closed in a dedicated per-client owner task, fixing an anyio cancel-scope
   task-ownership violation during teardown: the exit stack used to be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.0.0"
+version = "2.0.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/tests/mcp2x/test_subscription_contract.py
+++ b/tests/mcp2x/test_subscription_contract.py
@@ -362,17 +362,32 @@ def test_changelog_2_0_0_block_leads_with_removed_and_names_the_breaking_change(
 
 
 def test_pyproject_and_init_version_strings_agree_with_the_changelog_heading() -> None:
+    """All three version sites agree -- whatever the current version is.
+
+    This originally pinned the literal "2.0.0", which made it a test that
+    fails on every future release rather than a guard on the invariant it
+    exists to protect. P1's drift test already pins `pyproject.toml` against
+    `src/pmcp/__init__.py`; nothing pins either against the CHANGELOG, which
+    is the gap that let a release ship a heading its sources disagreed with.
+    So: read the version, don't assert it.
+    """
     pyproject_text = (REPO_ROOT / "pyproject.toml").read_text()
     init_text = (REPO_ROOT / "src" / "pmcp" / "__init__.py").read_text()
 
-    assert re.search(r'^version = "2\.0\.0"', pyproject_text, re.MULTILINE), (
-        pyproject_text
-    )
-    assert re.search(r'^__version__ = "2\.0\.0"', init_text, re.MULTILINE), init_text
+    pyproject_match = re.search(r'^version = "([^"]+)"', pyproject_text, re.MULTILINE)
+    assert pyproject_match, pyproject_text
+    version = pyproject_match.group(1)
 
-    # And the [2.0.0] block itself must exist (redundant with the test
-    # above, but this is the one place all three sites are checked together).
-    _changelog_2_0_0_block()
+    assert re.search(
+        rf'^__version__ = "{re.escape(version)}"', init_text, re.MULTILINE
+    ), f"pyproject.toml says {version!r}; src/pmcp/__init__.py disagrees:\n{init_text}"
+
+    changelog_text = (REPO_ROOT / "CHANGELOG.md").read_text()
+    assert re.search(rf"^## \[{re.escape(version)}\]", changelog_text, re.MULTILINE), (
+        f"sources say {version!r} but CHANGELOG.md has no '## [{version}]' heading -- "
+        "a release whose notes and sources disagree reports the wrong version from "
+        "/health and the pmcp/{version} User-Agent"
+    )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Patch release of the four fixes merged since 2.0.0. No breaking changes.

## Contents

- **#137** — per-client owner task for remote transport teardown, closing the anyio cancel-scope violation deferred through three phases
- **#138** — tool risk honours the server's own `readOnlyHint`/`destructiveHint`; word-boundary matching so "Source Re**put**ation" stops meaning "put"
- **#138** — `gateway.describe` no longer claims "Technical failure detected" on success
- **#135** — a fresh gateway no longer tells every client it has no tools

## Two of these had no CHANGELOG entry

P3B's single-writer discipline for the `[Unreleased]` block didn't carry over to the ad-hoc PRs that followed, so the block covered only the anyio fix. Entries added for the other three — without which the release notes would have understated what shipped.

## The version guard fired, and that is it working

`test_pyproject_and_init_version_strings_agree_with_the_changelog_heading` went red on the bump. It hardcoded `"2.0.0"`, making it a test that fails on **every** future release rather than a guard on the invariant it protects.

Rewritten to read the version from `pyproject.toml` and assert `__init__.py` and the CHANGELOG heading agree with it, whatever it is. Verified it still catches a real mismatch: setting `__version__` to `9.9.9` turns it red, restoring turns it green.

Worth keeping the distinction — P1's drift test pins `pyproject` against `__init__`; **nothing** pinned either against the CHANGELOG, which is the gap this guard exists for and now actually covers. The neighbouring test asserting the `[2.0.0]` block leads with `### Removed` stays pinned to 2.0.0 deliberately: that's a historical fact about that release, not an invariant.

## Verification

Full suite **2508 passed / 3 skipped / 0 failed**; ruff, format, mypy (42 files) clean; `uv lock` regenerated; P1's drift test green on the bumped version.

Merging and tagging `v2.0.1` triggers release.yml → PyPI via trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->