### PR TITLE
fix: add allowPrivateRegistry config field alongside the env var

### DIFF
--- a/src/pmcp/config/loader.py
+++ b/src/pmcp/config/loader.py
@@ -312,6 +312,66 @@ def _read_config_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     return data, None
 
 
+REGISTRY_ALLOW_PRIVATE_CONFIG_KEY = "allowPrivateRegistry"
+
+
+def registry_allow_private_from_config(
+    project_root: Path | None = None,
+    user_config_paths: Sequence[Path] | None = None,
+    custom_config_path: Path | None = None,
+) -> bool | None:
+    """Read the top-level ``allowPrivateRegistry`` flag from the config files.
+
+    The private-registry opt-in was env-var-only (`PMCP_REGISTRY_ALLOW_PRIVATE`),
+    which roadmap v9's PRIVREG criterion specified as "env var + config field"
+    (Consiliency/pmcp#139). This is the config half.
+
+    Precedence matches `load_configs`: project > user > custom, first match
+    wins. Returns ``None`` when no config file states a preference, so the
+    caller can distinguish "not configured" from "configured false" -- the env
+    var only overrides when it is explicitly set, and an explicit ``false``
+    here must not be silently upgraded by an absent env var.
+
+    Deliberately a plain reader rather than module-level state mutated at load
+    time: a process-global toggle is exactly the shape that made
+    `sse_starlette`'s `AppStatus.should_exit` latch so hard to diagnose.
+    """
+    candidates: list[Path] = []
+    if project_root is not None:
+        candidates.append(Path(project_root) / ".mcp.json")
+    candidates.extend(
+        list(user_config_paths)
+        if user_config_paths is not None
+        else default_user_config_paths()
+    )
+    if custom_config_path is not None:
+        candidates.append(Path(custom_config_path))
+
+    for path in candidates:
+        raw, error = _read_config_object(path)
+        if raw is None:
+            if error is not None:
+                logger.warning(
+                    "Ignoring %s while reading %s: %s",
+                    REGISTRY_ALLOW_PRIVATE_CONFIG_KEY,
+                    path,
+                    error,
+                )
+            continue
+        if REGISTRY_ALLOW_PRIVATE_CONFIG_KEY not in raw:
+            continue
+        value = raw[REGISTRY_ALLOW_PRIVATE_CONFIG_KEY]
+        if isinstance(value, bool):
+            return value
+        logger.warning(
+            "Ignoring %s in %s: expected a boolean, got %r",
+            REGISTRY_ALLOW_PRIVATE_CONFIG_KEY,
+            path,
+            value,
+        )
+    return None
+
+
 def _parse_config_or_warn(path: Path) -> McpConfigFile | None:
     """Parse a config file, surfacing a WARNING when it exists but is malformed.
 

--- a/src/pmcp/manifest/registry.py
+++ b/src/pmcp/manifest/registry.py
@@ -114,18 +114,30 @@ def default_registry_cache_path() -> Path:
     return base / "pmcp" / "registry-cache.json"
 
 
-def registry_private_enabled() -> bool:
+def registry_private_enabled(config_value: bool | None = None) -> bool:
     """Opt-in flag (default OFF) for private registries + draft-schema tolerance.
 
     Aimed at developers debugging their own private MCP servers against PMCP.
     With it off, PMCP uses only the public registry and the GA-shaped behavior.
+
+    Two sources, since roadmap v9's PRIVREG criterion specified "env var +
+    config field" and only the env var was built (Consiliency/pmcp#139).
+    `config_value` is the `allowPrivateRegistry` config field, or ``None`` when
+    no config file states a preference.
+
+    The env var wins **only when explicitly set**. Absence is not a preference:
+    reading an unset env var as ``false`` would silently override a config file
+    that said ``true``, which is the whole point of adding the field.
     """
-    return os.environ.get(REGISTRY_ALLOW_PRIVATE_ENV, "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    raw = os.environ.get(REGISTRY_ALLOW_PRIVATE_ENV)
+    if raw is not None and raw.strip():
+        return raw.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+    return bool(config_value)
 
 
 def _is_loopback_endpoint_host(hostname: str) -> bool:
@@ -163,7 +175,10 @@ def _private_endpoint_allowed(endpoint: str) -> bool:
     return parsed.scheme == "http" and _is_loopback_endpoint_host(hostname)
 
 
-def effective_registry_endpoint(default: str = DEFAULT_REGISTRY_ENDPOINT) -> str:
+def effective_registry_endpoint(
+    default: str = DEFAULT_REGISTRY_ENDPOINT,
+    config_value: bool | None = None,
+) -> str:
     """Return the configured private registry endpoint only when opt-in is on.
 
     Flag off (default): the configured private endpoint is ignored and the
