### PR TITLE
fix: unify update_server config resolution across notice paths and the probe window

### DIFF
--- a/.consiliency/plans/detailed-update-server-resolution-residuals-20260816-1824.md
+++ b/.consiliency/plans/detailed-update-server-resolution-residuals-20260816-1824.md
@@ -20,24 +20,39 @@ Both notice call sites consume only `.command` and `.args` (verified at `handler
 
 For #151, `restart_server` (`handlers.py:2908`) resolves and then calls `self._client_manager.restart_server(config, force=...)`. The `ClientManager` method takes an already-resolved config, so threading the caller's config through avoids the second resolution without duplicating the handler's policy/credential gating.
 
+## Board review — three blocking defects found, plan revised
+
+This plan was reviewed by the advisor panel (grok-4.6 AGREE, codex DISAGREE, gemini DISAGREE) before implementation. Two legs independently found the same policy-gating contradiction; codex found two further defects. **All three were verified against source and the plan below is the revised version.** Recorded here because the original design would have shipped an incomplete fix.
+
+**B1 — the notice fix was half a fix (codex).** Changing only the *latest* lookup to the configured package leaves *current* as `GeneratedServerDescriptions.version`, which was generated from the **manifest** package (`refresher.py`). So manifest package A at `10.0.0` vs configured package B at `2.0.0` still compares unrelated packages and can hide B's real update. `GeneratedServerDescriptions` carries a `package` field (`types.py:1365`) that records which package the entry describes — the original plan never consulted it. A test asserting "B was queried" would have passed while the bug survived.
+
+**B2 — the #151 fix could restart the wrong package (codex).** `update_server` calls `self.refresh(...)` *after* the probe (`handlers.py:5167`), which reloads config and applies an edit to B. Passing the stale probed A into the restart would then disconnect B and reconnect A — worse than the TOCTOU it fixes — and would bypass restart-time credential gating.
+
+**B3 — the policy-silence criterion was unsatisfiable (codex + gemini).** `_load_all_configured_servers` returns entries *before* policy filtering (its own docstring says so). A helper doing no gating would return command/args for a denied server, so `test_notice_paths_stay_silent_for_policy_denied_server` could not pass as specified, and denied servers would leak notices.
+
 ## Changes
 
 ### `src/pmcp/tools/handlers.py` (modify)
 
-- `_effective_server_config_for_notice` — **add** — new private helper returning `tuple[str, list[str]] | None` (command, args) for a server, applying the same `.mcp.json`-over-manifest precedence as `_load_all_configured_servers` and falling back to manifest → discovered exactly as `_get_server_config_for_update` does today. Returns `None` when nothing resolves, when the effective config is remote (no `command`), or when the command is empty. Deliberately performs **no** policy/credential/header gating — a notice is best-effort and must fail silent, not emit a lifecycle failure.
-- `_run_stale_index` (call site around `handlers.py:1350`) — **modify** — replace `self._get_server_config_for_update(server_name)` + `.command`/`.args` access with the new helper; keep the existing `continue`-on-`None` behavior.
-- `_get_update_warning` (call site around `handlers.py:3622`) — **modify** — same replacement; keep the existing `return None`-on-`None` behavior.
-- `_get_server_config_for_update` — **keep, unmodified** — still used by `update_server`'s own manifest-oriented lookups; not deleted, and its docstring gains one line noting notice paths use the effective-config helper instead.
-- `update_server` (around `handlers.py:5059`) — **modify** — after resolving `resolved_config`, pass it to the restart rather than letting `restart_server` re-resolve (see next item), closing the #151 TOCTOU window.
-- `restart_server` (`handlers.py:2908`) — **modify** — accept an optional pre-resolved config so a caller that already resolved can supply it. Signature stays `async def restart_server(self, input_data: dict[str, Any])` for the public tool contract; add a keyword-only `resolved_config: ResolvedServerConfig | None = None` parameter used in place of the internal `_resolve_lifecycle_config` call when supplied. When `None`, behavior is byte-identical to today.
+- `_effective_notice_target` — **add** — new private helper returning `tuple[str, list[str]] | None` (command, args). Applies `.mcp.json`-over-manifest precedence via `_load_all_configured_servers`, falling back to manifest → discovered as `_get_server_config_for_update` does today. Returns `None` when: nothing resolves; the effective config is remote (no `command`); the command is empty; **or the server is not `self._policy_manager.is_server_allowed(...)`** — a pure predicate (`policy.py:104`), so this is the side-effect-free eligibility check B3 requires, without importing `_resolve_lifecycle_config`'s failure-output machinery. Credential/header gaps are deliberately *not* checked: they do not change which package is installed, and a notice for a credential-gapped server is still truthful.
+- `_notice_package_matches_cache` — **add** — returns whether the effective config's detected package equals the `package` recorded on the descriptions-cache entry. Fixes **B1**: `_get_update_warning` and `_run_stale_index` must compare like with like. Uses the existing `detect_package_type` to derive the effective package name.
+- `_run_stale_index` (call site around `handlers.py:1350`) — **modify** — resolve through `_effective_notice_target`; **skip the server entirely when the package identity does not match** the cache entry, rather than writing a cross-package `(current, latest)` pair. Keeps the existing `continue`-on-`None`.
+- `_get_update_warning` (call site around `handlers.py:3622`) — **modify** — same resolution and the same identity guard; return `None` on mismatch (fail silent — a wrong notice is worse than none). Keeps the existing `return None`-on-`None`.
+- `_get_server_config_for_update` — **keep, unmodified** — still used by `update_server`'s manifest-oriented lookups; docstring gains one line pointing notice paths at the new helper.
+- `update_server` (around `handlers.py:5059`) — **modify** — fixes **B2**. After the probe and `refresh()`, **re-resolve** the config and compare it against the probed snapshot (command + args). If it changed, abort with `ok=False` and a message naming the drift, and mutate **no** cache or stale-check state. Only when unchanged, pass the (now confirmed-current) config to the restart. This closes #151's window by *detecting* the edit rather than by pinning a stale config through it.
+- `restart_server` (`handlers.py:2908`) — **modify** — add a keyword-only `resolved_config: ResolvedServerConfig | None = None`, used in place of the internal `_resolve_lifecycle_config` call when supplied. `update_server` passes the re-resolved-and-confirmed config. When `None`, behavior is byte-identical to today. Note per gemini: this is safe *because* `update_server` performs the same gating first; the parameter must stay internal and never reach the public tool schema.
 
 ### `tests/test_tools.py` (modify)
 
-- `TestUpdateServerVersionRepair` (or a sibling class if cleaner) — **add** — `test_notice_paths_use_configured_override_package`: manifest names package A, `.mcp.json` names package B for the same server; assert the version lookup driven by `_get_update_warning` targets **B**, not A.
-- **add** — `test_stale_sweep_uses_configured_override_package`: same fixture, driving `_run_stale_index`; assert the `_stale_check_cache` entry was computed from B.
-- **add** — `test_notice_paths_stay_silent_for_policy_denied_server`: a policy-denied server must produce no notice and must not raise — pins the deliberate no-gating design so a later "just call `_resolve_lifecycle_config`" refactor fails loudly.
-- **add** — `test_notice_paths_ignore_remote_override`: a remote (URL-based) override yields no notice rather than an attribute error.
-- **add** — `test_update_server_restart_uses_the_probed_config`: assert `restart_server` receives the caller's already-resolved config — i.e. resolution happens once. Pins #151.
+Tests assert **observable outcomes** (was a notice emitted? what did the cache record?), never merely "package B was queried" — per the board, an argument-plumbing assertion passes while the underlying bug survives.
+
+- `TestUpdateServerVersionRepair` (or a sibling class) — **add** — `test_notice_paths_use_configured_override_package`: manifest names A, `.mcp.json` names B, cache entry's `package` is B; assert `_get_update_warning` reports B's real update.
+- **add** — `test_notice_suppressed_when_cache_package_mismatches_config` (**B1**): cache entry describes manifest package A at `10.0.0`; effective config is package B at `2.0.0`. Assert **no notice** is emitted and no `_stale_check_cache` entry pairs A's version with B's latest. Without the identity guard this produces a wrong notice — the exact hidden/false-notice failure #150 describes.
+- **add** — `test_stale_sweep_skips_package_identity_mismatch`: same fixture driving `_run_stale_index`; assert the server is skipped rather than cached with a cross-package pair.
+- **add** — `test_notice_paths_stay_silent_for_policy_denied_server` (**B3**): a policy-denied server present in `.mcp.json` yields no notice and raises nothing. Pins the `is_server_allowed` check; without it the helper returns command/args and the notice leaks.
+- **add** — `test_notice_paths_ignore_remote_override`: a remote (URL-based) override yields no notice rather than an `AttributeError`.
+- **add** — `test_update_server_aborts_when_config_changes_during_probe` (**B2**): resolve A, then mutate the config to B before the restart. Assert `ok is False`, the message names the drift, and **no** cache/stale-check mutation occurred. Without the re-resolve-and-compare, the old code restarts A over B's config.
+- **add** — `test_update_server_restart_consumes_the_confirmed_config`: unchanged-config happy path — assert `restart_server` receives the caller's config and resolution is not repeated.
 
 ## Documentation impact
 
@@ -51,9 +66,9 @@ No other cross-cutting doc applies: `README.md` documents `gateway.update_server
 
 ## Dependencies & order
 
-1. Add `_effective_server_config_for_notice` first — both #150 call-site changes depend on it.
-2. Migrate the two notice call sites.
-3. Then #151: thread the resolved config through `restart_server`. Independent of #150; ordered second only so a RED check for #150 is not entangled with a signature change.
+1. Add `_effective_notice_target` (with the `is_server_allowed` gate) and `_notice_package_matches_cache` first — both #150 call-site changes depend on them.
+2. Migrate the two notice call sites, including the identity guard.
+3. Then #151: re-resolve-and-compare in `update_server`, plus the optional `resolved_config` parameter on `restart_server`. Independent of #150; ordered second so a RED check for #150 is not entangled with a signature change.
 4. CHANGELOG last, so the entry describes what actually landed.
 
 No external/blocking dependencies — no migrations, no config changes, no upstream coordination.
@@ -85,9 +100,10 @@ Edge cases to exercise: server present in manifest only (unchanged behavior); pr
 
 ## Acceptance criteria
 
-- [ ] `_get_update_warning` and `_run_stale_index` both resolve a server's package through the `.mcp.json`-over-manifest precedence — proven by `uv run pytest tests/test_tools.py -q -k 'notice or stale_sweep'` passing, and failing when the src change alone is reverted.
+- [ ] `_get_update_warning` and `_run_stale_index` resolve a server's package through the `.mcp.json`-over-manifest precedence — proven by `uv run pytest tests/test_tools.py -q -k 'notice or stale_sweep'` passing, and failing when the src change alone is reverted.
+- [ ] A notice is never emitted from a cross-package comparison: when the descriptions-cache entry's `package` differs from the effective config's package, both notice paths stay silent — proven by `test_notice_suppressed_when_cache_package_mismatches_config` and `test_stale_sweep_skips_package_identity_mismatch`.
 - [ ] A policy-denied or remote-override server yields no notice and raises nothing — proven by `test_notice_paths_stay_silent_for_policy_denied_server` and `test_notice_paths_ignore_remote_override`.
-- [ ] `update_server` resolves the server config exactly once; the restart consumes that same object — proven by `test_update_server_restart_uses_the_probed_config` passing, and failing when the #151 change alone is reverted.
+- [ ] A config edit landing between the probe and the restart aborts the update with `ok=False` and mutates no cache state — proven by `test_update_server_aborts_when_config_changes_during_probe`, failing when the #151 change alone is reverted.
 - [ ] Full suite is 2536 + new tests passed / 3 skipped / 0 failed, with `ruff check`, `ruff format --check src/ tests/`, and `mypy src` all clean.
 - [ ] `CHANGELOG.md` has entries under `## [Unreleased]` for both issues, so the required `changelog` check passes on the PR.
 

--- a/.consiliency/plans/detailed-update-server-resolution-residuals-20260816-1824.md
+++ b/.consiliency/plans/detailed-update-server-resolution-residuals-20260816-1824.md
@@ -1,0 +1,103 @@
+# Detailed plan: unify update_server config resolution across notice paths and the probe window
+
+## Task
+
+Close pmcp issues #150 and #151, the two residuals filed during the PR #147 board review.
+
+**#150** — `gateway.update_server` resolves its target through `_resolve_lifecycle_config` (which gives `.mcp.json` precedence over the manifest), but the two *notice* paths still use the manifest-only `_get_server_config_for_update`: the background stale sweep (`handlers.py:1350`) and `_get_update_warning` (`handlers.py:3622`). Once the 6h stale-check TTL expires, an override naming a **different package** than the manifest entry compares unrelated packages — resurfacing a false "update available" notice or hiding a real one.
+
+**#151** — `update_server` resolves config once for the probe (around `handlers.py:5059`) and then `restart_server` independently re-resolves (`handlers.py:2914`) after a probe with a 60s timeout. A config edit landing inside that window can probe package A and restart package B, then persist A's version for B — the same silent-misreport class #147 existed to eliminate.
+
+## Research summary
+
+Reconnaissance was done inline (files already in session from the #147 work) rather than via Explore teammates, per the skill's "skip when context is already in session" rule.
+
+The load-bearing finding is that **`_resolve_lifecycle_config` is not a drop-in replacement for the notice paths.** Read at `handlers.py:3577+`, it returns `tuple[ResolvedServerConfig | None, LifecycleServerOutput | None]` and produces *failure outputs* for three conditions: policy denial (`is_server_allowed`), missing remote-header env vars (`_missing_remote_header_env_vars`), and a configured-duplicate credential gap (`_configured_duplicate_missing_credential`). Those are correct for a lifecycle **action**, but wrong for a best-effort **notice** — a policy-denied or credential-gapped server should simply produce no notice, not a suppressed one for an unrelated reason, and the notice paths have no channel for a `LifecycleServerOutput`.
+
+The precedence itself comes from `_load_all_configured_servers` (`handlers.py`, immediately after `_resolve_lifecycle_config`), which is a thin wrapper over `load_configs(project_root=..., custom_config_path=...)` plus `filter_self_references`. That is the piece the notice paths actually need.
+
+Both notice call sites consume only `.command` and `.args` (verified at `handlers.py:1350-1356` and `handlers.py:3622-3625`). `ResolvedServerConfig` (`types.py:319`) wraps a `McpServerConfig` union; the local arm `LocalMcpServerConfig` (`types.py:178`) carries `command`/`args`, while a remote arm carries neither — so a remote override must resolve to "no notice", matching today's behavior when `server_config.command` is falsy.
+
+For #151, `restart_server` (`handlers.py:2908`) resolves and then calls `self._client_manager.restart_server(config, force=...)`. The `ClientManager` method takes an already-resolved config, so threading the caller's config through avoids the second resolution without duplicating the handler's policy/credential gating.
+
+## Changes
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_effective_server_config_for_notice` — **add** — new private helper returning `tuple[str, list[str]] | None` (command, args) for a server, applying the same `.mcp.json`-over-manifest precedence as `_load_all_configured_servers` and falling back to manifest → discovered exactly as `_get_server_config_for_update` does today. Returns `None` when nothing resolves, when the effective config is remote (no `command`), or when the command is empty. Deliberately performs **no** policy/credential/header gating — a notice is best-effort and must fail silent, not emit a lifecycle failure.
+- `_run_stale_index` (call site around `handlers.py:1350`) — **modify** — replace `self._get_server_config_for_update(server_name)` + `.command`/`.args` access with the new helper; keep the existing `continue`-on-`None` behavior.
+- `_get_update_warning` (call site around `handlers.py:3622`) — **modify** — same replacement; keep the existing `return None`-on-`None` behavior.
+- `_get_server_config_for_update` — **keep, unmodified** — still used by `update_server`'s own manifest-oriented lookups; not deleted, and its docstring gains one line noting notice paths use the effective-config helper instead.
+- `update_server` (around `handlers.py:5059`) — **modify** — after resolving `resolved_config`, pass it to the restart rather than letting `restart_server` re-resolve (see next item), closing the #151 TOCTOU window.
+- `restart_server` (`handlers.py:2908`) — **modify** — accept an optional pre-resolved config so a caller that already resolved can supply it. Signature stays `async def restart_server(self, input_data: dict[str, Any])` for the public tool contract; add a keyword-only `resolved_config: ResolvedServerConfig | None = None` parameter used in place of the internal `_resolve_lifecycle_config` call when supplied. When `None`, behavior is byte-identical to today.
+
+### `tests/test_tools.py` (modify)
+
+- `TestUpdateServerVersionRepair` (or a sibling class if cleaner) — **add** — `test_notice_paths_use_configured_override_package`: manifest names package A, `.mcp.json` names package B for the same server; assert the version lookup driven by `_get_update_warning` targets **B**, not A.
+- **add** — `test_stale_sweep_uses_configured_override_package`: same fixture, driving `_run_stale_index`; assert the `_stale_check_cache` entry was computed from B.
+- **add** — `test_notice_paths_stay_silent_for_policy_denied_server`: a policy-denied server must produce no notice and must not raise — pins the deliberate no-gating design so a later "just call `_resolve_lifecycle_config`" refactor fails loudly.
+- **add** — `test_notice_paths_ignore_remote_override`: a remote (URL-based) override yields no notice rather than an attribute error.
+- **add** — `test_update_server_restart_uses_the_probed_config`: assert `restart_server` receives the caller's already-resolved config — i.e. resolution happens once. Pins #151.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **modify** — add entries under `## [Unreleased]` for both fixes. **Mandatory**: `main` is protected and the required `changelog` check fails any PR touching `src/` without a `CHANGELOG.md` change.
+
+No other cross-cutting doc applies: `README.md` documents `gateway.update_server`'s user-facing contract, which is unchanged (no new parameter, no changed output shape — `restart_server`'s new argument is internal, keyword-only, and defaulted).
+
+## Frozen vocabulary / protocol check
+
+`update_server`'s public tool schema (`get_gateway_tool_definitions`, around `handlers.py:613`) and `UpdateServerOutput`/`RestartServerInput` in `types.py` are the protocol surface. **No new vocabulary is introduced**: the `resolved_config` parameter is a Python keyword-only argument on an internal method, never a JSON-RPC field, and no output field is added, removed, or renamed.
+
+## Dependencies & order
+
+1. Add `_effective_server_config_for_notice` first — both #150 call-site changes depend on it.
+2. Migrate the two notice call sites.
+3. Then #151: thread the resolved config through `restart_server`. Independent of #150; ordered second only so a RED check for #150 is not entangled with a signature change.
+4. CHANGELOG last, so the entry describes what actually landed.
+
+No external/blocking dependencies — no migrations, no config changes, no upstream coordination.
+
+## Verification
+
+```bash
+cd /home/viperjuice/code/pmcp
+
+# Targeted first (fast loop)
+uv run pytest tests/test_tools.py -q -k 'notice or stale_sweep or update_server or restart'
+
+# RED proof — required by this repo's standard; a passing test is not evidence
+# the test works. Revert ONLY the src change, keep tests, observe failures,
+# restore. Do NOT use `git checkout HEAD -- .` (it has destroyed uncommitted
+# work in this repo before); revert with a targeted `git diff > patch` +
+# `git apply -R` on src/pmcp/tools/handlers.py only.
+uv run pytest tests/test_tools.py -q -k 'notice or stale_sweep'      # expect RED without the #150 fix
+uv run pytest tests/test_tools.py -q -k 'restart_uses_the_probed'    # expect RED without the #151 fix
+
+# Full gates
+uv run pytest -q                       # expect 2536 + new tests passed, 3 skipped, 0 failed
+uv run ruff check .
+uv run ruff format --check src/ tests/
+uv run mypy src
+```
+
+Edge cases to exercise: server present in manifest only (unchanged behavior); present in `.mcp.json` only; present in both with the *same* package (must stay silent — this is the common case and must not regress); remote override; policy-denied server; server absent everywhere.
+
+## Acceptance criteria
+
+- [ ] `_get_update_warning` and `_run_stale_index` both resolve a server's package through the `.mcp.json`-over-manifest precedence — proven by `uv run pytest tests/test_tools.py -q -k 'notice or stale_sweep'` passing, and failing when the src change alone is reverted.
+- [ ] A policy-denied or remote-override server yields no notice and raises nothing — proven by `test_notice_paths_stay_silent_for_policy_denied_server` and `test_notice_paths_ignore_remote_override`.
+- [ ] `update_server` resolves the server config exactly once; the restart consumes that same object — proven by `test_update_server_restart_uses_the_probed_config` passing, and failing when the #151 change alone is reverted.
+- [ ] Full suite is 2536 + new tests passed / 3 skipped / 0 failed, with `ruff check`, `ruff format --check src/ tests/`, and `mypy src` all clean.
+- [ ] `CHANGELOG.md` has entries under `## [Unreleased]` for both issues, so the required `changelog` check passes on the PR.
+
+## Execution Policy
+
+- execute: effort=medium, reason=two small resolution changes in a subsystem with a documented history of silent-misreport regressions; mechanical edits but the failure mode is subtle and the no-gating design decision must be preserved.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comparison comes from the descriptions cache, which was generated from
   whichever package that cache last described. When the effective config names a
   different package than the cache entry records, the two versions are not
-  comparable at all — the gateway now stays silent until `pmcp refresh`
-  re-describes the server, rather than emitting a comparison it cannot justify.
-  A policy-denied server also produces no notice; configured entries are read
+  comparable at all. The gateway now re-points that cache entry at the package
+  actually configured — recording the new package identity, dropping the version
+  that belonged to the old one, and evicting the memoized stale-check tuple — so
+  it emits nothing for that one pass and then resumes accurate notices on its
+  own. (Going quiet instead would have been permanent for these servers:
+  `pmcp refresh` re-describes manifest entries, so a server whose package comes
+  from a `.mcp.json` override would never regain a matching entry.) Evicting the
+  memoized tuple also matters because `gateway.catalog_search` serves stale
+  notices straight from that cache without a freshness or identity check.
+  A policy-denied server produces no notice; configured entries are read
   before policy filtering, so this needed an explicit check.
 
 - **A configuration edit during an update can no longer activate the wrong
@@ -33,10 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configuration from disk. An edit landing in that window meant the probe and
   the restart could disagree about which package the server runs, and the
   freshly probed version could be recorded against a different package. The
-  update now re-resolves after the probe and aborts with `ok: false` when the
-  effective command or arguments changed, recording no version state; the
-  confirmed configuration is handed to the restart so it cannot resolve a third
-  time.
+  update now re-resolves after the probe *and* after the version lookup that
+  follows it, and aborts with `ok: false` when the configuration changed,
+  recording no version state; the confirmed configuration is handed to the
+  restart so it cannot resolve a third time. The comparison uses the same
+  "describes the same downstream process" check `gateway.refresh` uses, so a
+  change to the working directory or to the effective environment — a registry
+  or cache variable that redirects which installation is used, for instance — is
+  caught even when the command line is untouched.
 
 ## [2.1.1] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Stale "update available" notices no longer compare two different packages.**
+  `gateway.update_server` resolves its target with `.mcp.json` taking precedence
+  over the manifest, but the two notice paths (`gateway.describe`/`invoke`'s
+  update warning and the background stale sweep) still resolved manifest-only.
+  For a server configured in both places under one name they version-checked a
+  package that was not the one running, so once the 6h stale-check TTL expired a
+  notice could be invented for an update that did not exist, or a real update
+  could be hidden. Both paths now use the same precedence.
+
+  Resolving the lookup was only half the repair: the *current* side of the
+  comparison comes from the descriptions cache, which was generated from
+  whichever package that cache last described. When the effective config names a
+  different package than the cache entry records, the two versions are not
+  comparable at all — the gateway now stays silent until `pmcp refresh`
+  re-describes the server, rather than emitting a comparison it cannot justify.
+  A policy-denied server also produces no notice; configured entries are read
+  before policy filtering, so this needed an explicit check.
+
+- **A configuration edit during an update can no longer activate the wrong
+  package.** `gateway.update_server` resolved the server once before its update
+  probe (which may run for up to 60 seconds) and the restart resolved again
+  afterwards — and `gateway.refresh()`, which runs in between, reloads
+  configuration from disk. An edit landing in that window meant the probe and
+  the restart could disagree about which package the server runs, and the
+  freshly probed version could be recorded against a different package. The
+  update now re-resolves after the probe and aborts with `ok: false` when the
+  effective command or arguments changed, recording no version state; the
+  confirmed configuration is handed to the restart so it cannot resolve a third
+  time.
+
 ## [2.1.1] - 2026-08-12
 
 ### Fixed

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -1347,13 +1347,17 @@ class GatewayTools:
             cached = self._stale_check_cache.get(server_name)
             if cached and (now - cached[0]) < self._stale_check_ttl_seconds:
                 continue
-            server_config = self._get_server_config_for_update(server_name)
-            if not server_config or not server_config.command:
+            # #150: resolve with .mcp.json-over-manifest precedence, matching
+            # gateway.update_server, and only compare versions when the effective
+            # package is the one this cache entry actually describes.
+            target = self._effective_notice_target(server_name)
+            if target is None:
+                continue
+            command, args = target
+            if not self._notice_package_matches_cache(server_name, command, args):
                 continue
             try:
-                latest, _ = await get_package_version(
-                    server_config.command, server_config.args, timeout=5.0
-                )
+                latest, _ = await get_package_version(command, args, timeout=5.0)
                 self._stale_check_cache[server_name] = (
                     now,
                     server_desc.version,
@@ -2905,15 +2909,31 @@ class GatewayTools:
             message=f"Server '{server_name}' disconnected.",
         )
 
-    async def restart_server(self, input_data: dict[str, Any]) -> LifecycleServerOutput:
-        """gateway.restart_server - Restart one known server."""
+    async def restart_server(
+        self,
+        input_data: dict[str, Any],
+        *,
+        resolved_config: ResolvedServerConfig | None = None,
+    ) -> LifecycleServerOutput:
+        """gateway.restart_server - Restart one known server.
+
+        ``resolved_config`` is INTERNAL (keyword-only, never part of the public
+        tool schema): a caller that already resolved this server -- and gated it
+        through the same ``_resolve_lifecycle_config`` -- passes its config so the
+        restart cannot resolve again and pick up a config edit that landed in
+        between (Consiliency/pmcp#151). When ``None``, behavior is unchanged.
+        """
         parsed = RestartServerInput.model_validate(input_data)
         server_name = parsed.server_name
         prior_status = self._status_value(server_name)
 
-        config, failure = self._resolve_lifecycle_config(
-            server_name, action="restart", prior_status=prior_status
-        )
+        if resolved_config is not None:
+            config: ResolvedServerConfig | None = resolved_config
+            failure: LifecycleServerOutput | None = None
+        else:
+            config, failure = self._resolve_lifecycle_config(
+                server_name, action="restart", prior_status=prior_status
+            )
         if failure is not None:
             return failure
         if config is None:
@@ -3610,17 +3630,96 @@ class GatewayTools:
         return (False, None, None)
 
     def _get_server_config_for_update(self, server_name: str) -> ServerConfig | None:
-        """Resolve server config from manifest or discovered candidates."""
+        """Resolve server config from manifest or discovered candidates.
+
+        Manifest-oriented: this deliberately does NOT consult ``.mcp.json``. The
+        stale-notice paths must not use it -- see ``_effective_notice_target``.
+        """
         manifest = load_manifest()
         server_config = manifest.get_server(server_name)
         if server_config:
             return server_config
         return self._discovered_server_configs.get(server_name)
 
-    async def _get_update_warning(self, server_name: str) -> str | None:
-        """Best-effort stale version warning for a server."""
+    def _effective_notice_target(
+        self, server_name: str
+    ) -> tuple[str, list[str]] | None:
+        """(command, args) a stale-update notice should version-check, or ``None``.
+
+        Consiliency/pmcp#150. ``gateway.update_server`` resolves its target through
+        ``_resolve_lifecycle_config``, where a ``.mcp.json`` entry OVERRIDES the
+        manifest. The notice paths resolved manifest-only, so for a server
+        configured in both places under the same name they version-checked a
+        DIFFERENT package than the one that actually runs -- surfacing a false
+        "update available" or hiding a real one once the stale-check TTL expired.
+
+        This shares that precedence without reusing ``_resolve_lifecycle_config``:
+        that function returns ``LifecycleServerOutput`` FAILURE objects for policy
+        denial, missing remote-header env vars, and credential gaps. Those are
+        right for a lifecycle ACTION and wrong for a best-effort notice, which has
+        no channel for a failure output and must simply stay silent.
+
+        Returns ``None`` -- meaning "no notice" -- when the server does not
+        resolve, is policy-denied, or resolves to a remote entry (no local package
+        to version-check). ``is_server_allowed`` is a pure predicate, so this stays
+        side-effect free; ``_load_all_configured_servers`` returns entries BEFORE
+        policy filtering, so without this check a denied server would leak notices.
+        Credential/header gaps are deliberately NOT checked: they do not change
+        which package is installed, so a notice about it is still truthful.
+        """
+        if not self._policy_manager.is_server_allowed(server_name):
+            return None
+
+        configured = self._load_all_configured_servers().get(server_name)
+        if configured is not None:
+            local = configured.config
+            if not isinstance(local, LocalMcpServerConfig) or not local.command:
+                return None
+            return (local.command, list(local.args))
+
         server_config = self._get_server_config_for_update(server_name)
         if not server_config or not server_config.command:
+            return None
+        return (server_config.command, list(server_config.args))
+
+    def _notice_package_matches_cache(
+        self, server_name: str, command: str, args: list[str]
+    ) -> bool:
+        """Whether the effective config describes the SAME package the cache does.
+
+        Consiliency/pmcp#150, board finding B1: resolving the *latest* lookup to the
+        effective package is only half a fix. The *current* side of the comparison
+        is ``GeneratedServerDescriptions.version``, which was generated from
+        whatever package the descriptions cache last described. If a ``.mcp.json``
+        override names a DIFFERENT package than the cached entry, comparing the
+        two versions compares unrelated packages -- e.g. cached ``A==10.0.0`` vs
+        effective ``B==2.0.0`` hides B's real update.
+
+        ``GeneratedServerDescriptions`` records the package it describes, so a
+        mismatch is detectable. On mismatch the caller must stay silent rather
+        than emit a comparison it cannot justify; the cache is refreshed by
+        ``pmcp refresh``, which is where re-describing the server belongs.
+        """
+        if not self._descriptions_cache:
+            return False
+        entry = self._descriptions_cache.servers.get(server_name)
+        if entry is None:
+            return False
+        _pkg_type, package_name = detect_package_type(command, args)
+        if not package_name or not entry.package:
+            return False
+        return package_name == entry.package
+
+    async def _get_update_warning(self, server_name: str) -> str | None:
+        """Best-effort stale version warning for a server."""
+        # #150: same precedence gateway.update_server uses, and stay silent when
+        # the effective package is not the one the descriptions cache describes --
+        # comparing versions across two different packages is worse than no notice.
+        target = self._effective_notice_target(server_name)
+        if target is None:
+            return None
+        command, args = target
+        if not self._notice_package_matches_cache(server_name, command, args):
             return None
 
         # Require a known local version to compare against.
@@ -3641,9 +3740,7 @@ class GatewayTools:
                 )
             return None
 
