### PR TITLE
feat(manifest): add telnyx now that an official MCP server exists

### DIFF
--- a/src/pmcp/manifest/manifest.yaml
+++ b/src/pmcp/manifest/manifest.yaml
@@ -953,6 +953,20 @@ servers:
     env_var: "TWILIO_ACCOUNT_SID"
     env_instructions: "Set TWILIO_ACCOUNT_SID, TWILIO_API_KEY, TWILIO_API_SECRET from https://console.twilio.com"
 
+  telnyx:
+    description: "Telnyx communications - voice calls, SMS/MMS, phone numbers, messaging profiles"
+    keywords: [telnyx, sms, mms, voice, calls, phone, numbers, messaging, telephony, communication, api]
+    install:
+      mac: ["npx", "-y", "telnyx-mcp"]
+      linux: ["npx", "-y", "telnyx-mcp"]
+      wsl: ["npx", "-y", "telnyx-mcp"]
+      windows: ["npx", "-y", "telnyx-mcp"]
+    command: "npx"
+    args: ["-y", "telnyx-mcp"]
+    requires_api_key: true
+    env_var: "TELNYX_API_KEY"
+    env_instructions: "Set TELNYX_API_KEY from https://portal.telnyx.com/#/app/api-keys. TELNYX_PUBLIC_KEY, TELNYX_CLIENT_ID and TELNYX_CLIENT_SECRET are also supported for webhook verification and OAuth."
+
   mailgun:
     description: "Mailgun email API - send emails, manage domains, mailing lists, templates"
     keywords: [mailgun, email, sending, transactional, smtp, domains, templates, api]


### PR DESCRIPTION
Half of #77.

## What changed upstream

That issue deferred Telnyx because `telnyx-mcp` on npm was at **v6.83.0**, tracking the Telnyx *SDK* version line rather than being an MCP server, and no remote endpoint resolved.

It is now **v7.13.0**, described as *"The official MCP Server for the Telnyx API"*, maintained by `team-telnyx <admin@telnyx.com>` and published from `github.com/team-telnyx/telnyx-node` under `packages/mcp-server`. Ownership verified before adding, as the issue explicitly asked.

Worth noting how this was missed: the earlier check searched the **MCP registry** only, and a vendor can publish to npm without registering. Registry absence is not evidence of non-existence.

## Verified, not assumed

- **Env vars read from the package**, not guessed — unpacked the tarball: `TELNYX_API_KEY` is the credential, with `TELNYX_PUBLIC_KEY` / `TELNYX_CLIENT_ID` / `TELNYX_CLIENT_SECRET` also supported.
- **The server actually runs.** Spawned it over stdio and completed a handshake: `protocolVersion 2025-11-25`, `serverInfo: telnyx_api 7.2.0`. A manifest entry that only proves the YAML parses proves very little.
- **Windows install matches the dominant convention** — bare `npx`, which is 82 entries to 1 in this manifest.

## One thing to know before enabling it

Its primary tool is `execute` — *"Run TypeScript code against a pre-authenticated SDK client"*. That is a **code-execution surface**, not a narrow API wrapper. PMCP classifies it HIGH risk, correctly, via the word-boundary matching shipped in 2.0.1. Flagging it because "add a comms server" doesn't convey that shape.

## Algolia stays deferred

No `@algolia/mcp`, no `algolia-mcp`, nothing on PyPI — npm returns only their regular API clients. **#77 stays open** for that half.

Full suite **2521 passed / 3 skipped / 0 failed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->