@@ -171,7 +186,7 @@ def effective_registry_endpoint(default: str = DEFAULT_REGISTRY_ENDPOINT) -> str
     https:// (or loopback http://) URL that does not target a link-local or
     metadata host; otherwise it is rejected and the public endpoint is used.
     """
-    if registry_private_enabled():
+    if registry_private_enabled(config_value):
         private = os.environ.get(REGISTRY_PRIVATE_ENDPOINT_ENV, "").strip()
         if private:
             if _private_endpoint_allowed(private):

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -31,6 +31,7 @@ from pmcp.auth import (
 from pmcp.client.manager import ClientManager
 from pmcp.config.guidance import GuidanceConfig
 from pmcp.config.loader import (
+    registry_allow_private_from_config,
     StartupObservationSnapshot,
     StartupSkipReason,
     build_startup_observation_snapshot,
@@ -2975,7 +2976,16 @@ class GatewayTools:
         cached = load_registry_cache()
         if cached is not None and cached.servers:
             return cached
-        endpoint = effective_registry_endpoint()
+        # The private-registry opt-in has two sources (#139): the env var and
+        # the `allowPrivateRegistry` config field. Resolve the config half here,
+        # where the config paths are known, rather than reaching for global
+        # state inside registry.py.
+        endpoint = effective_registry_endpoint(
+            config_value=registry_allow_private_from_config(
+                project_root=self._project_root,
+                custom_config_path=self._custom_config_path,
+            )
+        )
         # Draft-schema tolerance applies only when actually using a private
         # endpoint, so enabling the flag never changes public-registry results.
         fetched = await fetch_registry_servers(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -461,3 +461,95 @@ async def test_allow_draft_schema_includes_non_latest(monkeypatch) -> None:
     )
     assert {s.name for s in on.servers} == {"Latest", "Draft"}
     assert "registry_draft_schema_allowed" in on.diagnostics
+
+
+def test_config_field_enables_private_registry_without_the_env_var(
+    monkeypatch, tmp_path
+) -> None:
+    """The config half of v9 PRIVREG's "env var + config field" (#139).
+
+    Only the env var was ever built, so an operator whose gateway config lives
+    in a file had no way to express this without editing the unit's
+    environment. The default stays OFF.
+    """
+    import json
+
+    from pmcp.config.loader import registry_allow_private_from_config
+    from pmcp.manifest.registry import registry_private_enabled
+
+    monkeypatch.delenv("PMCP_REGISTRY_ALLOW_PRIVATE", raising=False)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    # No config file at all: still off, and "no preference" is None, not False.
+    assert (
+        registry_allow_private_from_config(project_root=project, user_config_paths=[])
+        is None
+    )
+
+    (project / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {}, "allowPrivateRegistry": True})
+    )
+    value = registry_allow_private_from_config(
+        project_root=project, user_config_paths=[]
+    )
+    assert value is True
+    assert registry_private_enabled(value) is True
+
+
+def test_env_var_overrides_the_config_field_only_when_explicitly_set(
+    monkeypatch, tmp_path
+) -> None:
+    """Absence of the env var is not a preference.
+
+    Reading an unset `PMCP_REGISTRY_ALLOW_PRIVATE` as "false" would silently
+    override a config file that said true -- which would defeat the point of
+    adding the field. An explicitly-set env var still wins in both directions.
+    """
+    import json
+
+    from pmcp.config.loader import registry_allow_private_from_config
+    from pmcp.manifest.registry import registry_private_enabled
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {}, "allowPrivateRegistry": True})
+    )
+    config_true = registry_allow_private_from_config(
+        project_root=project, user_config_paths=[]
+    )
+
+    # Unset env: the config field stands.
+    monkeypatch.delenv("PMCP_REGISTRY_ALLOW_PRIVATE", raising=False)
+    assert registry_private_enabled(config_true) is True
+
+    # Empty-string env is also not a preference.
+    monkeypatch.setenv("PMCP_REGISTRY_ALLOW_PRIVATE", "")
+    assert registry_private_enabled(config_true) is True
+
+    # Explicitly off: env wins over a config field that said true.
+    monkeypatch.setenv("PMCP_REGISTRY_ALLOW_PRIVATE", "0")
+    assert registry_private_enabled(config_true) is False
+
+    # Explicitly on: env wins over a config field that said false.
+    monkeypatch.setenv("PMCP_REGISTRY_ALLOW_PRIVATE", "1")
+    assert registry_private_enabled(False) is True
+
+
+def test_non_boolean_config_field_is_ignored_not_coerced(monkeypatch, tmp_path) -> None:
+    """A truthy string must not silently enable a security-relevant opt-in."""
+    import json
+
+    from pmcp.config.loader import registry_allow_private_from_config
+
+    monkeypatch.delenv("PMCP_REGISTRY_ALLOW_PRIVATE", raising=False)
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {}, "allowPrivateRegistry": "yes"})
+    )
+    assert (
+        registry_allow_private_from_config(project_root=project, user_config_paths=[])
+        is None
+    )


### PR DESCRIPTION
Closes #139.

Roadmap v9's PRIVREG criterion specified the private-registry opt-in as *"a single config flag (**env var + config field**)"*. Only the env var was ever built — `config/loader.py` had no registry surface at all. Found by the v9/v10/v11 audit as **the one criterion of 97 that was genuinely unbuilt** rather than merely unticked.

`allowPrivateRegistry` is now a top-level boolean in the config file, beside the existing `autoStart` key, resolved project > user > custom to match `load_configs`.

## Two decisions worth stating

**Absence of the env var is not a preference.** The old reader treated an unset variable as `false`. Threading a config value through it naively would have let an *absent* env var silently override a config file that said `true` — defeating the point of the field. The env var now wins only when explicitly set, in both directions: an explicit `"0"` still overrides a config field that said true.

**The value is threaded as a parameter, not held in module state.** A process-global toggle set at config-load time would have been a smaller diff — and it is exactly the shape that made `sse_starlette`'s `AppStatus.should_exit` latch so hard to diagnose earlier in this same effort. Not repeating that pattern on purpose.

**Non-boolean values are ignored with a warning, not coerced.** A truthy string must not silently enable a security-relevant opt-in.

## Verification

Three tests, each **proven to catch the gap** — reverting only the source turns all three red, restoring turns them green:

```
FAILED test_config_field_enables_private_registry_without_the_env_var
FAILED test_env_var_overrides_the_config_field_only_when_explicitly_set
FAILED test_non_boolean_config_field_is_ignored_not_coerced
```

Full suite **2511 passed / 3 skipped / 0 failed**; ruff, format, mypy (42 files) clean. Default remains OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->