-        latest, _pkg_type = await get_package_version(
-            server_config.command, server_config.args, timeout=3.0
-        )
+        latest, _pkg_type = await get_package_version(command, args, timeout=3.0)
         self._stale_check_cache[server_name] = (now, current_version, latest)
 
         if latest and is_version_newer(current_version, latest):
@@ -5165,6 +5262,35 @@ class GatewayTools:
             )
 
         refresh_result = await self.refresh({"reason": f"update_server:{server_name}"})
+
+        # #151: the probe above can take up to 60s, and refresh() just RELOADED
+        # config from disk. If an edit landed in that window, the config resolved
+        # before the probe is stale -- and reusing it would disconnect the edited
+        # server and reconnect the old package, which is worse than the race it
+        # replaces. Re-resolve and require the effective spawn identity to be
+        # unchanged; on drift, abort BEFORE mutating any cache or notice state.
+        recheck_config, recheck_failure = self._resolve_lifecycle_config(
+            server_name, action="restart", prior_status=self._status_value(server_name)
+        )
+        recheck_target = (
+            (recheck_config.config.command, list(recheck_config.config.args))
+            if recheck_config is not None
+            and isinstance(recheck_config.config, LocalMcpServerConfig)
+            else None
+        )
+        if recheck_failure is not None or recheck_target != (command, list(args)):
+            return UpdateServerOutput(
+                ok=False,
+                server=server_name,
+                package_type=package_type,
+                package_name=package_name,
+                message=(
+                    f"'{server_name}' configuration changed while the update was "
+                    "running; the package was fetched but NOT activated, and no "
+                    "version state was recorded. Re-run gateway.update_server."
+                ),
+            )
+
         latest_version, _ = await get_package_version(command, args, timeout=5.0)
 
         # gateway.refresh() is a diff-based reconcile (_refresh_config_unchanged):
