### PR TITLE
chore: v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-08-12
+
 ### Fixed
 - **`gateway.update_server` now actually restarts the server, and no longer
   leaves a stale "update available" notice behind after a successful

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.1.0"
+version = "2.1.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Patch release for the `gateway.update_server` repair merged in #147.

## Why 2.1.1 and not 2.2.0

The only shipped change since 2.1.0 is a bug fix. `gateway.update_server` does gain an optional `force` parameter, which is additive to a public tool surface — but it exists to serve the fix (a restart is now mandatory, so callers need a way to proceed past pending requests) rather than to add a capability. Defaults to `false`, so every existing call behaves as before apart from the fix itself.

Callers should know the tool can now return `ok: false` where it previously always reported success after the probe — that is the fix, not a regression: it means the package was fetched but the server could not be restarted, so the old version is still serving.

## Verification

- `pytest -q` → **2536 passed, 3 skipped, 0 failed**
- `ruff check .` → All checks passed; `ruff format --check src/ tests/` → 112 files already formatted
- `mypy src` → Success, no issues in 42 source files
- Version guards (106 tests) pass: the drift test and the `__init__.py`/CHANGELOG coherence check both agree at 2.1.1
- `uv.lock` regenerated

## Follow-ups left open

#150 (notice paths still use the manifest-only resolver) and #151 (config resolved twice across the probe window) — both narrow, both filed during review of #147.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->