### PR TITLE
investigation: 'SSE stream ended without a response' -- reproduced, root-caused, no fix included

### DIFF
--- a/.consiliency/notes/sse-stream-ended-investigation-20260812.md
+++ b/.consiliency/notes/sse-stream-ended-investigation-20260812.md
@@ -1,7 +1,12 @@
 # Investigation: intermittent "SSE stream ended without a response"
 
-Status: IN PROGRESS — draft written while probe trials run; final numbers
-filled in below once the batch completes.
+Status: **DONE — reproduced reliably, root-caused, no fix shipped.** The
+exact reported error string is reproduced by killing the downstream peer
+process mid-response, in the post-headers/pre-completion window: 40%
+(16/40) when the kill lands during a follow-up tool call, 6% (3/50) when it
+lands during the initial `connect_server()`/`initialize` handshake — the
+exact call site named in the symptom. The message is accurate in every
+case; there is no pmcp defect to fix. See "Conclusion" below.
 
 ## Symptom
 
@@ -145,8 +150,199 @@ concurrently starts `disconnect_server(name, force=True)` for the *same*
 server after a random 0–20ms delay, racing teardown against the still-open
 SSE read.
 
-<!-- INTERRUPT_RESULTS_PLACEHOLDER -->
+**0/40 trials, 1,200 race attempts, 0 target hits, 0 sibling hits.** But not
+"clean" — 5-12 of each trial's 30 races (roughly a third overall) produced a
+bare `CancelledError`. Root cause of *that*: `disconnect_server` calls
+`cancel_pending_requests(name)` (manager.py:826-... , cancelling
+`pending.future`) **before** it closes the remote transport
+(`_close_remote_transport`). The pending future — the thing
+`gateway.invoke()` is awaiting via `send_request` /
+`_await_with_idle_timeout` (manager.py:2039-2134) — is a pmcp-level object,
+entirely separate from the mcp SDK's own `read_stream`/`_handle_sse_response`
+machinery. Cancelling it wins the race every time it fires: `gateway.invoke()`
+sees `CancelledError` immediately, well before the mcp SDK's transport
+owner task has even started unwinding, let alone before `_handle_sse_response`
+could notice the connection dying and synthesize its own error. **A
+disconnect that pmcp itself initiates against a server with an in-flight
+request can therefore never surface this exact message through
+`gateway.invoke()`** — pmcp's own cancellation always gets there first.  This
+rules out "concurrent `disconnect_server` racing an in-flight request to the
+same server" as a source, on top of Run 1 already having found no evidence
+for "healthy peer, high organic connect/disconnect/invoke concurrency" as a
+source.
+
+### Dead end, documented so it isn't retried: in-process task-cancel
+
+Before building the SIGKILL variant below, first tried
+`sse_flake_probe_serverkill.py`: cancel the peer's own `uvicorn.Server.serve()`
+asyncio task (`task.cancel()`, not a graceful `should_exit = True`) while a
+client request is in flight, in the *same* process as the client (no
+subprocess). Result: **0/10 races even touched** — every tool call
+completed successfully regardless of the kill. Cancelling the outer
+`serve()` task does not reliably tear down already-accepted connection
+handlers (they run as separate tasks/transports uvicorn's cancellation
+doesn't reach), so the client-visible TCP connection kept working. Confirmed
+via `appstatus_before`/`appstatus_after` in its JSON output that this
+approach also never trips the process-global `AppStatus.should_exit` latch
+(good for safety, useless for reproduction). Not pursued further — recorded
+here so a future attempt doesn't waste time on the same approach.
+
+### Result — peer-process SIGKILL variant (reproduces the exact symptom)
+
+`sse_flake_probe_sigkill.py` runs the peer in its own OS process
+(`_serverkill_runner.py`) and sends it `SIGKILL` at a random delay after
+starting a `gateway.invoke()` tool call — the kernel then force-closes every
+fd of that process, including the client's live socket, which an in-process
+`task.cancel()` could not do. This is **not** routed through any pmcp
+disconnect code (`disconnect_server`/`cancel_pending_requests` are never
+called until the `finally:` cleanup, after the race already resolved), so it
+tests the third hypothesis: a peer that dies for reasons entirely outside
+pmcp, mid-response.
+
+| variant | delay window | trials | target hits | rate |
+|---|---|---|---|---|
+| mid-tool-call kill, trial 0 | 0-5ms | 10 kills | 4 | 40% |
+| mid-tool-call kill, trial 2 | 0-6ms | 30 kills | 12 | 40% |
+| **mid-tool-call kill, combined** | 0-6ms | **40 kills** | **16** | **40%** |
+
+Sample hit (via `gateway.invoke()`'s own error envelope):
+```
+{"code":"E302","message":"SSE stream ended without a response",
+ "details":{"tool_id":"probe-sigkill::fr_echo"},
+ "suggestion":"Check tool arguments and server status","retryable":false}
+```
+The other ~60% surfaced as `E201 Server probe-sigkill disconnected`
+(pmcp's own dispatcher noticing the read stream broke), not a crash and not
+the sibling message — consistent with the kill landing outside the narrow
+post-headers window (see below).
+
+**This reliably, mechanistically reproduces the target failure mode.** It
+is real and reachable through pmcp's actual client code, not a probe
+artifact — see the exact-symptom confirmation below.
+
+### Result — SIGKILL during the INITIAL connect (matches the reported symptom's exact call site)
+
+The originally reported text is specifically `Failed to connect to <name>:
+SSE stream ended without a response` — the format `connect_all()` /
+`connect_server()` wrap around a failed `_connect_singleflight` (manager.py).
+`initialize` is a `JSONRPCRequest` answered over SSE exactly like
+`tools/call` (Step 1), so `sse_flake_probe_sigkill_connect.py` races the
+same `SIGKILL` against `manager.connect_server()` itself instead of a
+follow-up tool call.
+
+| delay window | trials | target hits | rate |
+|---|---|---|---|
+| 0-8ms | 15 kills | 0 | 0% |
+| 1-6ms, trial 1 | 20 kills | 2 | 10% |
+| 1-6ms, trial 2 | 30 kills | 1 | 3% |
+| **1-6ms, combined** | | **50 kills** | **3** | **6%** |
+
+Sample hit, verbatim, matching the reported symptom exactly:
+```
+Failed to connect to probe-connect-kill: SSE stream ended without a response
+```
+The 0-8ms window (no hits) and the bulk of the 1-6ms window's misses
+(`unhandled errors in a TaskGroup (1 sub-exception)`, wrapping an
+`httpx2.ReadError`) show *why* the rate is lower here than for the
+tool-call variant: a kill early enough to land before the peer has even
+sent SSE response *headers* raises inside `client.stream()`'s `__aenter__`
+(`_handle_post_request`, manager's underlying `httpx2.AsyncClient.stream`)
+-- **outside** `_handle_sse_response`'s bare `except Exception: pass`
+(streamable_http.py:447-448), so it propagates as a raw connection error
+through the anyio task group instead of being caught and turned into the
+target message. Only a kill that lands *after* headers arrive but *before*
+the response completes reaches the swallow-and-resolve path that produces
+this exact string -- correspondingly narrower window, correspondingly lower
+hit rate, for a `initialize` round-trip that's fast in-process versus a
+`tools/call`.
+
+## Conclusion
+
+**Root cause identified, but it is not a pmcp defect.** Across every
+variant tested:
+
+- Healthy peers, arbitrarily high organic connect/disconnect/invoke
+  concurrency (Run 1: 240 `connect_all()` batches, 7,200 SSE-response tool
+  calls, 1,200 disconnects) — **zero** reproductions. No evidence of a
+  client-side race, `httpx2` connection-pool staleness
+  (`keepalive_expiry=5.0`), or pmcp lifecycle-lock interaction producing
+  this message while the peer stays up. This isn't just unobserved at this
+  probe's scale — the connect-time SIGKILL boundary finding *structurally
+  excludes* the stale-pooled-connection hypothesis specifically: a
+  connection the server already closed cannot deliver fresh SSE response
+  headers on reuse, so that failure mode surfaces in `client.stream()`'s
+  `__aenter__` (the `TaskGroup`/`ReadError` flavor from the connect-time
+  results table above), never inside `_handle_sse_response`'s swallow-and-
+  resolve path that produces the target string.
+- pmcp's own `disconnect_server` racing an in-flight request to the same
+  server (1,200 attempts) — **zero** reproductions of the target message;
+  pmcp's own `cancel_pending_requests` always wins that race first, so this
+  path structurally cannot be the source either.
+- The **only** thing that reliably reproduces the exact reported string,
+  at both the tool-call site (40% hit rate in the right timing window) and
+  the connect-time site named in the original symptom (6% hit rate, exact
+  string match), is **the peer process dying while it is mid-response** to
+  an SSE-framed request, specifically after it has sent response headers
+  but before it finishes streaming the JSON-RPC response.
+
+Given Step 1's finding that `mcp.server.MCPServer` built without an
+`event_store` (true of every downstream this repo tests against, and
+plausibly true of most real ones too, since resumability is opt-in) never
+attaches an SSE event `id`, **any** such mid-response peer death is
+permanently unresumable and unconditionally produces this exact message —
+there is no code defect here to fix; this is the mcp SDK correctly
+reporting that it cannot get a response from a peer that is no longer
+there. The "load-correlated, several servers connect/disconnect around the
+same time" framing is consistent with this: busy periods are exactly when a
+downstream server process is more likely to be OOM-killed, restarted, or
+recycled by its own supervisor, and precisely mid-response is an ordinary
+place for a killed process to be caught.
+
+**No fix is included in this PR.** There is nothing incorrect in
+`src/pmcp/client/manager.py` or in how it uses the mcp SDK's transport to
+change; the message is accurate. Per the task's own instructions, a
+speculative fix for a hypothesis this note could not confirm (client-side
+race / connection-pool staleness) is deliberately not being shipped.
 
 ## What would be tried next with more time
 
-(filled in after the reproduction attempt, whichever branch it lands on)
+- **Confirm the downstream-server-death hypothesis against the real fleet**:
+  correlate actual `SSE stream ended without a response` occurrences in
+  production/CI logs against downstream server process restarts, OOM
+  kills, or supervisor-triggered recycles in the same time window. If they
+  line up, this closes the loop with the connect-time-SIGKILL finding above
+  and confirms there is nothing left to chase on the pmcp side.
+- **Observability improvement (not a bug fix, not attempted here)**:
+  `connect_server`'s error message could distinguish "the peer died
+  mid-response" (this failure mode -- likely retryable moments later once
+  the peer restarts) from other SSE-transport failures, so an operator
+  reading `Failed to connect to <name>: SSE stream ended without a
+  response` has a more actionable signal than the raw upstream string.
+  Speculative; would need product input on desired wording/behavior (e.g.
+  whether `connect_server`/`connect_all` should auto-retry once for this
+  specific error class) before implementing.
+- **Real TCP-level interruption** (a proxy/load-balancer dropping the
+  connection rather than the peer process dying) was not separately tested;
+  SIGKILL of the peer process was used as the closest available local
+  proxy for "the connection dies mid-response for reasons outside pmcp".
+  If the real fleet's downstream servers sit behind a proxy/LB, that is a
+  distinct mechanism worth its own probe (e.g. an `iptables` REJECT/DROP
+  rule toggled mid-response, or a deliberately misbehaving intermediary)
+  before ruling it out.
+
+## Probe scripts (committed alongside this note)
+
+- `scripts/probes/sse_flake_probe.py` + `run_sse_flake_probe.py` — organic
+  load (Run 1).
+- `scripts/probes/sse_flake_probe_interrupt.py` +
+  `run_sse_flake_probe_interrupt.py` — pmcp-side disconnect/invoke race.
+- `scripts/probes/sse_flake_probe_serverkill.py` — in-process task-cancel
+  (dead end, kept for the record).
+- `scripts/probes/sse_flake_probe_sigkill.py` /
+  `sse_flake_probe_sigkill_connect.py` + `_serverkill_runner.py` —
+  peer-process `SIGKILL`, mid-tool-call and mid-connect. These are the ones
+  that reproduce the reported symptom; run e.g.:
+  ```
+  uv run python scripts/probes/sse_flake_probe_sigkill_connect.py \
+      --kills 50 --min-delay-ms 1 --max-delay-ms 6 --trial-id 0
+  ```

--- a/.consiliency/notes/sse-stream-ended-investigation-20260812.md
+++ b/.consiliency/notes/sse-stream-ended-investigation-20260812.md
@@ -1,0 +1,152 @@
+# Investigation: intermittent "SSE stream ended without a response"
+
+Status: IN PROGRESS — draft written while probe trials run; final numbers
+filled in below once the batch completes.
+
+## Symptom
+
+`Failed to connect to <name>: SSE stream ended without a response`,
+intermittent, load-correlated: several downstream servers connecting or
+disconnecting around the same time, not a single quiet connect.
+
+## Step 1 — upstream trigger conditions
+
+Source: `mcp/client/streamable_http.py` (mcp 2.0.0, this worktree's
+`.venv/lib/python3.11/site-packages/mcp/client/streamable_http.py`),
+`StreamableHTTPTransport._handle_sse_response` (lines ~411-459) and its
+sibling `_handle_reconnection` (lines ~475-534).
+
+`_handle_sse_response` runs once per outbound JSON-RPC *request* whose POST
+got back a `text/event-stream` response (the normal case here: `fake_remote`
+/ any real `mcp.server.MCPServer` defaults `json_response=False`, so every
+request — `initialize`, every `tools/call` — answers over SSE, not plain
+JSON). The exact sequence that reaches `_resolve_abandoned_request(...,
+"SSE stream ended without a response")` (line 458):
+
+1. The POST got a `200` with `content-type: text/event-stream`, so control
+   entered `_handle_sse_response`.
+2. The `async for sse in event_source:` loop over that stream terminates —
+   either by running out of events (server closed the stream) or by an
+   exception raised while reading it — **before** `_handle_sse_event`
+   ever returns `True` (i.e., before the actual JSON-RPC response/error for
+   this request arrived). Any exception here is swallowed by a bare
+   `except Exception: logger.debug("SSE stream ended", exc_info=True)`
+   (line 447-448) — so a `RemoteProtocolError`, a `ReadError`, a connection
+   reset, an `httpx2.StreamClosed` — all look identical from this point on.
+3. `last_event_id` is still `None` — i.e., **no SSE event with an `id:`
+   field was ever received on this stream** before it ended. (If at least
+   one `id`-bearing event *had* arrived, control instead goes to
+   `_handle_reconnection`, whose own give-up path after
+   `MAX_RECONNECTION_ATTEMPTS` (=2) produces the sibling message "SSE
+   stream ended and reconnection attempts were exhausted" instead — a
+   different message for a related but distinguishable failure.)
+
+So the message specifically means: *a request got an SSE-framed response,
+and that stream was torn down (cleanly or via exception) before sending
+either the actual response or a single resumption-capable event.* Nothing
+in this function is pmcp-specific; it is purely a client-side reaction to
+what the peer connection did.
+
+Two concrete real-world shapes that satisfy this, both purely at the
+HTTP/TCP layer (no protocol violation needed):
+
+- **Stale pooled connection**: `httpx2.AsyncClient`'s connection pool
+  (`DEFAULT_LIMITS = Limits(max_connections=100, max_keepalive_connections=20,
+  keepalive_expiry=5.0)`, `.venv/lib/python3.11/site-packages/httpx2/_config.py:248`)
+  hands out a persistent connection that the *server* has since closed
+  (idle timeout, worker recycle, load-triggered connection churn). The
+  request write may partially succeed but the server never answers on that
+  socket; the client sees a reset/EOF with zero SSE bytes received —
+  `last_event_id` stays `None` by construction.
+- **Server closes an SSE response stream before its first byte** under its
+  own load (e.g. many sessions initializing/tearing down concurrently
+  causing the server's own anyio task group / session manager to cancel or
+  reap a handler before it ever calls `send()` for the first chunk).
+
+Both are consistent with "load-correlated, several servers connect/disconnect
+around the same time" — neither requires a bug in pmcp's own code; the
+question this investigation had to answer was whether one is real and
+reachable in-process, or whether pmcp's own transport-ownership /
+lifecycle-lock code contributes a third way to reach the same message.
+
+## Ruled out before this investigation started (do not re-litigate)
+
+`sse_starlette.sse.AppStatus.should_exit` is a **process-global class
+attribute**, latched `True` the first time any uvicorn server shuts down in
+the process and never reset — every SSE stream afterwards, in any event
+loop, against any server, terminates immediately with exactly this message.
+Diagnosed and fixed in `tests/runtime/fake_remote.py`'s `run_fake_remote`
+`finally:` block (resets `AppStatus.should_exit = False`) and documented in
+`.consiliency/plans/detailed-anyio-transport-task-ownership-20260811-0204.md`
+("Finding 2"). This investigation's probe (see below) is deliberately
+structured to avoid rediscovering it: every trial runs in its own fresh
+subprocess, and within a trial no server is torn down until the very end
+(after the manager's own `disconnect_all()`), so the process-global latch
+is never tripped mid-trial.
+
+## Step 2 — reproduction attempt
+
+Probe: `scripts/probes/sse_flake_probe.py` (single trial, one process) +
+`scripts/probes/run_sse_flake_probe.py` (multi-trial driver, spawns one
+fresh subprocess per trial, aggregates).
+
+Design: N real in-process `fake_remote` Streamable HTTP servers (same
+harness as `tests/runtime/test_downstream_remote.py`), one real
+`ClientManager`, per cycle:
+  1. `manager.connect_all(configs, retry=False)` — true concurrent connect
+     across all N servers (the one call where pmcp's own `_lifecycle_lock`
+     does *not* serialize the N servers' network I/O against each other —
+     see manager.py:587-611 — matching the real-world "several servers
+     connect around the same time" trigger, e.g. gateway startup / refresh).
+  2. A burst of concurrent `gateway.invoke()` tool calls spread across the
+     connected servers — every one is a POST whose response is SSE-framed
+     (see Step 1), so this is what actually exercises
+     `_handle_sse_response` at volume.
+  3. Concurrent `disconnect_server(..., force=True)` on half the servers
+     while the other half's connections/pooled sockets are still warm,
+     interleaving teardown network activity with (the next cycle's)
+     connect activity in time.
+  4. `manager.disconnect_all()` after all cycles.
+
+Every string in `connect_all()`'s returned errors, every
+`gateway.invoke()` result's `errors`, and any escaping exception is
+classified into: target hit (`"SSE stream ended without a response"`),
+sibling hit (`"...reconnection attempts were exhausted"`), or other.
+
+### Result — organic-load runs
+
+| run | servers | cycles | calls/cycle | trials | connect_all batches | tool calls | target hits | sibling hits | crashes | wall |
+|---|---|---|---|---|---|---|---|---|---|---|
+| smoke | 3 | 2 | 5 | 1 | 2 | 10 | 0 | 0 | 0 | 2.8s |
+| smoke2 | 8 | 5 | 20 | 10 | 50 | 1,000 | 0 | 0 | 0 | 67.9s |
+| **run1** | **10** | **6** | **30** | **40** | **240** | **7,200** | **0** | **0** | **0** | 200.1s |
+
+**0/40 trials hit the target string, across 240 concurrent-connect batches
+and 7,200 SSE-response tool calls, 1,200 disconnects.** No hint of the
+sibling message either. Organic load through the real code paths pmcp
+exercises (`connect_all`, concurrent `gateway.invoke`, concurrent
+`disconnect_server`) did not reproduce it in-process at this scale.
+
+### Result — deliberate-race variant
+
+Rationale for a second probe: Step 1 established that `fake_remote`'s
+`MCPServer` is built with no `event_store`
+(`build_fake_remote_app` in `tests/runtime/fake_remote.py` calls
+`MCPServer("fake-remote")` and `mcp.streamable_http_app()` with no
+`event_store=`), so `mcp.server.streamable_http`'s `event_id` is `None` for
+every SSE event it ever sends (`.venv/.../mcp/server/streamable_http.py:1047-1049`).
+That means the client's `last_event_id` never becomes non-`None`
+(`mcp/client/streamable_http.py:429-430`), so **any** interruption of an
+in-flight SSE response — not only one before its first byte — lands on the
+target message rather than the reconnect-exhausted sibling. Rather than keep
+betting on organic timing to land in that window, `sse_flake_probe_interrupt.py`
+forces it directly: each cycle starts a `gateway.invoke()` tool call, then
+concurrently starts `disconnect_server(name, force=True)` for the *same*
+server after a random 0–20ms delay, racing teardown against the still-open
+SSE read.
+
+<!-- INTERRUPT_RESULTS_PLACEHOLDER -->
+
+## What would be tried next with more time
+
+(filled in after the reproduction attempt, whichever branch it lands on)

--- a/scripts/probes/_serverkill_runner.py
+++ b/scripts/probes/_serverkill_runner.py
@@ -1,0 +1,46 @@
+"""Standalone runner for `sse_flake_probe_serverkill.py`: serves
+`build_fake_remote_app()` via uvicorn in its OWN process, so the parent
+probe can SIGKILL it -- the OS then forcibly closes every fd including any
+live client connections, which is what an in-process `task.cancel()` could
+not reliably do (see `sse_flake_probe_serverkill.py`'s docstring for why
+that in-process attempt produced 0 races touched).
+
+Usage: python _serverkill_runner.py <port> <auth-value>
+Prints "READY" to stdout once listening.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import uvicorn
+
+from tests.runtime.fake_remote import build_fake_remote_app
+
+
+def main() -> None:
+    port = int(sys.argv[1])
+    auth_value = sys.argv[2]
+    app = build_fake_remote_app(expected_auth_value=auth_value)
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="error", lifespan="on"
+    )
+    server = uvicorn.Server(config)
+
+    import asyncio
+
+    async def _run() -> None:
+        serve_task = asyncio.create_task(server.serve())
+        while not server.started:
+            await asyncio.sleep(0.01)
+        print("READY", flush=True)
+        await serve_task
+
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probes/run_sse_flake_probe.py
+++ b/scripts/probes/run_sse_flake_probe.py
@@ -1,0 +1,153 @@
+"""Multi-trial driver for `sse_flake_probe.py`.
+
+Spawns one FRESH subprocess per trial (see that module's docstring for why:
+`sse_starlette.sse.AppStatus.should_exit` is a process-global latch, so
+looping trials inside one process would just rediscover the already-fixed
+bug rather than probe the open one), aggregates results, and reports the
+observed failure rate as `hits/trials`.
+
+Usage:
+    uv run python scripts/probes/run_sse_flake_probe.py \
+        --trials 40 --servers 8 --cycles 5 --calls-per-cycle 20 --jobs 4
+
+Investigation note: .consiliency/notes/sse-stream-ended-investigation-20260812.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+PROBE = Path(__file__).with_name("sse_flake_probe.py")
+
+
+async def _run_one(
+    trial_id: int, servers: int, cycles: int, calls_per_cycle: int, sem: asyncio.Semaphore
+) -> dict:
+    async with sem:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(PROBE),
+            "--servers",
+            str(servers),
+            "--cycles",
+            str(cycles),
+            "--calls-per-cycle",
+            str(calls_per_cycle),
+            "--trial-id",
+            str(trial_id),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        return {
+            "trial_id": trial_id,
+            "crashed": True,
+            "returncode": proc.returncode,
+            "stderr_tail": stderr.decode(errors="replace")[-4000:],
+        }
+
+    last_line = stdout.decode(errors="replace").strip().splitlines()
+    if not last_line:
+        return {
+            "trial_id": trial_id,
+            "crashed": True,
+            "returncode": 0,
+            "stderr_tail": stderr.decode(errors="replace")[-4000:],
+            "note": "no stdout",
+        }
+    try:
+        return json.loads(last_line[-1])
+    except json.JSONDecodeError:
+        return {
+            "trial_id": trial_id,
+            "crashed": True,
+            "returncode": 0,
+            "stderr_tail": stderr.decode(errors="replace")[-4000:],
+            "stdout_tail": last_line[-1][-2000:],
+            "note": "stdout last line was not JSON",
+        }
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    sem = asyncio.Semaphore(args.jobs)
+    start = time.monotonic()
+    tasks = [
+        asyncio.create_task(
+            _run_one(i, args.servers, args.cycles, args.calls_per_cycle, sem)
+        )
+        for i in range(args.trials)
+    ]
+    results = []
+    for done in asyncio.as_completed(tasks):
+        r = await done
+        results.append(r)
+        tag = "HIT" if r.get("target_hits") else ("SIBLING" if r.get("sibling_hits") else ("CRASH" if r.get("crashed") else "clean"))
+        print(
+            f"[{len(results)}/{args.trials}] trial={r.get('trial_id')} {tag} "
+            f"elapsed={r.get('elapsed_s', 0):.1f}s "
+            f"total_wall={time.monotonic() - start:.1f}s",
+            flush=True,
+        )
+    elapsed = time.monotonic() - start
+
+    hits = [r for r in results if r.get("target_hits")]
+    sibling_only = [
+        r for r in results if r.get("sibling_hits") and not r.get("target_hits")
+    ]
+    crashed = [r for r in results if r.get("crashed")]
+
+    print()
+    print(f"=== {args.trials} trials, servers={args.servers} cycles={args.cycles} "
+          f"calls_per_cycle={args.calls_per_cycle} jobs={args.jobs} "
+          f"wall={elapsed:.1f}s ===")
+    print(f"TARGET hits ('SSE stream ended without a response'): {len(hits)}/{args.trials}")
+    print(f"sibling-only hits ('...reconnection attempts were exhausted'): "
+          f"{len(sibling_only)}/{args.trials}")
+    print(f"probe crashes (not a flake hit, a probe bug): {len(crashed)}/{args.trials}")
+
+    if hits:
+        print("\n--- sample TARGET hit(s) ---")
+        for r in hits[:5]:
+            print(f"trial {r['trial_id']}: {r['target_hits'][0]}")
+
+    if crashed:
+        print("\n--- probe crashes ---")
+        for r in crashed[:5]:
+            print(f"trial {r['trial_id']}: rc={r.get('returncode')} note={r.get('note')}")
+            print(r.get("stderr_tail", "")[-800:])
+
+    print()
+    print(json.dumps({
+        "trials": args.trials,
+        "servers": args.servers,
+        "cycles": args.cycles,
+        "calls_per_cycle": args.calls_per_cycle,
+        "target_hit_count": len(hits),
+        "sibling_only_count": len(sibling_only),
+        "crash_count": len(crashed),
+        "elapsed_s": elapsed,
+    }))
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trials", type=int, default=40)
+    parser.add_argument("--servers", type=int, default=8)
+    parser.add_argument("--cycles", type=int, default=5)
+    parser.add_argument("--calls-per-cycle", type=int, default=20)
+    parser.add_argument("--jobs", type=int, default=4, help="max concurrent trial subprocesses")
+    args = parser.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probes/run_sse_flake_probe.py
+++ b/scripts/probes/run_sse_flake_probe.py
@@ -26,7 +26,11 @@ PROBE = Path(__file__).with_name("sse_flake_probe.py")
 
 
 async def _run_one(
-    trial_id: int, servers: int, cycles: int, calls_per_cycle: int, sem: asyncio.Semaphore
+    trial_id: int,
+    servers: int,
+    cycles: int,
+    calls_per_cycle: int,
+    sem: asyncio.Semaphore,
 ) -> dict:
     async with sem:
         proc = await asyncio.create_subprocess_exec(
@@ -88,7 +92,15 @@ async def main_async(args: argparse.Namespace) -> int:
     for done in asyncio.as_completed(tasks):
         r = await done
         results.append(r)
-        tag = "HIT" if r.get("target_hits") else ("SIBLING" if r.get("sibling_hits") else ("CRASH" if r.get("crashed") else "clean"))
+        tag = (
+            "HIT"
+            if r.get("target_hits")
+            else (
+                "SIBLING"
+                if r.get("sibling_hits")
+                else ("CRASH" if r.get("crashed") else "clean")
+            )
+        )
         print(
             f"[{len(results)}/{args.trials}] trial={r.get('trial_id')} {tag} "
             f"elapsed={r.get('elapsed_s', 0):.1f}s "
@@ -104,12 +116,18 @@ async def main_async(args: argparse.Namespace) -> int:
     crashed = [r for r in results if r.get("crashed")]
 
     print()
-    print(f"=== {args.trials} trials, servers={args.servers} cycles={args.cycles} "
-          f"calls_per_cycle={args.calls_per_cycle} jobs={args.jobs} "
-          f"wall={elapsed:.1f}s ===")
-    print(f"TARGET hits ('SSE stream ended without a response'): {len(hits)}/{args.trials}")
-    print(f"sibling-only hits ('...reconnection attempts were exhausted'): "
-          f"{len(sibling_only)}/{args.trials}")
+    print(
+        f"=== {args.trials} trials, servers={args.servers} cycles={args.cycles} "
+        f"calls_per_cycle={args.calls_per_cycle} jobs={args.jobs} "
+        f"wall={elapsed:.1f}s ==="
+    )
+    print(
+        f"TARGET hits ('SSE stream ended without a response'): {len(hits)}/{args.trials}"
+    )
+    print(
+        f"sibling-only hits ('...reconnection attempts were exhausted'): "
+        f"{len(sibling_only)}/{args.trials}"
+    )
     print(f"probe crashes (not a flake hit, a probe bug): {len(crashed)}/{args.trials}")
 
     if hits:
@@ -120,20 +138,26 @@ async def main_async(args: argparse.Namespace) -> int:
     if crashed:
         print("\n--- probe crashes ---")
         for r in crashed[:5]:
-            print(f"trial {r['trial_id']}: rc={r.get('returncode')} note={r.get('note')}")
+            print(
+                f"trial {r['trial_id']}: rc={r.get('returncode')} note={r.get('note')}"
+            )
             print(r.get("stderr_tail", "")[-800:])
 
     print()
-    print(json.dumps({
-        "trials": args.trials,
-        "servers": args.servers,
-        "cycles": args.cycles,
-        "calls_per_cycle": args.calls_per_cycle,
-        "target_hit_count": len(hits),
-        "sibling_only_count": len(sibling_only),
-        "crash_count": len(crashed),
-        "elapsed_s": elapsed,
-    }))
+    print(
+        json.dumps(
+            {
+                "trials": args.trials,
+                "servers": args.servers,
+                "cycles": args.cycles,
+                "calls_per_cycle": args.calls_per_cycle,
+                "target_hit_count": len(hits),
+                "sibling_only_count": len(sibling_only),
+                "crash_count": len(crashed),
+                "elapsed_s": elapsed,
+            }
+        )
+    )
 
     return 0
 
@@ -144,7 +168,9 @@ def main() -> int:
     parser.add_argument("--servers", type=int, default=8)
     parser.add_argument("--cycles", type=int, default=5)
     parser.add_argument("--calls-per-cycle", type=int, default=20)
-    parser.add_argument("--jobs", type=int, default=4, help="max concurrent trial subprocesses")
+    parser.add_argument(
+        "--jobs", type=int, default=4, help="max concurrent trial subprocesses"
+    )
     args = parser.parse_args()
     return asyncio.run(main_async(args))
 

--- a/scripts/probes/run_sse_flake_probe_interrupt.py
+++ b/scripts/probes/run_sse_flake_probe_interrupt.py
@@ -1,0 +1,102 @@
+"""Multi-trial driver for `sse_flake_probe_interrupt.py` -- see that module's
+docstring for the hypothesis under test. One fresh subprocess per trial for
+the same reason as `run_sse_flake_probe.py` (the `AppStatus.should_exit`
+process-global latch).
+
+Usage:
+    uv run python scripts/probes/run_sse_flake_probe_interrupt.py \
+        --trials 50 --races 30 --jobs 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+PROBE = Path(__file__).with_name("sse_flake_probe_interrupt.py")
+
+
+async def _run_one(trial_id: int, races: int, min_delay: float, max_delay: float, sem: asyncio.Semaphore) -> dict:
+    async with sem:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, str(PROBE),
+            "--races", str(races),
+            "--min-delay-ms", str(min_delay),
+            "--max-delay-ms", str(max_delay),
+            "--trial-id", str(trial_id),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        return {"trial_id": trial_id, "crashed": True, "returncode": proc.returncode,
+                "stderr_tail": stderr.decode(errors="replace")[-3000:]}
+    lines = stdout.decode(errors="replace").strip().splitlines()
+    if not lines:
+        return {"trial_id": trial_id, "crashed": True, "returncode": 0,
+                "stderr_tail": stderr.decode(errors="replace")[-3000:], "note": "no stdout"}
+    try:
+        return json.loads(lines[-1])
+    except json.JSONDecodeError:
+        return {"trial_id": trial_id, "crashed": True, "returncode": 0,
+                "stdout_tail": lines[-1][-1000:], "note": "not JSON"}
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    sem = asyncio.Semaphore(args.jobs)
+    start = time.monotonic()
+    tasks = [
+        asyncio.create_task(_run_one(i, args.races, args.min_delay_ms, args.max_delay_ms, sem))
+        for i in range(args.trials)
+    ]
+    results = []
+    for done in asyncio.as_completed(tasks):
+        r = await done
+        results.append(r)
+        tag = "HIT" if r.get("target_hits") else ("SIBLING" if r.get("sibling_hits") else ("CRASH" if r.get("crashed") else "clean"))
+        other_n = len(r.get("other") or [])
+        print(f"[{len(results)}/{args.trials}] trial={r.get('trial_id')} {tag} other_errs={other_n} "
+              f"elapsed={r.get('elapsed_s', 0):.2f}s total_wall={time.monotonic()-start:.1f}s", flush=True)
+
+    hits = [r for r in results if r.get("target_hits")]
+    crashed = [r for r in results if r.get("crashed")]
+    total_races = args.trials * args.races
+    print()
+    print(f"=== {args.trials} trials x {args.races} races = {total_races} race attempts, "
+          f"delay=[{args.min_delay_ms},{args.max_delay_ms}]ms jobs={args.jobs} "
+          f"wall={time.monotonic()-start:.1f}s ===")
+    print(f"TARGET hits: {len(hits)}/{args.trials} trials")
+    print(f"probe crashes: {len(crashed)}/{args.trials}")
+    if hits:
+        print("--- sample hits ---")
+        for r in hits[:5]:
+            print(f"trial {r['trial_id']}: {r['target_hits'][0]}")
+    if crashed:
+        for r in crashed[:3]:
+            print(f"crash trial {r['trial_id']}: {r.get('stderr_tail','')[-600:]}")
+    print(json.dumps({
+        "trials": args.trials, "races": args.races, "total_race_attempts": total_races,
+        "target_hit_trials": len(hits), "crash_trials": len(crashed),
+        "elapsed_s": time.monotonic() - start,
+    }))
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--trials", type=int, default=20)
+    p.add_argument("--races", type=int, default=30)
+    p.add_argument("--min-delay-ms", type=float, default=0.0)
+    p.add_argument("--max-delay-ms", type=float, default=15.0)
+    p.add_argument("--jobs", type=int, default=8)
+    args = p.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probes/run_sse_flake_probe_interrupt.py
+++ b/scripts/probes/run_sse_flake_probe_interrupt.py
@@ -20,56 +20,96 @@ from pathlib import Path
 PROBE = Path(__file__).with_name("sse_flake_probe_interrupt.py")
 
 
-async def _run_one(trial_id: int, races: int, min_delay: float, max_delay: float, sem: asyncio.Semaphore) -> dict:
+async def _run_one(
+    trial_id: int,
+    races: int,
+    min_delay: float,
+    max_delay: float,
+    sem: asyncio.Semaphore,
+) -> dict:
     async with sem:
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, str(PROBE),
-            "--races", str(races),
-            "--min-delay-ms", str(min_delay),
-            "--max-delay-ms", str(max_delay),
-            "--trial-id", str(trial_id),
+            sys.executable,
+            str(PROBE),
+            "--races",
+            str(races),
+            "--min-delay-ms",
+            str(min_delay),
+            "--max-delay-ms",
+            str(max_delay),
+            "--trial-id",
+            str(trial_id),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await proc.communicate()
 
     if proc.returncode != 0:
-        return {"trial_id": trial_id, "crashed": True, "returncode": proc.returncode,
-                "stderr_tail": stderr.decode(errors="replace")[-3000:]}
+        return {
+            "trial_id": trial_id,
+            "crashed": True,
+            "returncode": proc.returncode,
+            "stderr_tail": stderr.decode(errors="replace")[-3000:],
+        }
     lines = stdout.decode(errors="replace").strip().splitlines()
     if not lines:
-        return {"trial_id": trial_id, "crashed": True, "returncode": 0,
-                "stderr_tail": stderr.decode(errors="replace")[-3000:], "note": "no stdout"}
+        return {
+            "trial_id": trial_id,
+            "crashed": True,
+            "returncode": 0,
+            "stderr_tail": stderr.decode(errors="replace")[-3000:],
+            "note": "no stdout",
+        }
     try:
         return json.loads(lines[-1])
     except json.JSONDecodeError:
-        return {"trial_id": trial_id, "crashed": True, "returncode": 0,
-                "stdout_tail": lines[-1][-1000:], "note": "not JSON"}
+        return {
+            "trial_id": trial_id,
+            "crashed": True,
+            "returncode": 0,
+            "stdout_tail": lines[-1][-1000:],
+            "note": "not JSON",
+        }
 
 
 async def main_async(args: argparse.Namespace) -> int:
     sem = asyncio.Semaphore(args.jobs)
     start = time.monotonic()
     tasks = [
-        asyncio.create_task(_run_one(i, args.races, args.min_delay_ms, args.max_delay_ms, sem))
+        asyncio.create_task(
+            _run_one(i, args.races, args.min_delay_ms, args.max_delay_ms, sem)
+        )
         for i in range(args.trials)
     ]
     results = []
     for done in asyncio.as_completed(tasks):
         r = await done
         results.append(r)
-        tag = "HIT" if r.get("target_hits") else ("SIBLING" if r.get("sibling_hits") else ("CRASH" if r.get("crashed") else "clean"))
+        tag = (
+            "HIT"
+            if r.get("target_hits")
+            else (
+                "SIBLING"
+                if r.get("sibling_hits")
+                else ("CRASH" if r.get("crashed") else "clean")
+            )
+        )
         other_n = len(r.get("other") or [])
-        print(f"[{len(results)}/{args.trials}] trial={r.get('trial_id')} {tag} other_errs={other_n} "
-              f"elapsed={r.get('elapsed_s', 0):.2f}s total_wall={time.monotonic()-start:.1f}s", flush=True)
+        print(
+            f"[{len(results)}/{args.trials}] trial={r.get('trial_id')} {tag} other_errs={other_n} "
+            f"elapsed={r.get('elapsed_s', 0):.2f}s total_wall={time.monotonic() - start:.1f}s",
+            flush=True,
+        )
 
     hits = [r for r in results if r.get("target_hits")]
     crashed = [r for r in results if r.get("crashed")]
     total_races = args.trials * args.races
     print()
-    print(f"=== {args.trials} trials x {args.races} races = {total_races} race attempts, "
-          f"delay=[{args.min_delay_ms},{args.max_delay_ms}]ms jobs={args.jobs} "
-          f"wall={time.monotonic()-start:.1f}s ===")
+    print(
+        f"=== {args.trials} trials x {args.races} races = {total_races} race attempts, "
+        f"delay=[{args.min_delay_ms},{args.max_delay_ms}]ms jobs={args.jobs} "
+        f"wall={time.monotonic() - start:.1f}s ==="
+    )
     print(f"TARGET hits: {len(hits)}/{args.trials} trials")
     print(f"probe crashes: {len(crashed)}/{args.trials}")
     if hits:
@@ -78,12 +118,19 @@ async def main_async(args: argparse.Namespace) -> int:
             print(f"trial {r['trial_id']}: {r['target_hits'][0]}")
     if crashed:
         for r in crashed[:3]:
-            print(f"crash trial {r['trial_id']}: {r.get('stderr_tail','')[-600:]}")
-    print(json.dumps({
-        "trials": args.trials, "races": args.races, "total_race_attempts": total_races,
-        "target_hit_trials": len(hits), "crash_trials": len(crashed),
-        "elapsed_s": time.monotonic() - start,
-    }))
+            print(f"crash trial {r['trial_id']}: {r.get('stderr_tail', '')[-600:]}")
+    print(
+        json.dumps(
+            {
+                "trials": args.trials,
+                "races": args.races,
+                "total_race_attempts": total_races,
+                "target_hit_trials": len(hits),
+                "crash_trials": len(crashed),
+                "elapsed_s": time.monotonic() - start,
+            }
+        )
+    )
     return 0
 
 

--- a/scripts/probes/sse_flake_probe.py
+++ b/scripts/probes/sse_flake_probe.py
@@ -27,16 +27,16 @@ string was observed) -- a hard crash (uncaught exception, non-JSON output)
 is a distinct, worse outcome the driver also has to handle.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # noqa: E402
 
-import argparse
-import asyncio
-import json
-import logging
-import sys
-import time
-from dataclasses import dataclass, field
-from pathlib import Path
+import argparse  # noqa: E402
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+from pathlib import Path  # noqa: E402
 
 # The probe classifies via returned error strings / exceptions, not logs;
 # INFO/DEBUG httpx+pmcp logging is pure I/O overhead here and, at the
@@ -50,12 +50,12 @@ logging.basicConfig(level=logging.ERROR)
 # requiring callers to invoke via `-m` or set PYTHONPATH themselves.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from pmcp.client.manager import ClientManager
-from pmcp.policy.policy import PolicyManager
-from pmcp.tools.handlers import GatewayTools
-from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
-from tests.runtime.fake_remote import run_fake_remote
-from tests.runtime.harness import alloc_port
+from pmcp.client.manager import ClientManager  # noqa: E402
+from pmcp.policy.policy import PolicyManager  # noqa: E402
+from pmcp.tools.handlers import GatewayTools  # noqa: E402
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig  # noqa: E402
+from tests.runtime.fake_remote import run_fake_remote  # noqa: E402
+from tests.runtime.harness import alloc_port  # noqa: E402
 
 TARGET_STRING = "SSE stream ended without a response"
 SIBLING_STRING = "SSE stream ended and reconnection attempts were exhausted"
@@ -103,7 +103,9 @@ async def _run_trial(
 
     async with _fake_remotes(n_servers) as remotes:
         manager = ClientManager()
-        gateway_tools = GatewayTools(client_manager=manager, policy_manager=PolicyManager())
+        gateway_tools = GatewayTools(
+            client_manager=manager, policy_manager=PolicyManager()
+        )
         try:
             for cycle in range(cycles):
                 configs = [
@@ -133,7 +135,8 @@ async def _run_trial(
                         }
                     )
                     for i in range(calls_per_cycle)
-                    for name in [online[i % len(online)]] if online
+                    for name in [online[i % len(online)]]
+                    if online
                 ]
                 call_results = await asyncio.gather(*call_tasks, return_exceptions=True)
                 for cr in call_results:

--- a/scripts/probes/sse_flake_probe.py
+++ b/scripts/probes/sse_flake_probe.py
@@ -1,0 +1,219 @@
+"""Single-trial probe for the "SSE stream ended without a response" flake.
+
+Investigation note: .consiliency/notes/sse-stream-ended-investigation-20260812.md
+
+Drives concurrent connect/disconnect + concurrent tool-call traffic against N
+real, in-process `fake_remote` Streamable HTTP servers (the same harness
+`tests/runtime/test_downstream_remote.py` uses), through a real in-process
+`ClientManager`, and watches for the target error string surfacing anywhere:
+in `connect_all()`'s returned error list, in a `gateway.invoke()` result's
+errors, or in an uncaught exception from teardown.
+
+Run ONE trial per process (see `run_sse_flake_probe.py`, the multi-trial
+driver) — `sse_starlette.sse.AppStatus.should_exit` is a process-global latch
+(see `tests/runtime/fake_remote.py`'s docstring / `run_fake_remote`'s
+`finally:` block) that, once tripped by any uvicorn shutdown in this
+process, poisons every SSE stream afterwards. A multi-trial *loop inside one
+process* would just be re-discovering that already-fixed bug, not probing
+the open one.
+
+Usage:
+    uv run python scripts/probes/sse_flake_probe.py --servers 8 --cycles 5 \
+        --calls-per-cycle 20 --trial-id 0
+
+Prints one JSON object to stdout as the last line of output. Exit code 0
+means "ran without a crash" (the JSON itself reports whether the target
+string was observed) -- a hard crash (uncaught exception, non-JSON output)
+is a distinct, worse outcome the driver also has to handle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# The probe classifies via returned error strings / exceptions, not logs;
+# INFO/DEBUG httpx+pmcp logging is pure I/O overhead here and, at the
+# concurrency levels this probe needs, was materially limiting how many
+# cycles fit in a trial's wall-clock budget.
+logging.basicConfig(level=logging.ERROR)
+
+# `tests.runtime.fake_remote` is only importable with the repo root on
+# sys.path; running this file directly (`python scripts/probes/x.py`) puts
+# `scripts/probes/` there instead, so add the root explicitly rather than
+# requiring callers to invoke via `-m` or set PYTHONPATH themselves.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from pmcp.client.manager import ClientManager
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
+from tests.runtime.fake_remote import run_fake_remote
+from tests.runtime.harness import alloc_port
+
+TARGET_STRING = "SSE stream ended without a response"
+SIBLING_STRING = "SSE stream ended and reconnection attempts were exhausted"
+AUTH_VALUE = "Bearer probe-secret-token"
+
+
+def _config(name: str, url: str) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=RemoteMcpServerConfig(
+            type="streamable-http", url=url, headers={"Authorization": AUTH_VALUE}
+        ),
+    )
+
+
+@dataclass
+class TrialResult:
+    trial_id: int
+    servers: int
+    cycles: int
+    calls_per_cycle: int
+    target_hits: list[str] = field(default_factory=list)
+    sibling_hits: list[str] = field(default_factory=list)
+    other_connect_errors: list[str] = field(default_factory=list)
+    other_invoke_errors: list[str] = field(default_factory=list)
+    other_exceptions: list[str] = field(default_factory=list)
+    elapsed_s: float = 0.0
+
+    @property
+    def hit(self) -> bool:
+        return bool(self.target_hits)
+
+
+async def _run_trial(
+    trial_id: int, n_servers: int, cycles: int, calls_per_cycle: int
+) -> TrialResult:
+    result = TrialResult(
+        trial_id=trial_id,
+        servers=n_servers,
+        cycles=cycles,
+        calls_per_cycle=calls_per_cycle,
+    )
+    start = time.monotonic()
+
+    async with _fake_remotes(n_servers) as remotes:
+        manager = ClientManager()
+        gateway_tools = GatewayTools(client_manager=manager, policy_manager=PolicyManager())
+        try:
+            for cycle in range(cycles):
+                configs = [
+                    _config(f"probe-{i}", remotes[i].mcp_url) for i in range(n_servers)
+                ]
+
+                # Real concurrent connect: connect_all() fires one asyncio
+                # task per server and gathers them -- this is the one place
+                # pmcp's own lifecycle lock does NOT serialize the network
+                # I/O of N servers against each other (see investigation
+                # note "why connect_all, not N x connect_server").
+                errors = await manager.connect_all(configs, retry=False)
+                for err in errors:
+                    _classify(err, result)
+
+                online = [c.name for c in configs if manager.is_server_online(c.name)]
+
+                # Concurrent tool-call load: every fr_echo call is a POST
+                # whose response arrives over SSE (fake_remote's MCPServer
+                # defaults to json_response=False), so this is what
+                # exercises `_handle_sse_response` under concurrency.
+                call_tasks = [
+                    gateway_tools.invoke(
+                        {
+                            "tool_id": f"{name}::fr_echo",
+                            "arguments": {"text": f"c{cycle}-{i}"},
+                        }
+                    )
+                    for i in range(calls_per_cycle)
+                    for name in [online[i % len(online)]] if online
+                ]
+                call_results = await asyncio.gather(*call_tasks, return_exceptions=True)
+                for cr in call_results:
+                    if isinstance(cr, Exception):
+                        _classify(str(cr), result)
+                    elif not cr.ok:
+                        for err in cr.errors or []:
+                            _classify(err, result)
+
+                # Concurrent disconnect of half the servers while the other
+                # half is mid-reconnect-eligible-window -- interleaves
+                # teardown network activity (socket close, session DELETE)
+                # with the next cycle's connect activity in time, even
+                # though bookkeeping is serialized by the lifecycle lock.
+                half = online[: len(online) // 2]
+                await asyncio.gather(
+                    *(manager.disconnect_server(name, force=True) for name in half),
+                    return_exceptions=True,
+                )
+
+            await manager.disconnect_all()
+        except Exception as exc:  # noqa: BLE001 - probe must not crash on a hit
+            _classify(str(exc), result)
+            result.other_exceptions.append(repr(exc))
+            try:
+                await manager.disconnect_all()
+            except Exception:  # noqa: BLE001
+                pass
+
+    result.elapsed_s = time.monotonic() - start
+    return result
+
+
+def _classify(message: str, result: TrialResult) -> None:
+    if TARGET_STRING in message:
+        result.target_hits.append(message)
+    elif SIBLING_STRING in message:
+        result.sibling_hits.append(message)
+    else:
+        result.other_connect_errors.append(message)
+
+
+class _fake_remotes:
+    """Fan out `run_fake_remote` across N ephemeral ports as one context manager."""
+
+    def __init__(self, n: int) -> None:
+        self._n = n
+        self._stack: list = []
+
+    async def __aenter__(self):
+        import contextlib
+
+        self._exit_stack = contextlib.AsyncExitStack()
+        await self._exit_stack.__aenter__()
+        remotes = []
+        for _ in range(self._n):
+            remote = await self._exit_stack.enter_async_context(
+                run_fake_remote(alloc_port(), expected_auth_value=AUTH_VALUE)
+            )
+            remotes.append(remote)
+        return remotes
+
+    async def __aexit__(self, *exc_info):
+        return await self._exit_stack.__aexit__(*exc_info)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--servers", type=int, default=8)
+    parser.add_argument("--cycles", type=int, default=5)
+    parser.add_argument("--calls-per-cycle", type=int, default=20)
+    parser.add_argument("--trial-id", type=int, default=0)
+    args = parser.parse_args()
+
+    result = asyncio.run(
+        _run_trial(args.trial_id, args.servers, args.cycles, args.calls_per_cycle)
+    )
+    print(json.dumps(result.__dict__))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probes/sse_flake_probe_interrupt.py
+++ b/scripts/probes/sse_flake_probe_interrupt.py
@@ -21,28 +21,28 @@ random delay, so the disconnect's transport teardown races the tool call's
 still-open SSE read.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # noqa: E402
 
-import argparse
-import asyncio
-import contextlib
-import json
-import logging
-import random
-import sys
-import time
-from dataclasses import dataclass, field
-from pathlib import Path
+import argparse  # noqa: E402
+import asyncio  # noqa: E402
+import contextlib  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import random  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+from pathlib import Path  # noqa: E402
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 logging.basicConfig(level=logging.ERROR)
 
-from pmcp.client.manager import ClientManager
-from pmcp.policy.policy import PolicyManager
-from pmcp.tools.handlers import GatewayTools
-from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
-from tests.runtime.fake_remote import run_fake_remote
-from tests.runtime.harness import alloc_port
+from pmcp.client.manager import ClientManager  # noqa: E402
+from pmcp.policy.policy import PolicyManager  # noqa: E402
+from pmcp.tools.handlers import GatewayTools  # noqa: E402
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig  # noqa: E402
+from tests.runtime.fake_remote import run_fake_remote  # noqa: E402
+from tests.runtime.harness import alloc_port  # noqa: E402
 
 TARGET_STRING = "SSE stream ended without a response"
 SIBLING_STRING = "SSE stream ended and reconnection attempts were exhausted"
@@ -82,13 +82,17 @@ def _classify(message: str, result: TrialResult) -> None:
         result.other.append(message)
 
 
-async def _run_trial(trial_id: int, races: int, min_delay_ms: float, max_delay_ms: float) -> TrialResult:
+async def _run_trial(
+    trial_id: int, races: int, min_delay_ms: float, max_delay_ms: float
+) -> TrialResult:
     result = TrialResult(trial_id=trial_id, races=races)
     start = time.monotonic()
 
     async with run_fake_remote(alloc_port(), expected_auth_value=AUTH_VALUE) as remote:
         manager = ClientManager()
-        gateway_tools = GatewayTools(client_manager=manager, policy_manager=PolicyManager())
+        gateway_tools = GatewayTools(
+            client_manager=manager, policy_manager=PolicyManager()
+        )
         config = _config("probe-race", remote.mcp_url)
         try:
             for i in range(races):
@@ -107,7 +111,10 @@ async def _run_trial(trial_id: int, races: int, min_delay_ms: float, max_delay_m
 
                 call_task = asyncio.create_task(
                     gateway_tools.invoke(
-                        {"tool_id": "probe-race::fr_echo", "arguments": {"text": f"race-{i}"}}
+                        {
+                            "tool_id": "probe-race::fr_echo",
+                            "arguments": {"text": f"race-{i}"},
+                        }
                     )
                 )
                 disc_task = asyncio.create_task(_delayed_disconnect())

--- a/scripts/probes/sse_flake_probe_interrupt.py
+++ b/scripts/probes/sse_flake_probe_interrupt.py
@@ -1,0 +1,160 @@
+"""Single-trial probe, variant 2: deliberately race a tool call against a
+disconnect of the SAME server, instead of hoping organic load produces the
+race.
+
+Rationale (see the investigation note): `fake_remote`'s `MCPServer` is built
+with no `event_store`, so `mcp.server.streamable_http`'s per-event `event_id`
+(`.venv/.../mcp/server/streamable_http.py:1047-1049`) is `None` for every SSE
+event it ever sends. On the client side that means `last_event_id` never
+becomes non-`None` (`mcp/client/streamable_http.py:429-430`), so *any*
+interruption of an in-flight SSE response -- not just one before its first
+byte -- lands on the target message
+("SSE stream ended without a response") rather than the reconnect-exhausted
+sibling. `sse_flake_probe.py` bet on organic connection-pool/server-load
+timing to produce that interruption; this variant forces it directly, to
+learn whether the code path is reachable in-process at all before spending
+more organic-load trial budget.
+
+For each cycle: start a tool call, then concurrently start
+`disconnect_server(name, force=True)` for the SAME server after a small
+random delay, so the disconnect's transport teardown races the tool call's
+still-open SSE read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import logging
+import random
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+logging.basicConfig(level=logging.ERROR)
+
+from pmcp.client.manager import ClientManager
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
+from tests.runtime.fake_remote import run_fake_remote
+from tests.runtime.harness import alloc_port
+
+TARGET_STRING = "SSE stream ended without a response"
+SIBLING_STRING = "SSE stream ended and reconnection attempts were exhausted"
+AUTH_VALUE = "Bearer probe-secret-token"
+
+
+def _config(name: str, url: str) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=RemoteMcpServerConfig(
+            type="streamable-http", url=url, headers={"Authorization": AUTH_VALUE}
+        ),
+    )
+
+
+@dataclass
+class TrialResult:
+    trial_id: int
+    races: int
+    target_hits: list[str] = field(default_factory=list)
+    sibling_hits: list[str] = field(default_factory=list)
+    other: list[str] = field(default_factory=list)
+    elapsed_s: float = 0.0
+
+    @property
+    def hit(self) -> bool:
+        return bool(self.target_hits)
+
+
+def _classify(message: str, result: TrialResult) -> None:
+    if TARGET_STRING in message:
+        result.target_hits.append(message)
+    elif SIBLING_STRING in message:
+        result.sibling_hits.append(message)
+    else:
+        result.other.append(message)
+
+
+async def _run_trial(trial_id: int, races: int, min_delay_ms: float, max_delay_ms: float) -> TrialResult:
+    result = TrialResult(trial_id=trial_id, races=races)
+    start = time.monotonic()
+
+    async with run_fake_remote(alloc_port(), expected_auth_value=AUTH_VALUE) as remote:
+        manager = ClientManager()
+        gateway_tools = GatewayTools(client_manager=manager, policy_manager=PolicyManager())
+        config = _config("probe-race", remote.mcp_url)
+        try:
+            for i in range(races):
+                errors = await manager.connect_server(config, retry=False)
+                for err in errors:
+                    _classify(err, result)
+                if not manager.is_server_online("probe-race"):
+                    continue
+
+                delay = random.uniform(min_delay_ms, max_delay_ms) / 1000.0
+
+                async def _delayed_disconnect() -> None:
+                    await asyncio.sleep(delay)
+                    with contextlib.suppress(Exception):
+                        await manager.disconnect_server("probe-race", force=True)
+
+                call_task = asyncio.create_task(
+                    gateway_tools.invoke(
+                        {"tool_id": "probe-race::fr_echo", "arguments": {"text": f"race-{i}"}}
+                    )
+                )
+                disc_task = asyncio.create_task(_delayed_disconnect())
+                call_result, _ = await asyncio.gather(
+                    call_task, disc_task, return_exceptions=True
+                )
+                if isinstance(call_result, BaseException):
+                    # gather(return_exceptions=True) reports a cancelled
+                    # tool-call task as a bare CancelledError here (it does
+                    # not subclass Exception since Python 3.8), so this must
+                    # check BaseException or a race that manifests as
+                    # cancellation silently escapes classification.
+                    _classify(repr(call_result), result)
+                elif not call_result.ok:
+                    for err in call_result.errors or []:
+                        _classify(err, result)
+
+                # Make sure this server is fully torn down before the next
+                # cycle's connect, whichever path the race took.
+                with contextlib.suppress(Exception):
+                    await manager.disconnect_server("probe-race", force=True)
+
+            with contextlib.suppress(Exception):
+                await manager.disconnect_all()
+        except Exception as exc:  # noqa: BLE001
+            _classify(str(exc), result)
+            with contextlib.suppress(Exception):
+                await manager.disconnect_all()
+
+    result.elapsed_s = time.monotonic() - start
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--races", type=int, default=20)
+    parser.add_argument("--min-delay-ms", type=float, default=0.0)
+    parser.add_argument("--max-delay-ms", type=float, default=15.0)
+    parser.add_argument("--trial-id", type=int, default=0)
+    args = parser.parse_args()
+
+    result = asyncio.run(
+        _run_trial(args.trial_id, args.races, args.min_delay_ms, args.max_delay_ms)
+    )
+    print(json.dumps(result.__dict__))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probes/sse_flake_probe_serverkill.py
+++ b/scripts/probes/sse_flake_probe_serverkill.py
@@ -1,0 +1,188 @@
+"""Single-trial probe, variant 3: sever the PEER side abruptly, mid-response,
+without going through any of pmcp's own disconnect code.
+
+Rationale: variant 2 (`sse_flake_probe_interrupt.py`) raced pmcp's own
+`disconnect_server` against an in-flight tool call and got 0/40 target hits
+across 1,200 race attempts -- but every one of those attempts also produced
+a `CancelledError` from `ClientManager.cancel_pending_requests`, called at
+the *start* of `disconnect_server` before the transport (and therefore the
+mcp SDK's own stream-ended handling) ever unwinds. That means the interrupt
+variant was never actually testing what the target message needs: an SSE
+response stream dying while pmcp is *not* the one tearing it down. This
+variant builds the peer directly (bypassing `run_fake_remote`'s managed
+context) and kills its serving task -- `task.cancel()`, not a graceful
+`server.should_exit = True` -- at a random moment after a tool call starts,
+so the peer dies as far as the client's socket is concerned without pmcp
+ever calling `disconnect_server` or `cancel_pending_requests`.
+
+`sse_starlette.sse.AppStatus.should_exit` note: `task.cancel()` does not
+run uvicorn's normal shutdown signal handler (`Server.serve()`'s
+`self.should_exit` is never set), so this does NOT set the process-global
+latch -- verified in the smoke run below (`appstatus_before`/`appstatus_after`
+in the JSON). This is deliberately not `run_fake_remote`, which calls
+`server.should_exit = True` in its `finally:` and is the one place the repo
+resets that latch; skipped entirely here on purpose.
+"""
+
+from __future__ import annotations  # noqa: E402
+
+import argparse  # noqa: E402
+import asyncio  # noqa: E402
+import contextlib  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import random  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+logging.basicConfig(level=logging.ERROR)
+
+import uvicorn  # noqa: E402
+from sse_starlette.sse import AppStatus  # noqa: E402
+
+from pmcp.client.manager import ClientManager  # noqa: E402
+from pmcp.policy.policy import PolicyManager  # noqa: E402
+from pmcp.tools.handlers import GatewayTools  # noqa: E402
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig  # noqa: E402
+from tests.runtime.fake_remote import build_fake_remote_app  # noqa: E402
+from tests.runtime.harness import alloc_port  # noqa: E402
+
+TARGET_STRING = "SSE stream ended without a response"
+SIBLING_STRING = "SSE stream ended and reconnection attempts were exhausted"
+AUTH_VALUE = "Bearer probe-secret-token"
+
+
+def _config(name: str, url: str) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=RemoteMcpServerConfig(
+            type="streamable-http", url=url, headers={"Authorization": AUTH_VALUE}
+        ),
+    )
+
+
+@dataclass
+class TrialResult:
+    trial_id: int
+    kills: int
+    target_hits: list[str] = field(default_factory=list)
+    sibling_hits: list[str] = field(default_factory=list)
+    other: list[str] = field(default_factory=list)
+    appstatus_before: bool | None = None
+    appstatus_after: bool | None = None
+    elapsed_s: float = 0.0
+
+
+def _classify(message: str, result: TrialResult) -> None:
+    if TARGET_STRING in message:
+        result.target_hits.append(message)
+    elif SIBLING_STRING in message:
+        result.sibling_hits.append(message)
+    else:
+        result.other.append(message)
+
+
+async def _start_server(port: int) -> tuple[uvicorn.Server, asyncio.Task]:
+    app = build_fake_remote_app(expected_auth_value=AUTH_VALUE)
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="error", lifespan="on"
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    for _ in range(200):
+        if server.started:
+            break
+        await asyncio.sleep(0.02)
+    else:
+        raise RuntimeError("server never started")
+    return server, task
+
+
+async def _run_trial(
+    trial_id: int, kills: int, min_delay_ms: float, max_delay_ms: float
+) -> TrialResult:
+    result = TrialResult(trial_id=trial_id, kills=kills)
+    result.appstatus_before = AppStatus.should_exit
+    start = time.monotonic()
+
+    manager = ClientManager()
+    gateway_tools = GatewayTools(client_manager=manager, policy_manager=PolicyManager())
+
+    for i in range(kills):
+        port = alloc_port()
+        server, serve_task = await _start_server(port)
+        config = _config("probe-kill", f"http://127.0.0.1:{port}/mcp")
+        try:
+            errors = await manager.connect_server(config, retry=False)
+            for err in errors:
+                _classify(err, result)
+            if not manager.is_server_online("probe-kill"):
+                continue
+
+            delay = random.uniform(min_delay_ms, max_delay_ms) / 1000.0
+
+            async def _kill_peer() -> None:
+                await asyncio.sleep(delay)
+                serve_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await serve_task
+
+            call_task = asyncio.create_task(
+                gateway_tools.invoke(
+                    {
+                        "tool_id": "probe-kill::fr_echo",
+                        "arguments": {"text": f"kill-{i}"},
+                    }
+                )
+            )
+            kill_task = asyncio.create_task(_kill_peer())
+            call_result, _ = await asyncio.gather(
+                call_task, kill_task, return_exceptions=True
+            )
+
+            if isinstance(call_result, BaseException):
+                _classify(repr(call_result), result)
+            elif not call_result.ok:
+                for err in call_result.errors or []:
+                    _classify(err, result)
+        finally:
+            # Best-effort teardown: pmcp's own disconnect against an
+            # already-dead peer, then make sure the serve task is gone.
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(
+                    manager.disconnect_server("probe-kill", force=True), timeout=3.0
+                )
+            if not serve_task.done():
+                serve_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await serve_task
+
+    with contextlib.suppress(Exception):
+        await manager.disconnect_all()
+
+    result.appstatus_after = AppStatus.should_exit
+    result.elapsed_s = time.monotonic() - start
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kills", type=int, default=10)
+    parser.add_argument("--min-delay-ms", type=float, default=0.0)
+    parser.add_argument("--max-delay-ms", type=float, default=30.0)
+    parser.add_argument("--trial-id", type=int, default=0)
+    args = parser.parse_args()
+
+    result = asyncio.run(
+        _run_trial(args.trial_id, args.kills, args.min_delay_ms, args.max_delay_ms)
+    )
+    print(json.dumps(result.__dict__))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probes/sse_flake_probe_sigkill.py
+++ b/scripts/probes/sse_flake_probe_sigkill.py
@@ -1,0 +1,175 @@
+"""Single-trial probe, variant 4: SIGKILL the peer's OS process mid-response.
+
+Variant 3 (`sse_flake_probe_serverkill.py`, in-process `task.cancel()` on
+uvicorn's `Server.serve()` task) produced 0 touched races out of 10 --
+cancelling the outer serve task does not reliably tear down already-accepted
+connection handlers, so the client-visible TCP connection often just kept
+working. This variant runs the peer in its own OS process
+(`_serverkill_runner.py`) and sends it SIGKILL mid-response: the kernel then
+closes every one of that process's file descriptors, including any live
+client socket, which is the closest local simulation of "the peer really did
+die mid-stream" available without raw packet injection.
+
+Same protocol as the other race variants: connect, start a tool call,
+concurrently kill the peer after a random delay, classify the result.
+"""
+
+from __future__ import annotations  # noqa: E402
+
+import argparse  # noqa: E402
+import asyncio  # noqa: E402
+import contextlib  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import random  # noqa: E402
+import signal  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+logging.basicConfig(level=logging.ERROR)
+
+from pmcp.client.manager import ClientManager  # noqa: E402
+from pmcp.policy.policy import PolicyManager  # noqa: E402
+from pmcp.tools.handlers import GatewayTools  # noqa: E402
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig  # noqa: E402
+from tests.runtime.harness import alloc_port  # noqa: E402
+
+RUNNER = Path(__file__).with_name("_serverkill_runner.py")
+TARGET_STRING = "SSE stream ended without a response"
+SIBLING_STRING = "SSE stream ended and reconnection attempts were exhausted"
+AUTH_VALUE = "Bearer probe-secret-token"
+
+
+def _config(name: str, url: str) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=RemoteMcpServerConfig(
+            type="streamable-http", url=url, headers={"Authorization": AUTH_VALUE}
+        ),
+    )
+
+
+@dataclass
+class TrialResult:
+    trial_id: int
+    kills: int
+    target_hits: list[str] = field(default_factory=list)
+    sibling_hits: list[str] = field(default_factory=list)
+    other: list[str] = field(default_factory=list)
+    elapsed_s: float = 0.0
+
+
+def _classify(message: str, result: TrialResult) -> None:
+    if TARGET_STRING in message:
+        result.target_hits.append(message)
+    elif SIBLING_STRING in message:
+        result.sibling_hits.append(message)
+    else:
+        result.other.append(message)
+
+
+async def _start_peer_process(port: int) -> asyncio.subprocess.Process:
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(RUNNER),
+        str(port),
+        AUTH_VALUE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    assert proc.stdout is not None
+    for _ in range(300):
+        line = await proc.stdout.readline()
+        if b"READY" in line:
+            return proc
+        if proc.returncode is not None:
+            raise RuntimeError("peer process exited before READY")
+    raise RuntimeError("peer process never printed READY")
+
+
+async def _run_trial(
+    trial_id: int, kills: int, min_delay_ms: float, max_delay_ms: float
+) -> TrialResult:
+    result = TrialResult(trial_id=trial_id, kills=kills)
+    start = time.monotonic()
+
+    manager = ClientManager()
+    gateway_tools = GatewayTools(client_manager=manager, policy_manager=PolicyManager())
+
+    for i in range(kills):
+        port = alloc_port()
+        proc = await _start_peer_process(port)
+        config = _config("probe-sigkill", f"http://127.0.0.1:{port}/mcp")
+        try:
+            errors = await manager.connect_server(config, retry=False)
+            for err in errors:
+                _classify(err, result)
+            if not manager.is_server_online("probe-sigkill"):
+                continue
+
+            delay = random.uniform(min_delay_ms, max_delay_ms) / 1000.0
+
+            async def _kill_peer() -> None:
+                await asyncio.sleep(delay)
+                with contextlib.suppress(ProcessLookupError):
+                    proc.send_signal(signal.SIGKILL)
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=2.0)
+
+            call_task = asyncio.create_task(
+                gateway_tools.invoke(
+                    {
+                        "tool_id": "probe-sigkill::fr_echo",
+                        "arguments": {"text": f"k{i}"},
+                    }
+                )
+            )
+            kill_task = asyncio.create_task(_kill_peer())
+            call_result, _ = await asyncio.gather(
+                call_task, kill_task, return_exceptions=True
+            )
+
+            if isinstance(call_result, BaseException):
+                _classify(repr(call_result), result)
+            elif not call_result.ok:
+                for err in call_result.errors or []:
+                    _classify(err, result)
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(
+                    manager.disconnect_server("probe-sigkill", force=True), timeout=3.0
+                )
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=3.0)
+
+    with contextlib.suppress(Exception):
+        await manager.disconnect_all()
+
+    result.elapsed_s = time.monotonic() - start
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kills", type=int, default=10)
+    parser.add_argument("--min-delay-ms", type=float, default=0.0)
+    parser.add_argument("--max-delay-ms", type=float, default=30.0)
+    parser.add_argument("--trial-id", type=int, default=0)
+    args = parser.parse_args()
+
+    result = asyncio.run(
+        _run_trial(args.trial_id, args.kills, args.min_delay_ms, args.max_delay_ms)
+    )
+    print(json.dumps(result.__dict__))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probes/sse_flake_probe_sigkill_connect.py
+++ b/scripts/probes/sse_flake_probe_sigkill_connect.py
@@ -1,0 +1,160 @@
+"""Single-trial probe, variant 5: SIGKILL the peer during the INITIAL
+connect handshake, not a follow-up tool call.
+
+Variant 4 (`sse_flake_probe_sigkill.py`) reproduced the target message by
+killing the peer mid-*tool-call*, after a successful connect. But the
+originally reported symptom is specifically at connect time:
+`Failed to connect to <name>: SSE stream ended without a response` -- the
+exact text `connect_all()` / `connect_server()` wrap around a failed
+`_connect_singleflight` (manager.py, "Failed to connect to {config.name}:
+{e}"). `initialize` is a JSONRPCRequest answered over SSE exactly like a
+`tools/call` (see the investigation note's Step 1), so the same upstream
+code path applies -- this variant closes the loop by racing the kill
+against `connect_server()` itself.
+"""
+
+from __future__ import annotations  # noqa: E402
+
+import argparse  # noqa: E402
+import asyncio  # noqa: E402
+import contextlib  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import random  # noqa: E402
+import signal  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+logging.basicConfig(level=logging.ERROR)
+
+from pmcp.client.manager import ClientManager  # noqa: E402
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig  # noqa: E402
+from tests.runtime.harness import alloc_port  # noqa: E402
+
+RUNNER = Path(__file__).with_name("_serverkill_runner.py")
+TARGET_STRING = "SSE stream ended without a response"
+SIBLING_STRING = "SSE stream ended and reconnection attempts were exhausted"
+AUTH_VALUE = "Bearer probe-secret-token"
+
+
+def _config(name: str, url: str) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=RemoteMcpServerConfig(
+            type="streamable-http", url=url, headers={"Authorization": AUTH_VALUE}
+        ),
+    )
+
+
+@dataclass
+class TrialResult:
+    trial_id: int
+    kills: int
+    target_hits: list[str] = field(default_factory=list)
+    sibling_hits: list[str] = field(default_factory=list)
+    other: list[str] = field(default_factory=list)
+    elapsed_s: float = 0.0
+
+
+def _classify(message: str, result: TrialResult) -> None:
+    if TARGET_STRING in message:
+        result.target_hits.append(message)
+    elif SIBLING_STRING in message:
+        result.sibling_hits.append(message)
+    else:
+        result.other.append(message)
+
+
+async def _start_peer_process(port: int) -> asyncio.subprocess.Process:
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(RUNNER),
+        str(port),
+        AUTH_VALUE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    assert proc.stdout is not None
+    for _ in range(300):
+        line = await proc.stdout.readline()
+        if b"READY" in line:
+            return proc
+        if proc.returncode is not None:
+            raise RuntimeError("peer process exited before READY")
+    raise RuntimeError("peer process never printed READY")
+
+
+async def _run_trial(
+    trial_id: int, kills: int, min_delay_ms: float, max_delay_ms: float
+) -> TrialResult:
+    result = TrialResult(trial_id=trial_id, kills=kills)
+    start = time.monotonic()
+    manager = ClientManager()
+
+    for i in range(kills):
+        port = alloc_port()
+        proc = await _start_peer_process(port)
+        config = _config("probe-connect-kill", f"http://127.0.0.1:{port}/mcp")
+        try:
+            delay = random.uniform(min_delay_ms, max_delay_ms) / 1000.0
+
+            async def _kill_peer() -> None:
+                await asyncio.sleep(delay)
+                with contextlib.suppress(ProcessLookupError):
+                    proc.send_signal(signal.SIGKILL)
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=2.0)
+
+            connect_task = asyncio.create_task(
+                manager.connect_server(config, retry=False)
+            )
+            kill_task = asyncio.create_task(_kill_peer())
+            errors, _ = await asyncio.gather(
+                connect_task, kill_task, return_exceptions=True
+            )
+
+            if isinstance(errors, BaseException):
+                _classify(repr(errors), result)
+            else:
+                for err in errors:
+                    _classify(err, result)
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(
+                    manager.disconnect_server("probe-connect-kill", force=True),
+                    timeout=3.0,
+                )
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=3.0)
+
+    with contextlib.suppress(Exception):
+        await manager.disconnect_all()
+
+    result.elapsed_s = time.monotonic() - start
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kills", type=int, default=10)
+    parser.add_argument("--min-delay-ms", type=float, default=0.0)
+    parser.add_argument("--max-delay-ms", type=float, default=30.0)
+    parser.add_argument("--trial-id", type=int, default=0)
+    args = parser.parse_args()
+
+    result = asyncio.run(
+        _run_trial(args.trial_id, args.kills, args.min_delay_ms, args.max_delay_ms)
+    )
+    print(json.dumps(result.__dict__))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This is an **investigation note, not a fix.** No `src/` changes. See
`.consiliency/notes/sse-stream-ended-investigation-20260812.md` for the full
writeup.

**The reported symptom is reproduced, at its exact reported call site, with
its exact reported string** -- but the root cause is a genuinely dead peer
(the downstream server process dying mid-response), which the mcp SDK
reports correctly. There is nothing incorrect in `src/pmcp/client/manager.py`
or its use of the mcp SDK's transport to fix, so **this PR ships no fix.**

## What was tried

1. **Organic load** (healthy peers, high concurrency): 240 `connect_all()`
   batches, 7,200 SSE-response tool calls, 1,200 disconnects across 40
   trials. **0 reproductions.**
2. **pmcp-side disconnect racing an in-flight request to the same server**:
   1,200 race attempts across 40 trials. **0 reproductions of the target
   string** -- pmcp's own `cancel_pending_requests` always wins that race
   first (produces a plain `CancelledError` instead), which structurally
   rules this hypothesis out.
3. **In-process `task.cancel()` on the peer's uvicorn serve task**: dead
   end, 0/10 races even touched (doesn't reliably sever live connections).
   Documented so it isn't retried.
4. **SIGKILL of the peer's OS process mid-tool-call**: **16/40 (40%)**
   target-string hit rate in the right timing window (post-headers,
   pre-completion).
5. **SIGKILL of the peer's OS process mid-`connect_server()`/`initialize`**
   -- the exact call site named in the original symptom: **3/50 (6%)**,
   producing the verbatim reported string:
   ```
   Failed to connect to <name>: SSE stream ended without a response
   ```

## Why this isn't a pmcp bug

Every downstream `mcp.server.MCPServer` in this repo's own test harness (and
plausibly most real ones, since resumability is opt-in) is built without an
`event_store`, so every SSE event it emits has no `id`. That makes *any*
mid-response peer death permanently unresumable and unconditionally
produces this exact message rather than the "reconnection attempts
exhausted" sibling -- there's no client-side defect involved, just an
accurate report that the peer is gone. The "load-correlated, several
servers connect/disconnect around the same time" framing is consistent with
downstream server processes being more likely to be OOM-killed / restarted
/ recycled during busy periods, which is outside pmcp's control.

## Also ruled out from re-litigation

`sse_starlette.sse.AppStatus.should_exit`'s process-global latch (already
diagnosed and fixed in `tests/runtime/fake_remote.py`) was deliberately
avoided by construction (fresh subprocess per trial) and is not the finding
here.

## Gates

No `src/` or `tests/` changes, so the full pytest/mypy gates don't apply per
the task instructions. `ruff check` / `ruff format --check` are clean on
all new files under `scripts/probes/`.

## Next steps (not done here)

- Correlate real fleet occurrences of this message against downstream
  server restarts/OOM kills to close the loop.
- Possible (speculative, not attempted) observability improvement:
  distinguish "peer died mid-response" from other SSE-transport failures in
  the surfaced error text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->