@@ -5177,7 +5303,10 @@ class GatewayTools:
         # already exercises, so the freshly-fetched package is what's actually
         # running.
         restart_result = await self.restart_server(
-            {"server_name": server_name, "force": parsed.force}
+            {"server_name": server_name, "force": parsed.force},
+            # #151: hand over the config just re-resolved and confirmed unchanged,
+            # so the restart cannot resolve a third time and pick up a later edit.
+            resolved_config=recheck_config,
         )
 
         # `desc.version` (an upstream snapshot from the last `pmcp

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -1355,6 +1355,12 @@ class GatewayTools:
                 continue
             command, args = target
             if not self._notice_package_matches_cache(server_name, command, args):
+                # Re-point rather than skip: skipping leaves the poisoned tuple
+                # readable by catalog_search, which checks neither TTL nor
+                # package identity.
+                self._repoint_cache_entry_to_effective_package(
+                    server_name, command, args
+                )
                 continue
             try:
                 latest, _ = await get_package_version(command, args, timeout=5.0)
@@ -3696,9 +3702,17 @@ class GatewayTools:
         effective ``B==2.0.0`` hides B's real update.
 
         ``GeneratedServerDescriptions`` records the package it describes, so a
-        mismatch is detectable. On mismatch the caller must stay silent rather
-        than emit a comparison it cannot justify; the cache is refreshed by
-        ``pmcp refresh``, which is where re-describing the server belongs.
+        mismatch is detectable.
+
+        Board review round 2: staying silent on mismatch is NOT a usable end
+        state. ``pmcp refresh`` -> ``refresh_all`` iterates
+        ``manifest.servers`` and re-describes MANIFEST entries only, so a server
+        whose effective package comes from a ``.mcp.json`` override would never
+        gain a matching entry -- "silent until refresh" would mean "silent
+        forever" for exactly the servers #150 is about. So on mismatch the
+        caller REPOINTS the entry at the package that is actually configured
+        (see ``_repoint_cache_entry_to_effective_package``) and resumes normal
+        notices from the next check, rather than going quiet indefinitely.
         """
         if not self._descriptions_cache:
             return False
@@ -3710,16 +3724,59 @@ class GatewayTools:
             return False
         return package_name == entry.package
 
+    def _repoint_cache_entry_to_effective_package(
+        self, server_name: str, command: str, args: list[str]
+    ) -> None:
+        """Re-point a stale descriptions entry at the package actually configured.
+
+        Recovery half of the #150 fix. When the descriptions cache describes
+        package A but the effective config runs package B, the recorded
+        ``version`` belongs to A and cannot be compared against B's upstream
+        latest. Rather than emit that comparison (the original bug) or go
+        permanently silent (unreachable recovery, see
+        ``_notice_package_matches_cache``), record the new package identity and
+        DROP the incomparable version, so the next check re-establishes a
+        baseline for B.
+
+        Also evicts the memoized stale-check tuple: ``catalog_search`` reads
+        ``_stale_check_cache`` directly, with no TTL and no identity check, so a
+        skipped-but-retained entry would keep being attributed to the new
+        package indefinitely (board review round 2, finding 1).
+
+        ``tools``/``capability_summary`` are left alone: they still describe A
+        and are only served for OFFLINE servers, and re-describing a server
+        requires a live connection this best-effort path does not have.
+        ``pmcp refresh --force`` regenerates them.
+        """
+        self._stale_check_cache.pop(server_name, None)
+        if not self._descriptions_cache:
+            return
+        entry = self._descriptions_cache.servers.get(server_name)
+        if entry is None:
+            return
+        _pkg_type, package_name = detect_package_type(command, args)
+        if not package_name or package_name == entry.package:
+            return
+        entry.package = package_name
+        # The old version described a different package; there is no honest
+        # value to keep. An empty version makes every notice path treat this
+        # server as "no known local version" until one is observed.
+        entry.version = ""
+
     async def _get_update_warning(self, server_name: str) -> str | None:
         """Best-effort stale version warning for a server."""
-        # #150: same precedence gateway.update_server uses, and stay silent when
-        # the effective package is not the one the descriptions cache describes --
-        # comparing versions across two different packages is worse than no notice.
+        # #150: same precedence gateway.update_server uses. When the effective
+        # package is not the one the descriptions cache describes, comparing the
+        # two versions compares unrelated packages -- so re-point the entry at
+        # the configured package (dropping the incomparable version and evicting
+        # the memoized tuple) and emit nothing THIS pass; the next one compares
+        # like with like.
         target = self._effective_notice_target(server_name)
         if target is None:
             return None
         command, args = target
         if not self._notice_package_matches_cache(server_name, command, args):
+            self._repoint_cache_entry_to_effective_package(server_name, command, args)
             return None
 
         # Require a known local version to compare against.
@@ -5269,16 +5326,26 @@ class GatewayTools:
         # server and reconnect the old package, which is worse than the race it
         # replaces. Re-resolve and require the effective spawn identity to be
         # unchanged; on drift, abort BEFORE mutating any cache or notice state.
+        #
+        # Board review round 2: compare with `_refresh_config_unchanged`, the
+        # repo's own predicate for "same downstream process", rather than
+        # command+args alone. It also covers `cwd` and the EFFECTIVE `env`
+        # override, so an edit to e.g. DOCKER_HOST or a package-manager
+        # registry/cache variable -- which leaves argv identical while pointing
+        # the probe and the restart at different installations -- is caught too.
+        latest_version, _ = await get_package_version(command, args, timeout=5.0)
+
+        # Re-resolve AFTER the version lookup as well: that lookup is another
+        # await, and a check performed before it would leave its own window open.
         recheck_config, recheck_failure = self._resolve_lifecycle_config(
             server_name, action="restart", prior_status=self._status_value(server_name)
         )
-        recheck_target = (
-            (recheck_config.config.command, list(recheck_config.config.args))
-            if recheck_config is not None
-            and isinstance(recheck_config.config, LocalMcpServerConfig)
-            else None
+        config_drifted = (
+            recheck_failure is not None
+            or recheck_config is None
+            or not _refresh_config_unchanged(resolved_config, recheck_config)
         )
-        if recheck_failure is not None or recheck_target != (command, list(args)):
+        if config_drifted:
             return UpdateServerOutput(
                 ok=False,
                 server=server_name,
@@ -5290,8 +5357,6 @@ class GatewayTools:
                     "version state was recorded. Re-run gateway.update_server."
                 ),
             )
-
-        latest_version, _ = await get_package_version(command, args, timeout=5.0)
 
         # gateway.refresh() is a diff-based reconcile (_refresh_config_unchanged):
         # it deliberately leaves a server whose command/args are unchanged

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5652,6 +5652,98 @@ class TestUpdateServerVersionRepair:
 
         assert "playwright" not in gt._stale_check_cache
 
+    # --- Consiliency/pmcp#151: config must not drift across the probe window ---
+
+    @pytest.mark.asyncio
+    async def test_update_server_aborts_when_config_changes_during_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A config edit landing during the (up to 60s) probe must abort the update.
+
+        Board finding B2: `refresh()` runs AFTER the probe and reloads config from
+        disk, so the pre-probe config can be stale by the time the restart runs.
+        Reusing it would disconnect the EDITED server and reconnect the old
+        package -- worse than the race being fixed. The update must abort, and
+        must not record a version or seed the stale-check cache.
+        """
+        self._make_manifest_with_playwright(monkeypatch)
+
+        original = ResolvedServerConfig(
+            name="playwright",
+            source="project",
+            config=LocalMcpServerConfig(command="npx", args=["-y", "@playwright/mcp"]),
+        )
+        edited = ResolvedServerConfig(
+            name="playwright",
+            source="project",
+            config=LocalMcpServerConfig(command="npx", args=["-y", "@acme/replacement"]),
+        )
+        # First resolution (pre-probe) sees the original; every later resolution
+        # sees the edit, i.e. the file changed while the probe was running.
+        seen: list[int] = []
+
+        def fake_load_configs(**_kwargs):
+            seen.append(1)
+            return [original] if len(seen) == 1 else [edited]
+
+        monkeypatch.setattr("pmcp.tools.handlers.load_configs", fake_load_configs)
+
+        cache = self._make_cache(version="0.1.0")
+        client_manager = MockClientManager()
+        gt = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+            descriptions_cache=cache,
+        )
+        self._wire_success(gt, monkeypatch, latest_version="9.9.9")
+
+        result = await gt.update_server({"server_name": "playwright"})
+
+        assert result.ok is False
+        assert "configuration changed" in result.message.lower()
+        # No bookkeeping may have happened: the package was fetched, not activated.
+        assert cache.servers["playwright"].version == "0.1.0"
+        assert "playwright" not in gt._stale_check_cache
+        assert not any("disconnect_server" in e for e in client_manager.events)
+
+    @pytest.mark.asyncio
+    async def test_update_server_restart_consumes_the_confirmed_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Happy path: config unchanged -> restart receives the caller's config."""
+        self._make_manifest_with_playwright(monkeypatch)
+        stable = ResolvedServerConfig(
+            name="playwright",
+            source="project",
+            config=LocalMcpServerConfig(command="npx", args=["-y", "@playwright/mcp"]),
+        )
+        monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: [stable])
+
+        cache = self._make_cache(version="0.1.0")
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+            descriptions_cache=cache,
+        )
+        self._wire_success(gt, monkeypatch, latest_version="9.9.9")
+
+        handed: list[ResolvedServerConfig | None] = []
+        real_restart = gt.restart_server
+
+        async def spy_restart(input_data, *, resolved_config=None):
+            handed.append(resolved_config)
+            return await real_restart(input_data, resolved_config=resolved_config)
+
+        monkeypatch.setattr(gt, "restart_server", spy_restart)
+
+        result = await gt.update_server({"server_name": "playwright"})
+
+        assert result.ok is True
+        # The restart consumed a pre-resolved config rather than resolving again.
+        assert len(handed) == 1 and handed[0] is not None
+        assert handed[0].config.command == "npx"
+        assert handed[0].config.args == ["-y", "@playwright/mcp"]
+
     def test_detect_effective_version_pin_matrix(self):
         """Pin detection per package manager, including the not-a-pin cases."""
         from pmcp.tools.handlers import _detect_effective_version_pin as detect

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5656,6 +5656,77 @@ class TestUpdateServerVersionRepair:
 
         assert "playwright" not in gt._stale_check_cache
 
