### PR TITLE
chore: v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-12
+
+### Added
+- **`allowPrivateRegistry` config field.** The private-registry opt-in was
+  env-var-only (`PMCP_REGISTRY_ALLOW_PRIVATE`), which roadmap v9's PRIVREG
+  criterion specified as "env var + config field"; only the env var was ever
+  built. It is now also a top-level boolean in the config file, beside
+  `autoStart`, resolved project > user > custom. The env var still wins, but
+  **only when explicitly set** -- an unset variable is not a preference, so it
+  cannot silently override a config file that enabled the flag. Non-boolean
+  values are ignored with a warning rather than coerced, so a truthy string
+  cannot quietly enable a security-relevant opt-in. Default remains OFF.
+  (Consiliency/pmcp#139)
+- **`telnyx` manifest entry.** Telnyx now publishes an official MCP server
+  (`telnyx-mcp`, maintained by `team-telnyx`, from
+  `github.com/team-telnyx/telnyx-node`); the entry was previously deferred
+  because the package name then tracked the Telnyx SDK version line. Note its
+  primary tool is `execute`, which runs TypeScript against a pre-authenticated
+  SDK client -- a code-execution surface rather than a narrow API wrapper, and
+  classified HIGH risk accordingly. (Consiliency/pmcp#77, partial: Algolia
+  still has no official server and remains deferred.)
+
 ## [2.0.1] - 2026-08-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.0.1"
+version = "2.1.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.0.1"
+__version__ = "2.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.0.1"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Next batch — the two commits merged since 2.0.1.

## Minor, not a patch

Both changes are **additive**, not repairs: `allowPrivateRegistry` adds a config surface that didn't exist, and the telnyx entry makes a server available that wasn't. Neither fixes broken behaviour, so `2.0.2` would understate them.

- **`allowPrivateRegistry` config field** (#139) — closes the "env var + config field" gap that roadmap v9 specified and only half-built. Env var still wins, but only when *explicitly* set, so an unset variable can't silently override a config file that enabled it. Non-boolean values are ignored with a warning rather than coerced. Default remains OFF.
- **`telnyx` manifest entry** (#77, partial) — Telnyx now publishes an official MCP server. Its primary tool is `execute`, which runs TypeScript against a pre-authenticated SDK client, so it's a code-execution surface rather than a narrow API wrapper, and is classified HIGH risk accordingly. Algolia still has no official server and stays deferred.

## Both CHANGELOG entries were backfilled

Neither PR added one. **Second consecutive release needing this** — P3B's single-writer discipline for the `[Unreleased]` block didn't survive into the ad-hoc PRs that followed. Worth a CI check that a PR touching `src/` or the manifest also touches `CHANGELOG.md`, rather than catching it at release time. Filing that as a follow-up rather than bolting it onto a release PR.

## The version guards did their job

Both pass on the bump: P1's drift test (`pyproject` vs `__init__`) and the coherence test generalised in 2.0.1 (sources vs the CHANGELOG heading). The latter would have gone **red** on this bump in its old hardcoded form — that generalisation earning its keep one release later.

Full suite **2521 passed / 3 skipped / 0 failed**; ruff, mypy (42 files) clean; `uv lock` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPkh9gfqshFGbtjJWxXzTi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->