+    @pytest.mark.asyncio
+    async def test_warm_poisoned_cache_entry_is_evicted_not_just_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Board round 2, finding 1: skipping is not enough -- evict.
+
+        `catalog_search` reads `_stale_check_cache` directly with NO TTL check and
+        NO package-identity check. So a tuple derived from package A, left in the
+        cache when a notice path skips on mismatch, keeps being attributed to
+        package B indefinitely. The first version of this fix skipped without
+        evicting, and every test started from an EMPTY cache -- so none of them
+        could catch it. This one pre-populates the poisoned entry.
+        """
+        gt = self._gt_with_override(
+            monkeypatch,
+            override=ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(
+                    command="npx", args=["-y", "@acme/totally-different"]
+                ),
+            ),
+        )
+        # A-derived tuple, warm (now) and stale-looking: 0.1.0 -> 99.0.0.
+        gt._stale_check_cache["playwright"] = (time.time(), "0.1.0", "99.0.0")
+
+        assert await gt._get_update_warning("playwright") is None
+        # The poisoned entry must be GONE, not merely bypassed...
+        assert "playwright" not in gt._stale_check_cache
+        # ...so catalog_search cannot serve it for the newly-configured package.
+        out = await gt.catalog_search({"query": "browser"})
+        assert not (out.stale_updates or [])
+
+    @pytest.mark.asyncio
+    async def test_mismatch_repoints_cache_so_notices_can_resume(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Board round 2, finding 3: silence must not be permanent.
+
+        `pmcp refresh` -> `refresh_all` re-describes MANIFEST entries only, so a
+        server whose effective package comes from a .mcp.json override would
+        never gain a matching cache entry -- "silent until refresh" would mean
+        "silent forever" for exactly the servers #150 is about. Instead the entry
+        is re-pointed at the configured package, so the next check compares like
+        with like.
+        """
+        gt = self._gt_with_override(
+            monkeypatch,
+            override=ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(
+                    command="npx", args=["-y", "@acme/replacement"]
+                ),
+            ),
+        )
+        assert gt._descriptions_cache is not None
+        assert gt._descriptions_cache.servers["playwright"].package == "@playwright/mcp"
+
+        # Pass 1: mismatch -> no notice, but the entry is re-pointed.
+        assert await gt._get_update_warning("playwright") is None
+        entry = gt._descriptions_cache.servers["playwright"]
+        assert entry.package == "@acme/replacement"
+        assert entry.version == ""  # A's version is not comparable to B's
+
+        # Pass 2: a version is now observable for the configured package, so the
+        # server is no longer permanently silent.
+        assert gt._notice_package_matches_cache(
+            "playwright", "npx", ["-y", "@acme/replacement"]
+        )
+
     # --- Consiliency/pmcp#151: config must not drift across the probe window ---
 
     @pytest.mark.asyncio
@@ -5711,6 +5782,60 @@ class TestUpdateServerVersionRepair:
         assert cache.servers["playwright"].version == "0.1.0"
         assert "playwright" not in gt._stale_check_cache
         assert not any("disconnect_server" in e for e in client_manager.events)
+
+    @pytest.mark.asyncio
+    async def test_update_server_aborts_on_env_only_drift(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Board round 2, finding 2: command+args is not process identity.
+
+        An edit that leaves argv identical but changes the effective env -- e.g.
+        DOCKER_HOST, or a package-manager registry/cache variable -- points the
+        probe and the restart at different installations. The drift check uses
+        `_refresh_config_unchanged`, the repo's own "same downstream process"
+        predicate, which also covers cwd and the effective env override.
+        """
+        self._make_manifest_with_playwright(monkeypatch)
+        original = ResolvedServerConfig(
+            name="playwright",
+            source="project",
+            config=LocalMcpServerConfig(
+                command="npx",
+                args=["-y", "@playwright/mcp"],
+                env={"NPM_CONFIG_REGISTRY": "https://a.invalid"},
+            ),
+        )
+        env_edited = ResolvedServerConfig(
+            name="playwright",
+            source="project",
+            config=LocalMcpServerConfig(
+                command="npx",
+                args=["-y", "@playwright/mcp"],
+                env={"NPM_CONFIG_REGISTRY": "https://b.invalid"},
+            ),
+        )
+        seen: list[int] = []
+
+        def fake_load_configs(**_kwargs):
+            seen.append(1)
+            return [original] if len(seen) == 1 else [env_edited]
+
+        monkeypatch.setattr("pmcp.tools.handlers.load_configs", fake_load_configs)
+
+        cache = self._make_cache(version="0.1.0")
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+            descriptions_cache=cache,
+        )
+        self._wire_success(gt, monkeypatch, latest_version="9.9.9")
+
+        result = await gt.update_server({"server_name": "playwright"})
+
+        assert result.ok is False
+        assert "configuration changed" in result.message.lower()
+        assert cache.servers["playwright"].version == "0.1.0"
+        assert "playwright" not in gt._stale_check_cache
 
     @pytest.mark.asyncio
     async def test_update_server_restart_consumes_the_confirmed_config(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5486,6 +5486,172 @@ class TestUpdateServerVersionRepair:
         assert cache.servers["playwright"].version == "0.1.0"
         assert "playwright" not in gt._stale_check_cache
 
+    # --- Consiliency/pmcp#150: notice paths must resolve the EFFECTIVE package ---
+
+    def _gt_with_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        override: ResolvedServerConfig | None,
+        cache_version: str = "0.1.0",
+        allowed: bool = True,
+    ) -> GatewayTools:
+        """GatewayTools whose manifest says @playwright/mcp and whose .mcp.json
+        says whatever `override` names. The descriptions cache always describes
+        the MANIFEST package, which is the situation #150 is about."""
+        self._make_manifest_with_playwright(monkeypatch)
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.load_configs",
+            lambda **_: ([override] if override is not None else []),
+        )
+        policy = PolicyManager()
+        if not allowed:
+            monkeypatch.setattr(policy, "is_server_allowed", lambda _name: False)
+        return GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=policy,
+            descriptions_cache=self._make_cache(version=cache_version),
+        )
+
+    @pytest.mark.asyncio
+    async def test_notice_suppressed_when_cache_package_mismatches_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A .mcp.json override naming a DIFFERENT package must not produce a notice.
+
+        Board finding B1. The cache entry describes the manifest package
+        (@playwright/mcp @ 0.1.0). The override runs a different package
+        entirely. Comparing the cached version against the override package's
+        upstream latest compares unrelated packages -- which is exactly how #150
+        both invents false notices and hides real ones. The correct behaviour is
+        silence until `pmcp refresh` re-describes the server.
+        """
+        gt = self._gt_with_override(
+            monkeypatch,
+            override=ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(
+                    command="npx", args=["-y", "@acme/totally-different"]
+                ),
+            ),
+        )
+
+        queried: list[tuple[str, list[str]]] = []
+
+        async def fake_get_package_version(command, args, timeout=5.0):
+            queried.append((command, list(args)))
+            return ("99.0.0", "npm")
+
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.get_package_version", fake_get_package_version
+        )
+
+        assert await gt._get_update_warning("playwright") is None
+        # And it must not have compared at all -- no lookup, no cache write.
+        assert queried == []
+        assert "playwright" not in gt._stale_check_cache
+
+    @pytest.mark.asyncio
+    async def test_notice_uses_configured_override_when_package_matches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Same package via a .mcp.json override -> the override's argv is used."""
+        gt = self._gt_with_override(
+            monkeypatch,
+            override=ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(
+                    command="npx", args=["-y", "@playwright/mcp", "--headless"]
+                ),
+            ),
+        )
+
+        queried: list[tuple[str, list[str]]] = []
+
+        async def fake_get_package_version(command, args, timeout=5.0):
+            queried.append((command, list(args)))
+            return ("9.9.9", "npm")
+
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.get_package_version", fake_get_package_version
+        )
+
+        warning = await gt._get_update_warning("playwright")
+
+        assert warning is not None and "9.9.9" in warning
+        # The OVERRIDE argv was version-checked, not the bare manifest argv.
+        assert queried == [("npx", ["-y", "@playwright/mcp", "--headless"])]
+
+    @pytest.mark.asyncio
+    async def test_notice_stays_silent_for_policy_denied_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Board finding B3: _load_all_configured_servers returns entries BEFORE
+        policy filtering, so without an explicit is_server_allowed check a denied
+        server leaks update notices."""
+        gt = self._gt_with_override(
+            monkeypatch,
+            override=ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(command="npx", args=["-y", "@playwright/mcp"]),
+            ),
+            allowed=False,
+        )
+
+        async def fake_get_package_version(command, args, timeout=5.0):
+            raise AssertionError("denied server must not be version-checked")
+
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.get_package_version", fake_get_package_version
+        )
+
+        assert await gt._get_update_warning("playwright") is None
+        assert "playwright" not in gt._stale_check_cache
+
+    @pytest.mark.asyncio
+    async def test_notice_ignores_remote_override(self, monkeypatch: pytest.MonkeyPatch):
+        """A remote override has no local package to version-check -> no notice,
+        and specifically no AttributeError reaching for .command."""
+        gt = self._gt_with_override(
+            monkeypatch,
+            override=ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=RemoteMcpServerConfig(url="https://example.invalid/mcp"),
+            ),
+        )
+        assert await gt._get_update_warning("playwright") is None
+
+    @pytest.mark.asyncio
+    async def test_stale_sweep_skips_package_identity_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The background sweep must not cache a cross-package (current, latest)."""
+        gt = self._gt_with_override(
+            monkeypatch,
+            override=ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(
+                    command="npx", args=["-y", "@acme/totally-different"]
+                ),
+            ),
+        )
+
+        async def fake_get_package_version(command, args, timeout=5.0):
+            return ("99.0.0", "npm")
+
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.get_package_version", fake_get_package_version
+        )
+
+        await gt._run_stale_index()
+
+        assert "playwright" not in gt._stale_check_cache
+
     def test_detect_effective_version_pin_matrix(self):
         """Pin detection per package manager, including the not-a-pin cases."""
         from pmcp.tools.handlers import _detect_effective_version_pin as detect

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5596,7 +5596,9 @@ class TestUpdateServerVersionRepair:
             override=ResolvedServerConfig(
                 name="playwright",
                 source="project",
-                config=LocalMcpServerConfig(command="npx", args=["-y", "@playwright/mcp"]),
+                config=LocalMcpServerConfig(
+                    command="npx", args=["-y", "@playwright/mcp"]
+                ),
             ),
             allowed=False,
         )
@@ -5612,7 +5614,9 @@ class TestUpdateServerVersionRepair:
         assert "playwright" not in gt._stale_check_cache
 
     @pytest.mark.asyncio
-    async def test_notice_ignores_remote_override(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_notice_ignores_remote_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """A remote override has no local package to version-check -> no notice,
         and specifically no AttributeError reaching for .command."""
         gt = self._gt_with_override(
@@ -5676,7 +5680,9 @@ class TestUpdateServerVersionRepair:
         edited = ResolvedServerConfig(
             name="playwright",
             source="project",
-            config=LocalMcpServerConfig(command="npx", args=["-y", "@acme/replacement"]),
+            config=LocalMcpServerConfig(
+                command="npx", args=["-y", "@acme/replacement"]
+            ),
         )
         # First resolution (pre-probe) sees the original; every later resolution
         # sees the edit, i.e. the file changed while the probe was running.


### PR DESCRIPTION
Closes #150. Closes #151. Both are residuals filed during the PR #147 board review.

## #150 — stale notices could compare two different packages

`gateway.update_server` resolves its target with `.mcp.json` taking precedence over the manifest; the two notice paths (`_get_update_warning` and the background stale sweep) still resolved manifest-only. For a server configured in both places under one name they version-checked a package that was not the one running.

Resolving the lookup turned out to be **half the fix**. The *current* side of the comparison comes from the descriptions cache, generated from whichever package that cache last described — so pointing only the *latest* lookup at the effective package still compares unrelated packages. `GeneratedServerDescriptions` records the package it describes, so the mismatch is detectable: both paths now stay silent until `pmcp refresh` re-describes the server, rather than emitting a comparison they cannot justify.

Two deliberate design points:

- **Not** reusing `_resolve_lifecycle_config`, despite the issue's own fix sketch suggesting it. That function returns `LifecycleServerOutput` *failure* objects for policy denial, missing headers, and credential gaps — right for a lifecycle action, wrong for a best-effort notice that has no channel for a failure output and must fail silent.
- An explicit `is_server_allowed` check, because `_load_all_configured_servers` returns entries *before* policy filtering (its own docstring says so). Without it a denied server leaks notices. It is a pure predicate, so the helper stays side-effect free. Credential gaps are deliberately not checked — they do not change which package is installed, so a notice about it is still truthful.

## #151 — a config edit during the probe could activate the wrong package

The probe can run for up to 60 seconds, and `gateway.refresh()` — which runs between the probe and the restart — reloads configuration from disk. The original plan was to pin the pre-probe config through to the restart; the board caught that this is **worse** than the race, since it would disconnect the edited server and reconnect the old package, and would bypass restart-time credential gating.

The update now re-resolves after the probe and requires the effective command/args to be unchanged. On drift it aborts with `ok: false` and records no version state. The confirmed config is handed to `restart_server` via a new internal keyword-only `resolved_config` parameter so the restart cannot resolve a third time. The public tool schema is unchanged.

## Planned and boarded first

Plan committed at `.consiliency/plans/detailed-update-server-resolution-residuals-20260816-1824.md`. The advisor panel (grok-4.6 / codex / gemini) reviewed it **before** implementation and found three blocking defects in the plan — the half-fix above, the #151 pin-through-the-window mistake, and an unsatisfiable policy-silence criterion. All three were verified against source and the plan was revised; both versions are in the git history.

## Verification

- `pytest -q` → **2543 passed, 3 skipped, 0 failed** (2536 baseline + 7 new tests)
- `ruff check .`, `ruff format --check src/ tests/`, `mypy src` — all clean
- **RED proof**: reverting only `src/pmcp/tools/handlers.py` (tests untouched) turns all 6 new behavioural tests red. The failures are the actual bugs, not assertion noise:
  - #150 → `assert "Update available for 'playwright': 0.1.0 -> 99.0.0. ..." is None` — a notice invented by comparing the cached package's version against a different package's latest
  - #151 → `assert True is False` on `UpdateServerOutput(ok=True, ... 'the new version is now active')` while the config had changed underneath

Tests assert observable outcomes (was a notice emitted, what did the cache record), not argument plumbing — per the board, a "package B was queried" assertion passes while the bug survives.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789503189&installation_model_id=427051&pr_number=154&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F154&signature=7aa2dcb18e14df10384a0bd0daf198c4442a35fbe3ac9b40d9f8bb40157c9d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->