### PR TITLE
fix: update probe no longer orphans its process tree on timeout

### DIFF
--- a/.consiliency/plans/detailed-installed-version-from-runner-cache-20260817-1600.md
+++ b/.consiliency/plans/detailed-installed-version-from-runner-cache-20260817-1600.md
@@ -38,6 +38,8 @@ So the obvious implementation — shell out to `npm ls` / `uv pip show` — **re
 
 The directory name is a hash of the *argument set*, so pmcp cannot compute it — it must scan and match on the dependency name. Measured cost: **0.36s for 114 entries**, filesystem reads only, no subprocess and no network.
 
+**Why matching on `dependencies` cannot collide with a transitive dependency** (the obvious objection, checked before planning): every npx cache entry declares **exactly one** dependency — the package npx was invoked for — while its `node_modules/` holds the full transitive closure. Sampled six entries, all `len(dependencies) == 1`, against a `node_modules` of 212 packages in one of them. So the match must be against `dependencies`, never `node_modules`; matching the latter would resolve any transitive package and is the trap to avoid.
+
 *uv* (`uv cache dir`/`environments-v2/<a>/<b>/`): a normal venv whose `lib/python*/site-packages/*.dist-info` directories carry name and version (`sse_starlette-3.4.6.dist-info`). Note the layout is **two levels deep**, not one — my first probe assumed one and found nothing.
 
 **Why this source is different from the five that failed.** It is bound to the package identity by construction: the cache entry names the package, and the version is read from that package's own metadata. Every prior attempt compared a version whose provenance was unrelated to the configured package — an upstream snapshot (`descriptions_cache.version`), or the MCP `serverInfo.version` (an *implementation* version; FastMCP 1.x reported the SDK's, mcp 2.x defaults it to `""`).

--- a/.consiliency/plans/detailed-installed-version-from-runner-cache-20260817-1600.md
+++ b/.consiliency/plans/detailed-installed-version-from-runner-cache-20260817-1600.md
@@ -151,3 +151,47 @@ When several npx cache entries contain the same package at different versions (d
 automation:
   suite_command: "uv run pytest -q"
 ```
+
+
+---
+
+## Board review — REJECTED (3/3 DISAGREE). Do not implement as written.
+
+Boarded before implementation. All three legs blocked. Every finding verified against this machine's real caches; recorded so the seventh attempt starts from facts.
+
+### B1 (fatal) — the fallback contradicts this plan's own acceptance criterion
+
+The Changes section keeps `descriptions_cache.version` as a fallback when no installed version is available; the Acceptance section requires **no notice** in that case. Those cannot both hold.
+
+And the fallback is not salvageable by the package-identity check: that value is written from the upstream registry (`refresher.py:243`), and this repo already labels it an upstream snapshot (`handlers.py:5199`). Identity agreement makes it the *right package's* upstream snapshot — still not an observed installed version. Keeping it means the sixth attempt still emits inferred-version notices, which is the whole defect.
+
+Worse, my proposed test (`test_notice_silent_when_installed_version_unavailable`) specifies "no cache entry **and no orderable fallback**" — so it would pass while the real regression (cache missing, description orderable) went uncovered. That is the same test-shape failure as rounds 1–4 on PR #154.
+
+### B2 — neither probe identifies the environment that actually ran
+
+**npx.** Matching `dependencies` does avoid transitive collisions (verified earlier). But it does not bind an entry to the *configured argument set*, and the cache holds the same package at several versions simultaneously. Verified on this machine:
+
+```
+@consiliency/agent-board-mcp -> ^1.2.0  ^1.2.1  ^1.2.2
+npm                          -> ^10.9.8 ^11.18.0 ^12.0.1
+playwright                   -> ^1.56.1 ^1.61.1
+```
+
+Newest-by-mtime picks whichever was invoked last — which can be an unrelated invocation, or `update_server`'s own `pkg@latest` probe, rather than the configured server's entry. The Open question at the end of this plan asked exactly this and the board's answer is that mtime is not sound.
+
+**uv.** Worse than npx, because there is no equivalent of npx's single-declared-dependency marker. Every environment contains its full transitive closure — verified: one env holds **30** `.dist-info` directories. Scanning by name matches a transitive dependency as readily as the invoked package.
+
+### B3 — undocumented internal layouts
+
+Both probes depend on cache layouts that are internal to npm and uv, not public interfaces. A layout change makes `installed_version` return `None` forever, which is indistinguishable from "no update available" — a silent, permanent regression. The proposed layout-change test guards the shape but cannot detect that the *real* cache has moved.
+
+### Where this leaves #150
+
+The runner caches do contain real installed versions — that part of the research holds, and it is the first source in six attempts that is bound to package identity. What they do not provide is a reliable mapping from *a configured server* to *the specific cache entry that server runs*.
+
+Options that would close that gap, none yet assessed:
+- Have pmcp record the resolved version at spawn time, when it knows the exact argv it launched — provenance by construction rather than by inference.
+- Probe the running process (`--version` on the same argv), accepting a subprocess per check.
+- Narrow the feature to servers pmcp installed itself, where the argument set is known.
+
+All three are materially different in cost and coverage from what this plan proposed.

--- a/.consiliency/plans/detailed-installed-version-from-runner-cache-20260817-1600.md
+++ b/.consiliency/plans/detailed-installed-version-from-runner-cache-20260817-1600.md
@@ -1,0 +1,151 @@
+# Detailed plan: read the installed version from the npx / uv runner caches
+
+## Task
+
+Fix Consiliency/pmcp#150 — the gateway fabricates "update available" notices, or hides real ones — by comparing against the version that is **actually installed** rather than an inferred one.
+
+This is the sixth attempt. The five previous ones are documented (PR #154 closed after three rejected rounds; two plan artifacts each rejected 3/3). Maintainer decision: **probe the package manager directly**.
+
+## Research summary
+
+**The blocking discovery, which kills the naive form of this plan.** Every server in the manifest launches through an *ephemeral runner*, not an installer:
+
+```
+npx -> npm  : 79 servers
+uvx -> pypi : 19 servers
+(unknown)   :  9 servers
+```
+
+`npx` and `uvx` fetch into a cache and discard; they do not install into any tree that `npm ls` or `uv pip show` can see. Verified:
+
+```
+$ npm ls @upstash/context7-mcp
+/home/viperjuice/code/pmcp
+└── (empty)
+```
+
+So the obvious implementation — shell out to `npm ls` / `uv pip show` — **returns nothing for the servers pmcp actually runs**. Had I written that, it would have silenced every notice, which is precisely the failure mode of attempt #4.
+
+**What does work: the runner caches are on disk and are queryable.**
+
+*npx* (`~/.npm/_npx/<hash>/`): each entry has a `package.json` naming the package it was created for, and the resolved package under `node_modules/`. Extracted real versions:
+
+```
+@brightdata/mcp    -> 2.11.1
+@twilio-alpha/mcp  -> 0.7.0
+@eslint/mcp        -> 0.3.8
+```
+
+The directory name is a hash of the *argument set*, so pmcp cannot compute it — it must scan and match on the dependency name. Measured cost: **0.36s for 114 entries**, filesystem reads only, no subprocess and no network.
+
+*uv* (`uv cache dir`/`environments-v2/<a>/<b>/`): a normal venv whose `lib/python*/site-packages/*.dist-info` directories carry name and version (`sse_starlette-3.4.6.dist-info`). Note the layout is **two levels deep**, not one — my first probe assumed one and found nothing.
+
+**Why this source is different from the five that failed.** It is bound to the package identity by construction: the cache entry names the package, and the version is read from that package's own metadata. Every prior attempt compared a version whose provenance was unrelated to the configured package — an upstream snapshot (`descriptions_cache.version`), or the MCP `serverInfo.version` (an *implementation* version; FastMCP 1.x reported the SDK's, mcp 2.x defaults it to `""`).
+
+**Prerequisite already landed.** #155 (merged, `58b1a02`) made `is_version_newer` fail closed, so an unreadable version now yields silence rather than a fabricated notice, and npm/Cargo order by SemVer while Python keeps PEP 440. Without it any version source would fabricate notices regardless.
+
+## Changes
+
+### `src/pmcp/manifest/installed_version.py` (create)
+
+New module — this is genuinely new capability with no existing home, and keeping it out of `version_checker.py` keeps "what is installed" separate from "what does the registry offer".
+
+- `installed_npm_version(package_name, *, cache_root=None)` — **add** — scan `~/.npm/_npx/*/package.json`, match `dependencies` against *package_name*, read `node_modules/<pkg>/package.json` `version`. Returns `str | None`. `cache_root` injectable for tests.
+- `installed_pypi_version(package_name, *, cache_root=None)` — **add** — scan `<uv cache>/environments-v2/*/*/lib/python*/site-packages/*.dist-info`, match the normalised distribution name (PEP 503: lowercase, `-`/`_`/`.` collapse), return its version.
+- `installed_version(package_type, package_name)` — **add** — dispatch on type; `None` for `docker`/`cargo`/`unknown` (out of scope, see Non-goals).
+- Module-level cache keyed by `(package_type, package_name)` with a short TTL — **add** — the scan is cheap but the notice paths run per-request; do not re-walk the tree on every `describe`.
+
+All lookups are **best-effort**: any `OSError`, malformed JSON, or missing path returns `None`, never raises. A notice is an advisory, not a correctness-critical path.
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_get_update_warning` — **modify** — take `current` from `installed_version(...)` when available; keep the existing `descriptions_cache` value only as a fallback, gated by the package-identity check already present. When neither yields an orderable version, return `None` (silence).
+- `_run_stale_index` — **modify** — same source and same fallback rule.
+- `_stale_check_cache` — **modify** — record the version *source* (`"installed" | "described"`) in the memo alongside the existing `pkg_type`, so a reader can tell an observed version from an inferred one and a later change of policy does not have to guess.
+- `update_server` success path — **modify** — after a successful restart, prefer the freshly-read installed version over the probed upstream latest when writing `desc_entry.version`, so the recorded baseline is what is running.
+
+### `tests/test_installed_version.py` (create)
+
+Fixture-driven against a **synthetic cache tree** (`tmp_path`), never the developer's real cache — a test that reads `~/.npm` passes or fails based on what happens to be on the machine.
+
+- **add** — `test_npm_version_read_from_npx_cache`: synthetic `_npx/<hash>/package.json` + `node_modules/<pkg>/package.json` → correct version.
+- **add** — `test_npm_scan_matches_the_right_entry`: three entries, only one matching → no cross-contamination.
+- **add** — `test_pypi_version_read_from_uv_environment`: synthetic two-level env with a `.dist-info` → correct version.
+- **add** — `test_pypi_name_normalisation`: `my_pkg` config name matches `my-pkg` dist-info per PEP 503.
+- **add** — `test_missing_cache_returns_none` / `test_malformed_json_returns_none` — best-effort contract.
+- **add** — `test_layout_change_is_detected`: assert against the *observed* layout (two-level for uv, `dependencies` key for npx). If a future runner changes its layout this must fail loudly rather than silently returning `None` forever, which would look identical to "no update available".
+
+### `tests/test_tools.py` (modify)
+
+- **add** — `test_notice_uses_installed_version_when_available`: installed `1.0.0`, upstream `2.0.0` → notice naming both.
+- **add** — `test_notice_silent_when_installed_version_unavailable`: no cache entry, no orderable fallback → no notice, no exception.
+- **add** — `test_package_change_compares_the_configured_package` (**the #150 case**): manifest names A, `.mcp.json` names B, cache holds B's real version → comparison is B-vs-B, never A-vs-B.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **modify** — entry under `## [Unreleased]`. **Mandatory**: `main` is protected and the `changelog` check fails any PR touching `src/` without one. Must say plainly that notices now compare the installed version, and that servers whose installed version cannot be determined produce no notice.
+- `README.md` — **check** whether it documents the update-notice behaviour; if so, update, else record `no doc footprint`.
+
+## Frozen vocabulary / protocol check
+
+No protocol surface changes. `installed_version` is internal; `_stale_check_cache` is private in-memory state with no serialised form; `CatalogSearchOutput.stale_updates` keeps its type and message format. **No new vocabulary.**
+
+## Dependencies & order
+
+1. `installed_version.py` plus its tests first — independently verifiable with zero risk to existing behaviour.
+2. Then migrate the two notice readers together; a partial migration leaves them disagreeing about what `current` means, which is the failure mode of rounds 1–3 on PR #154.
+3. Then the `update_server` baseline write.
+4. CHANGELOG last.
+
+No new runtime dependency: both probes are stdlib filesystem + `json`.
+
+## Verification
+
+```bash
+cd <worktree>
+uv run pytest tests/test_installed_version.py -q
+uv run pytest tests/test_tools.py -q -k 'notice or stale or installed'
+
+# RED proof — required. Revert ONLY the src changes with a targeted
+# `git diff > patch` + `git apply -R`. NEVER `git checkout HEAD -- .`
+# (it has destroyed uncommitted work in this repo).
+
+uv run pytest -q          # baseline 2553 + new, 3 skipped, 0 failed
+uv run ruff check . && uv run ruff format --check src/ tests/ && uv run mypy src
+```
+
+Then verify against the **real** cache manually, outside the suite, since the whole point is matching reality:
+
+```bash
+uv run python -c "from pmcp.manifest.installed_version import installed_version; \
+print(installed_version('npm','@brightdata/mcp'))"   # expect 2.11.1
+```
+
+Edge cases: package absent from cache; multiple cache entries for one package (pick the newest by mtime — document the choice); scoped npm names; PEP 503 normalisation; unreadable cache dir (permissions); `uv cache dir` failing.
+
+## Acceptance criteria
+
+- [ ] `installed_version('npm', '@brightdata/mcp')` returns the version present in the npx cache, proven against a synthetic tree and confirmed once by hand against the real cache.
+- [ ] A server whose installed version cannot be determined produces **no** notice — proven by `test_notice_silent_when_installed_version_unavailable`.
+- [ ] A `.mcp.json` override naming a different package than the manifest compares the **configured** package's installed version — proven by `test_package_change_compares_the_configured_package`, failing when the src change is reverted.
+- [ ] Full suite ≥2553 + new tests passed / 3 skipped / 0 failed; ruff, format, mypy clean; `## [Unreleased]` CHANGELOG entry present.
+
+## Non-goals
+
+- **docker and cargo.** 9 of 107 servers are unrecognised and none are docker/cargo in the manifest today. `installed_version` returns `None` for them, so they simply produce no notice — the honest degradation.
+- **Making the cache authoritative.** If a user runs a server through a pinned global install rather than the runner cache, this reads the cache entry, which may not be what ran. Bounded by the identity check and by failing closed; noted as a residual rather than solved.
+
+## Open question for the board
+
+When several npx cache entries contain the same package at different versions (different arg sets, e.g. with and without a flag), which is "installed"? The plan picks newest-by-mtime. The alternative is to return `None` on ambiguity — fewer notices, but every notice provably correct. Given five attempts have failed toward the "fabricated notice" side, the conservative option may be right.
+
+## Execution Policy
+
+- execute: effort=high, reason=sixth attempt at a defect class where five prior fixes each shipped a new hole; touches shared notice paths and introduces a new filesystem-dependent module.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```

--- a/.consiliency/plans/detailed-spawn-time-version-provenance-20260817-1800.md
+++ b/.consiliency/plans/detailed-spawn-time-version-provenance-20260817-1800.md
@@ -1,0 +1,128 @@
+# Detailed plan: record the installed version at spawn time, and re-check long-running servers
+
+## Task
+
+Fix Consiliency/pmcp#150 — the gateway fabricates "update available" notices, or hides real ones — by recording which version a server resolved to **at the moment pmcp launched it**, rather than inferring it afterwards.
+
+Seventh attempt. Maintainer decision, after the runner-cache plan was rejected 3/3: **record at spawn**, plus **a periodic guard so a long-running server does not keep a stale baseline forever**.
+
+## Research summary
+
+**Why the previous six failed, in one line each.** Rounds 1–3 (PR #154) patched one notice reader while another kept serving a poisoned tuple. Round 4 (re-key the memo) still sourced `current` from `descriptions_cache.version`. Round 5 (`serverInfo.version`) is an *implementation* version — FastMCP 1.x reports the SDK's, mcp 2.x defaults it to `""`. Round 6 (runner caches) read real installed versions but could not bind a **configured server** to the **cache entry it runs**: verified on this machine, the npx cache holds `@consiliency/agent-board-mcp` at 1.2.0, 1.2.1 *and* 1.2.2 concurrently, and `npm` at three majors.
+
+**Why spawn-time capture is different.** At `client/manager.py:1365` pmcp calls `create_subprocess_exec(local_config.command, *local_config.args, ...)`. It knows the exact argv, cwd and env of the process it is starting. Provenance is therefore **by construction** rather than by inference — there is no scan, no mtime heuristic, and no ambiguity about which cache entry or install tree is in play, because the resolution is the one pmcp itself performed. Every prior attempt tried to reconstruct this fact after the event; this records it at the only moment it is known for certain.
+
+`ManagedClient` (`manager.py:485`) already carries per-connection state (`config`, `process`, transport handles) and is the natural home.
+
+**The gap the maintainer identified, confirmed.** The existing background sweep (`_stale_indexer_loop`, `handlers.py:1332`) runs hourly (`_stale_index_interval_seconds = 3600`) and re-checks **upstream latest**. But a spawn-time installed version is captured only at spawn. A server started once and left running for weeks keeps that baseline indefinitely — nothing respawns it, so nothing re-reads it, and the gateway would compare a weeks-old installed version against today's upstream and be confidently wrong in the *quiet* direction (claiming an update that the operator may have already applied by restarting elsewhere, or missing drift entirely).
+
+So spawn-time capture alone is necessary but not sufficient; the guard is part of the fix, not an optional extra.
+
+**Existing scheduling.** `_stale_indexer_loop` already exists in-process, so the guard extends it rather than adding new machinery. `.github/workflows/maintenance.yml` is push/PR-triggered, not `schedule:`-triggered, and is a *repo* maintenance hook — wrong layer for a runtime gateway concern.
+
+## Changes
+
+### `src/pmcp/client/manager.py` (modify)
+
+- `ManagedClient` — **modify** — add `installed_version: str | None = None` and `installed_version_observed_at: float | None = None`. Per-connection, discarded on disconnect, which is correct: the fact is only true of *this* process.
+- `_connect_stdio` (spawn site, ~`manager.py:1365`) — **modify** — after a successful spawn, resolve the version for the argv just launched and store it on the `ManagedClient`. Best-effort: any failure leaves `None` and is logged at debug, never raises. A notice is advisory; a failed lookup must not break a connection.
+- `resolve_spawned_version(command, args, *, cwd, env)` — **add** (new helper, this module or a small sibling) — given the *exact* argv pmcp used, return the resolved installed version. For `npx`, locate the cache entry created for that argument set; for `uvx`, the environment for that spec. **Unlike attempt 6 this is not a scan-and-guess**: the argv is known, so the lookup is a direct resolution of that invocation, and on any ambiguity it returns `None` rather than picking a candidate.
+- `get_installed_version(server_name)` — **add** — accessor for the handlers layer; returns the value only for a currently-ONLINE server.
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_get_update_warning` — **modify** — take `current` from the client manager's spawn-time value. **No fallback to `descriptions_cache.version`** — the board's B1 finding on the last plan was that keeping it means still emitting inferred-version notices. When no spawn-time version exists, return `None` (silence).
+- `_run_stale_index` — **modify** — same source, same no-fallback rule.
+- `_stale_check_cache` — **modify** — record `version_source="spawn"` alongside the existing `pkg_type`, so a reader can never mistake an inferred value for an observed one.
+- `_stale_indexer_loop` / `_run_stale_index` — **modify** — **the guard**. For each ONLINE server whose `installed_version_observed_at` is older than a freshness bound (new `_installed_version_max_age_seconds`, default 24h), re-resolve the installed version for that connection's argv and update it. This is what stops a long-running server keeping a weeks-old baseline. Re-resolution is a filesystem read of a known location — no respawn, no restart, no disruption to the running server.
+- `update_server` success path — **modify** — after a successful restart the server has respawned, so the new spawn-time value is already correct; drop the old write of the probed upstream latest into `desc_entry.version`.
+
+### `tests/test_client_manager.py` (modify)
+
+- **add** — `test_spawn_records_installed_version`: a stdio spawn records a version and a timestamp on the `ManagedClient`.
+- **add** — `test_spawn_version_failure_does_not_break_connection`: resolution raising leaves `None` and the connection still succeeds. This is the safety property — pins that an advisory feature cannot take down a server.
+- **add** — `test_ambiguous_resolution_returns_none`: two candidate matches → `None`, not a guess. Directly pins the failure of attempt 6.
+
+### `tests/test_tools.py` (modify)
+
+Every test asserts an **observable notice outcome**, never a mutated field. Multiple prior tests passed while their bug survived.
+
+- **add** — `test_notice_uses_spawn_time_version`: spawn recorded `1.0.0`, upstream `2.0.0` → notice naming both.
+- **add** — `test_no_notice_without_a_spawn_time_version` (**pins B1**): no spawn-time version *and* an orderable `descriptions_cache.version` present → still **no notice**. The last plan's test omitted the orderable-fallback case and would have passed while the regression lived.
+- **add** — `test_package_change_compares_the_configured_package` (**the #150 case**): manifest names A, `.mcp.json` names B, server spawned from B → comparison is B-vs-B or silence, never A-vs-B.
+- **add** — `test_guard_refreshes_a_stale_spawn_time_version`: a connection whose `observed_at` is older than the bound gets re-resolved by a sweep pass, and a notice that was wrong becomes right. **This is the maintainer's requirement** and must fail without the guard.
+- **add** — `test_guard_leaves_fresh_versions_alone`: within the bound, no re-resolution (no needless filesystem work every hour).
+
+## Documentation impact
+
+- `CHANGELOG.md` — **modify** — entry under `## [Unreleased]`. **Mandatory**: `main` is protected and the `changelog` check fails any PR touching `src/` without one. Must state that notices now compare the version the server was actually started with, that a server whose version could not be determined produces no notice, and that long-running servers are re-checked periodically.
+- `README.md` — **check** whether update-notice behaviour is documented; update if so, else record `no doc footprint`.
+
+## Frozen vocabulary / protocol check
+
+No protocol surface changes. `ManagedClient` is internal; `_stale_check_cache` is private in-memory state with no serialised form; `CatalogSearchOutput.stale_updates` keeps its type and message format. **No new vocabulary, no new tool parameter, no schema change.**
+
+## Dependencies & order
+
+1. `resolve_spawned_version` + `ManagedClient` fields + spawn capture, with manager tests. Independently verifiable and inert — nothing reads the value yet, so this cannot change notice behaviour.
+2. Migrate both notice readers together, removing the fallback. A partial migration leaves them disagreeing about what `current` means — the failure mode of rounds 1–3.
+3. The guard in the sweep.
+4. CHANGELOG last.
+
+No new runtime dependency.
+
+## Verification
+
+```bash
+cd <worktree>
+uv run pytest tests/test_client_manager.py -q -k 'spawn or installed'
+uv run pytest tests/test_tools.py -q -k 'notice or spawn or guard or stale'
+
+# RED proof — required. Revert ONLY the src changes via a targeted
+# `git diff > patch` + `git apply -R`. NEVER `git checkout HEAD -- .`
+# (it has destroyed uncommitted work in this repo).
+# The guard test in particular MUST fail without the guard, or it is not
+# testing the maintainer's requirement.
+
+uv run pytest -q          # baseline 2553 + new, 3 skipped, 0 failed
+uv run ruff check . && uv run ruff format --check src/ tests/ && uv run mypy src
+```
+
+Then confirm against a real server, outside the suite — the point is matching reality:
+
+```bash
+# start a server through the gateway, then verify the recorded version equals
+# what that package actually resolved to.
+```
+
+Edge cases: server never started (lazy) → no version → silence; remote server (no local package) → silence; spawn succeeds but resolution fails; server restarted (value must refresh); two servers sharing one package; `observed_at` exactly at the bound.
+
+## Acceptance criteria
+
+- [ ] A stdio spawn records the installed version and timestamp on its `ManagedClient` — proven by `test_spawn_records_installed_version`.
+- [ ] A failed version resolution never breaks a connection — proven by `test_spawn_version_failure_does_not_break_connection`.
+- [ ] No notice is emitted without a spawn-time version, **even when an orderable `descriptions_cache.version` exists** — proven by `test_no_notice_without_a_spawn_time_version`, failing when the src change is reverted.
+- [ ] A `.mcp.json` override naming a different package than the manifest never yields a cross-package comparison — proven by `test_package_change_compares_the_configured_package`.
+- [ ] A long-running server's baseline is refreshed by the periodic guard rather than pinned at spawn — proven by `test_guard_refreshes_a_stale_spawn_time_version`, failing without the guard.
+- [ ] Full suite ≥2553 + new tests passed / 3 skipped / 0 failed; ruff, format, mypy clean; `## [Unreleased]` CHANGELOG entry present.
+
+## Non-goals
+
+- **Restarting servers to refresh a version.** The guard re-reads from disk; it never respawns a running server. Restarting to satisfy an advisory notice would be a worse cure than the disease.
+- **docker / cargo.** `resolve_spawned_version` returns `None` for them, so they produce no notice — the honest degradation. 9 of 107 manifest servers are unrecognised today.
+- **Lazy servers that have never started.** No spawn means no version means no notice. Called out because it is a real coverage reduction versus today's (wrong) notices.
+
+## Open question for the board
+
+The guard re-reads the installed version for a *running* process. If the on-disk package has been upgraded underneath a running server, the re-read reports the **new on-disk** version while the process still serves the **old** code. Is that the right reading? The alternative is to treat spawn-time as immutable for the life of the connection and instead notify "this server is running an older version than what is installed — restart it", which is arguably the more actionable message and cannot be confidently wrong. I lean toward the latter but want the board's view, since it changes what the guard is *for*.
+
+## Execution Policy
+
+- execute: effort=high, reason=seventh attempt at a defect class where six prior fixes each shipped a new hole; touches the connection spawn path, where a mistake breaks server startup rather than merely a notice.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```

--- a/.consiliency/plans/detailed-spawn-time-version-provenance-20260817-1800.md
+++ b/.consiliency/plans/detailed-spawn-time-version-provenance-20260817-1800.md
@@ -126,3 +126,43 @@ The guard re-reads the installed version for a *running* process. If the on-disk
 automation:
   suite_command: "uv run pytest -q"
 ```
+
+
+---
+
+## Board review — REJECTED. Do not implement as written.
+
+Boarded before implementation (2 usable legs, both blocking). I independently reproduced the central finding before reading the verdicts.
+
+### B1 (fatal) — "argv is authoritative provenance" is false
+
+The plan's entire basis. `create_subprocess_exec` returns once **`npx` itself** has started — before that runner has selected, fetched or launched the underlying package. npm may resolve to a *local*, *global*, or *cache-backed* copy; only the cache branch produces an `_npx` directory at all. So `resolve_spawned_version(command, args, ...)` would still be reconstructing runner behaviour after the fact — the very scan-and-guess that sank attempt 6, relocated to the spawn path where a mistake is more expensive.
+
+Verified independently on this machine before the verdicts arrived: a live `npx -y @eslint/mcp` process tree exposes **no** `_npx` path anywhere — not in any descendant's `cmdline`, not in `cwd`, not in open file descriptors. There is no observable link from the process pmcp started to the cache entry backing it.
+
+```
+scanning all node processes for _npx references...
+  (none)
+--- any process whose cwd or fds touch _npx ---
+  (none)
+```
+
+So the claim "provenance is by construction rather than inference" does not hold. Knowing the argv tells pmcp what it *asked for*, not what npm *chose*.
+
+### B2 — the A→B cross-package defect survives this plan
+
+The plan changes only where `current` comes from. Both notice writers still obtain `latest` via `_get_server_config_for_update` (`handlers.py:3622`), which prefers the **manifest** and ignores the running `.mcp.json` override. So B's observed installed version can still be compared against **A's** upstream latest — the original #150 defect, intact.
+
+Adding `version_source="spawn"` records provenance without *binding* it, and the server-keyed stale cache can still retain A's latest across a reconnect to B. Both sides of the comparison must come from the same effective configuration.
+
+### What this means after seven attempts
+
+Every approach so far has failed at the same joint: pmcp cannot observe, for a running server, **which package artifact is actually executing**. Not from the descriptions cache (upstream snapshot), not from `serverInfo` (implementation version), not from the runner caches (no server→entry binding), and not from spawn argv (npm resolves after the call returns).
+
+The remaining honest options are narrower than any attempted so far:
+
+- **Ask the process.** Run the server's own `--version` on the identical argv. It is the only method that observes the artifact that actually ran. Costs a subprocess per check.
+- **Only what pmcp installed.** Restrict notices to servers pmcp installed itself, recording the resolved version at install time. Correct by construction, but excludes hand-configured `.mcp.json` servers — the exact case #150 is about.
+- **Remove the feature.** No automatic notice can be wrong if there is no automatic notice; `gateway.update_server` still reports on demand.
+
+Note the second and third are the only ones that cannot be confidently wrong.

--- a/.consiliency/plans/detailed-version-probe-ask-the-server-20260817-2000.md
+++ b/.consiliency/plans/detailed-version-probe-ask-the-server-20260817-2000.md
@@ -134,6 +134,23 @@ Edge cases: server ignores the flag and runs (circleci); exits 0 with no version
 - **Probing on the request path.** Probes run only on the background sweep, behind the cache. A `describe` call must never spawn a process.
 - **docker / cargo.** No probe; `None` → no notice.
 
+## Measured: the startup side effects are real, not hypothetical
+
+Probing `@circleci/mcp-server-circleci --version` — one of the servers that ignores the flag — was measured while running:
+
+```
+t=3s   pids=7  open_sockets=5
+t=6s   pids=6  open_sockets=4
+t=9s   pids=5  open_sockets=4
+t=12s  pids=5  open_sockets=4
+```
+
+**Seven processes and five open network sockets**, sustained until killed. That is a real MCP server starting up and connecting outward, caused by an advisory update check, on a schedule, for a server that yields no version anyway.
+
+(By contrast `@eslint/mcp` had exited before the 10s sample — it prints its message and stops, so the cost there is bounded.)
+
+This materially strengthens the case against the approach: the servers that pay this cost are exactly the ones that give nothing back. Any implementation must at minimum avoid probing a server twice once it is known not to answer — but that only bounds the cost, it does not remove the first probe's side effects, and a cache expiry re-incurs them.
+
 ## Open question for the board
 
 The probe runs `<command> <args> --version`, i.e. **it starts the package**. For a server that ignores the flag this briefly runs a real server process that is then killed. Is that acceptable for something as trivial as an update notice — particularly for a server with side effects at startup (opening a browser, connecting to a database, writing state)? If not, the honest conclusion may be that no safe automatic probe exists and the feature should be removed rather than made 50% correct. I want the board's view, because this is the strongest argument against the whole approach and it is not one I can settle from the code.

--- a/.consiliency/plans/detailed-version-probe-ask-the-server-20260817-2000.md
+++ b/.consiliency/plans/detailed-version-probe-ask-the-server-20260817-2000.md
@@ -165,3 +165,26 @@ The probe runs `<command> <args> --version`, i.e. **it starts the package**. For
 automation:
   suite_command: "uv run pytest -q"
 ```
+
+
+---
+
+## Board review — REJECTED 3/3, with an explicit recommendation to REMOVE the feature
+
+Boarded with the side-effect question foregrounded and a statement that a recommendation to abandon would be acted on. All three legs blocked, and both readable legs answered the question directly.
+
+**grok:** *"Automatic `<command> <args> --version` probes are disqualifying. Remove the automatic notices rather than ship a 50%-correct scheduled spawn."* And on the proposed mitigation: *"'Probe only servers already running' does not"* remove the hazard.
+
+**codex:** *"Yes, automatic probing is disqualifying. It executes third-party server code merely to produce an advisory, including packages known to ignore `--version`."* On the mitigation: it *"would reduce the number of executions, but it does not remove the per-server hazard; those servers are precisely the ones most likely to have valid credentials and live"* connections.
+
+This matches the measurement taken before the verdicts arrived: probing one flag-ignoring server spawned **7 processes and opened 5 network sockets**. Executing third-party code on a schedule to produce an advisory notice is not a defensible trade.
+
+### A live bug found in passing — not part of this plan
+
+grok noted, and I verified, that the **existing** `_run_update_probe_command` (shipped, used by `gateway.update_server`) spawns **without** `start_new_session` and on timeout does `await asyncio.wait_for(process.communicate(), timeout=60.0)` — which abandons the child. No kill, no process-group cleanup. A probe that hangs today orphans its whole process tree.
+
+That is independent of #150 and should be filed separately.
+
+### Conclusion after eight attempts
+
+Every approach has failed at the same joint: pmcp cannot cheaply and safely observe which package artifact a running server is executing. The remaining options are not technical refinements but a product decision, and the board's recommendation is the honest one: **remove the automatic notices**, keep `gateway.update_server` as the explicit, user-initiated path, and word any remaining message so it does not claim to know the installed version.

--- a/.consiliency/plans/detailed-version-probe-ask-the-server-20260817-2000.md
+++ b/.consiliency/plans/detailed-version-probe-ask-the-server-20260817-2000.md
@@ -1,0 +1,150 @@
+# Detailed plan: ask the server its own version
+
+## Task
+
+Fix Consiliency/pmcp#150 — the gateway fabricates "update available" notices, or hides real ones — by asking each server to report its own version, using the identical command pmcp uses to launch it.
+
+Eighth attempt. Maintainer decision after the spawn-provenance plan was rejected: **ask the process**, accepting a subprocess per check.
+
+## Research summary
+
+**Why the previous seven failed, at one joint.** pmcp cannot observe *which package artifact a running server is executing*. Not from `descriptions_cache.version` (an upstream snapshot), not from `serverInfo.version` (an *implementation* version — FastMCP 1.x reports the SDK's, mcp 2.x defaults to `""`), not from the npx/uv runner caches (no server→entry binding; verified one package cached at 1.2.0, 1.2.1 and 1.2.2 concurrently), and not from spawn argv — verified independently that a live `npx -y @eslint/mcp` tree exposes **no** `_npx` path in any descendant's `cmdline`, `cwd` or fds, because npm resolves *after* `create_subprocess_exec` returns.
+
+Running the package's own `--version` is the only method that observes the artifact that actually runs, because the artifact answers for itself.
+
+**Measured coverage — 12 npm servers sampled from the manifest, real invocations:**
+
+```
+OK   @aashari/mcp-server-atlassian-confluence -> 3.3.0          (3s)
+OK   @aashari/mcp-server-atlassian-jira       -> 3.3.0          (4s)
+OK   @apify/actors-mcp-server                 -> 0.14.3         (7s)
+OK   @azure-devops/mcp                        -> 2.9.0          (5s)
+OK   @browserbasehq/mcp-server-browserbase    -> Version 2.4.3  (14s)
+OK   @dynatrace-oss/dynatrace-mcp-server      -> 2.1.2          (1s)
+none @azure/mcp, @benborla29/mcp-server-mysql, @brightdata/mcp,
+     @cloudflare/mcp-server-cloudflare, @elastic/mcp-server-elasticsearch
+none @circleci/mcp-server-circleci            -> HIT THE 90s CAP
+---- 6/12 parsed a version (50%)
+```
+
+**Three findings that shape the design, all measured rather than assumed:**
+
+1. **50% coverage.** Half the servers yield nothing. Those must produce *no notice* — which is still strictly better than today, where any server can receive a fabricated one.
+
+2. **A server can ignore `--version` and just run.** `@circleci/mcp-server-circleci` hit the 90s cap; `@eslint/mcp` printed *"ESLint MCP server is running"* and **exited 0**. So exit status is not a usability signal, and an unbounded probe would hang a sweep. A timeout is load-bearing.
+
+3. **Loose parsing would fabricate versions.** `firecrawl-mcp --version` emits only npm deprecation noise containing `koa-router@14.0.0` — exactly what a permissive regex grabs. Verified that strict whole-line matching (optionally `Version `-prefixed, optionally `v`-prefixed) extracts `4.0.2` and `0.0.79` while rejecting both the koa-router string and the "server is running" line.
+
+**Cost model, from the measured latencies.** Median 5s, max 90s. A 20s timeout costs ~82s for the 12 sampled and truncates one. Extrapolated over all 98 npm+pypi servers at the 4s median, a serial pass is **~390s**. So bounded concurrency and per-server caching are *required*, not optimisations.
+
+**Prerequisite already landed.** #155 (merged, `58b1a02`) made `is_version_newer` fail closed, so an unparseable version yields silence rather than a fabricated notice.
+
+## Changes
+
+### `src/pmcp/manifest/version_probe.py` (create)
+
+Separate module: this is subprocess execution, distinct from `version_checker.py`'s registry lookups.
+
+- `_VERSION_LINE_RE` — **add** — `^(?:[Vv]ersion\s+)?v?(\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?)\s*$`, matched **whole-line** against each output line. Anchoring is the load-bearing part: it is what rejects `koa-router@14.0.0`.
+- `parse_version_output(text)` — **add** — first line matching the anchored pattern, else `None`. Pure function, trivially testable against the real outputs captured above.
+- `probe_server_version(command, args, *, cwd, env, timeout)` — **add** — run `<command> <args...> --version` with the **same argv, cwd and sanitised env** pmcp uses to launch the server, capture stdout+stderr, kill the process group on timeout (servers that ignore the flag keep running), and return `parse_version_output(...)`. Returns `None` on timeout, non-zero exit, or unparseable output. Never raises.
+- `_PROBE_TIMEOUT_S = 20` — **add** — from the cost model: covers 11 of 12 sampled, truncates only the server that ignores the flag entirely.
+- Result cache keyed by `(command, tuple(args))` with a TTL — **add** — a probe costs a process, so it must not run per-request. Cache `None` results too, or an unsupported server is re-probed every sweep forever.
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_get_update_warning` — **modify** — take `current` from `probe_server_version(...)` using the **effective** config (`_effective_notice_target`, which honours `.mcp.json` over the manifest). **No fallback** to `descriptions_cache.version`; when the probe yields nothing, return `None`.
+- `_run_stale_index` — **modify** — same source, same no-fallback rule; this is where probes are actually paid for, on the existing hourly loop rather than on request paths.
+- **`latest` must come from the same effective config** — **modify** — the board's B2 finding on the last plan: both notice writers still took `latest` via `_get_server_config_for_update`, which prefers the manifest and ignores the override, so B's installed version could still be compared against A's latest. Both sides now derive from one resolution.
+- Bounded concurrency in the sweep — **add** — an `asyncio.Semaphore` (start at 4) so a pass over 98 servers does not spawn 98 processes. With the measured 4s median this puts a full pass near ~100s of wall time, off the request path.
+- `_stale_check_cache` — **modify** — record `version_source="probe"` beside the existing `pkg_type`, so an observed version can never be confused with an inferred one.
+
+### `tests/test_version_probe.py` (create)
+
+- **add** — `test_parses_bare_version` / `test_parses_version_prefixed`: `4.0.2` and `Version 0.0.79`, the two real shapes observed.
+- **add** — `test_rejects_npm_deprecation_noise`: the **verbatim** firecrawl output containing `koa-router@14.0.0` → `None`. Pins the fabrication case.
+- **add** — `test_rejects_server_started_message`: the verbatim `@eslint/mcp` line → `None`, **and** notes it exited 0, so exit status must not be treated as success.
+- **add** — `test_timeout_returns_none_and_kills_process_group`: a fake command that ignores the flag and sleeps → `None` within the bound, no orphan left. Pins the circleci behaviour.
+- **add** — `test_probe_uses_the_same_argv_and_env`: assert the spawn call receives the caller's exact command/args/cwd/env. If the probe ran a *different* command than the server, it would measure the wrong artifact — the failure of attempts 4-7.
+- **add** — `test_none_results_are_cached`: an unsupported server is probed once, not every sweep.
+
+### `tests/test_tools.py` (modify)
+
+Every test asserts an **observable notice outcome**, never a mutated field — several prior tests passed while their bug survived.
+
+- **add** — `test_notice_uses_probed_version`: probe returns `1.0.0`, upstream `2.0.0` → notice naming both.
+- **add** — `test_no_notice_when_probe_yields_nothing`: probe returns `None` **while an orderable `descriptions_cache.version` exists** → still no notice. The orderable-fallback case is what the last two plans' tests omitted.
+- **add** — `test_probe_and_latest_use_the_same_effective_config` (**pins B2**): manifest names A, `.mcp.json` names B → the probe runs B's argv **and** `latest` is fetched for B. Fails if either side reverts to the manifest.
+- **add** — `test_sweep_bounds_probe_concurrency`: N servers, semaphore of 4 → never more than 4 concurrent probes.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **modify** — entry under `## [Unreleased]`. **Mandatory**: `main` is protected and the `changelog` check fails any PR touching `src/` without one. Must state that notices now compare the version the server reports for itself, and that a server which does not report one produces no notice — an explicit, honest coverage reduction.
+- `README.md` — **check** whether update-notice behaviour is documented; update if so, else record `no doc footprint`.
+
+## Frozen vocabulary / protocol check
+
+No protocol surface changes. `version_probe` is internal; `_stale_check_cache` is private in-memory state with no serialised form; `CatalogSearchOutput.stale_updates` keeps its type and message format. **No new vocabulary, no new tool parameter, no schema change.**
+
+## Dependencies & order
+
+1. `version_probe.py` + its tests first — pure and independently verifiable, changes no notice behaviour.
+2. Migrate both notice readers together, including the `latest`-side fix. A partial migration leaves them disagreeing about what is being compared, which is the failure mode of rounds 1-3.
+3. Concurrency bound in the sweep.
+4. CHANGELOG last.
+
+No new runtime dependency (stdlib `asyncio.create_subprocess_exec`).
+
+## Verification
+
+```bash
+cd <worktree>
+uv run pytest tests/test_version_probe.py -q
+uv run pytest tests/test_tools.py -q -k 'notice or probe or stale'
+
+# RED proof — required. Revert ONLY the src changes via a targeted
+# `git diff > patch` + `git apply -R`. NEVER `git checkout HEAD -- .`
+# (it has destroyed uncommitted work in this repo).
+
+uv run pytest -q          # baseline 2553 + new, 3 skipped, 0 failed
+uv run ruff check . && uv run ruff format --check src/ tests/ && uv run mypy src
+```
+
+Then confirm against real servers, outside the suite — the whole point is matching reality:
+
+```bash
+uv run python -c "import asyncio; from pmcp.manifest.version_probe import probe_server_version; \
+print(asyncio.run(probe_server_version('npx', ['-y','@upstash/context7-mcp'], cwd=None, env=None, timeout=20)))"
+# expect 4.0.2 ; and @eslint/mcp must yield None, not a false positive
+```
+
+Edge cases: server ignores the flag and runs (circleci); exits 0 with no version (eslint); emits npm noise (firecrawl); a version appearing mid-line in prose; remote servers (no local command → no probe); lazy servers never started; probe binary missing.
+
+## Acceptance criteria
+
+- [ ] `parse_version_output` extracts `4.0.2` and `Version 0.0.79`, and returns `None` for the verbatim firecrawl and eslint outputs — proven by `test_version_probe.py`, and confirmed once by hand against the live packages.
+- [ ] A server that ignores `--version` is bounded by the timeout, yields `None`, and leaves no orphan process — proven by `test_timeout_returns_none_and_kills_process_group`.
+- [ ] No notice is emitted when the probe yields nothing, **even when an orderable `descriptions_cache.version` exists** — proven by `test_no_notice_when_probe_yields_nothing`, failing when the src change is reverted.
+- [ ] Both the probed version and the upstream `latest` derive from the same effective config, so a `.mcp.json` override never produces a cross-package comparison — proven by `test_probe_and_latest_use_the_same_effective_config`.
+- [ ] Full suite ≥2553 + new tests passed / 3 skipped / 0 failed; ruff, format, mypy clean; `## [Unreleased]` CHANGELOG entry present.
+
+## Non-goals
+
+- **Raising coverage above what servers report.** ~50% is the measured ceiling for this method. The other half produce no notice; that is the honest degradation and is not worked around.
+- **Probing on the request path.** Probes run only on the background sweep, behind the cache. A `describe` call must never spawn a process.
+- **docker / cargo.** No probe; `None` → no notice.
+
+## Open question for the board
+
+The probe runs `<command> <args> --version`, i.e. **it starts the package**. For a server that ignores the flag this briefly runs a real server process that is then killed. Is that acceptable for something as trivial as an update notice — particularly for a server with side effects at startup (opening a browser, connecting to a database, writing state)? If not, the honest conclusion may be that no safe automatic probe exists and the feature should be removed rather than made 50% correct. I want the board's view, because this is the strongest argument against the whole approach and it is not one I can settle from the code.
+
+## Execution Policy
+
+- execute: effort=high, reason=eighth attempt at a defect class where seven prior fixes each shipped a new hole; introduces subprocess execution on a background loop, where the failure modes are hangs and orphaned processes rather than a wrong string.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`gateway.update_server` no longer orphans a process tree when its update
+  probe hangs.** The probe runs the downstream package's own code (e.g.
+  `npx <pkg> --help`) with a 60-second timeout, but the process was spawned
+  without its own session and the timeout only abandoned the wait — it never
+  signalled the child. A package that ignores the probe flag and runs as a
+  server therefore left its whole tree alive, including grandchildren such as
+  the browser `@playwright/mcp` launches, which holds the profile lock and
+  breaks the next launch. The probe now spawns as a process-group leader and
+  reaps the group on timeout or cancellation.
+
+
+### Fixed
 - **Update notices are no longer fabricated for servers whose version is not a
   release number.** The version comparison extracted digits from whatever it was
   given and had no way to say "I cannot read this", so a server reporting

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -29,7 +29,7 @@ from pmcp.auth import (
     sanitize_url_elicitation_url,
 )
 
-from pmcp.client.manager import ClientManager
+from pmcp.client.manager import ClientManager, _terminate_process_tree
 from pmcp.config.guidance import GuidanceConfig
 from pmcp.config.loader import (
     registry_allow_private_from_config,
@@ -3678,13 +3678,31 @@ class GatewayTools:
         package code, e.g. ``npx <pkg> --help``, so it must not inherit other
         servers' credentials from the gateway's environment).
         """
+        # start_new_session makes the child a process-group leader, so a probe
+        # that hangs can be reaped as a TREE. Without it the timeout below
+        # abandoned the child: `wait_for` cancels the `communicate()` await but
+        # never signals the process, so a probe like `npx <pkg> --help` against a
+        # package that ignores the flag and runs as a server left its whole
+        # process tree alive -- including grandchildren such as the Chrome that
+        # @playwright/mcp launches, which then holds the profile SingletonLock
+        # and breaks the next launch.
         process = await asyncio.create_subprocess_exec(
             *command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            start_new_session=True,
         )
-        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60.0)
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(), timeout=60.0
+            )
+        except (TimeoutError, asyncio.CancelledError):
+            # Reap the tree before propagating; the caller turns TimeoutError
+            # into a user-facing "probe timed out" result, and cancellation must
+            # not leak a process either.
+            await _terminate_process_tree(process, "update-probe")
+            raise
         output = (
             stdout.decode("utf-8", errors="replace")
             + "\n"

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -3694,9 +3694,7 @@ class GatewayTools:
             start_new_session=True,
         )
         try:
-            stdout, stderr = await asyncio.wait_for(
-                process.communicate(), timeout=60.0
-            )
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60.0)
         except (TimeoutError, asyncio.CancelledError):
             # Reap the tree before propagating; the caller turns TimeoutError
             # into a user-facing "probe timed out" result, and cancellation must

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -3695,10 +3695,17 @@ class GatewayTools:
         )
         try:
             stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60.0)
-        except (TimeoutError, asyncio.CancelledError):
+        except (asyncio.TimeoutError, TimeoutError, asyncio.CancelledError):
             # Reap the tree before propagating; the caller turns TimeoutError
             # into a user-facing "probe timed out" result, and cancellation must
             # not leak a process either.
+            #
+            # asyncio.TimeoutError is listed EXPLICITLY: it only became an alias
+            # of the builtin TimeoutError in 3.11, and this project supports
+            # 3.10, where catching the builtin alone lets the timeout escape and
+            # the cleanup never runs. CI caught this on 3.10 while 3.11 and 3.12
+            # both passed -- the fix silently did nothing on the oldest
+            # supported version.
             await _terminate_process_tree(process, "update-probe")
             raise
         output = (

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4894,7 +4894,6 @@ class TestUpdateProbeProcessCleanup:
         # Parent spawns a grandchild, prints its pid, then hangs -- the shape of
         # a server that ignores the probe flag. The grandchild outlives the
         # parent unless the whole process GROUP is signalled.
-        marker = tmp_pid_file = None
         import tempfile
 
         fd, tmp_pid_file = tempfile.mkstemp()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4865,6 +4865,84 @@ class TestStaleIndexer:
         assert gt._stale_index_task is None
 
 
+class TestUpdateProbeProcessCleanup:
+    """The update probe must not orphan its process tree on timeout.
+
+    Shipped behaviour before this fix: `_run_update_probe_command` spawned
+    WITHOUT `start_new_session` and awaited `wait_for(communicate(), 60)`. On
+    timeout `wait_for` cancels the await but never signals the child, so a probe
+    against a package that ignores its flag and runs as a server left the whole
+    tree alive -- including grandchildren such as the Chrome that
+    @playwright/mcp launches, which holds the profile SingletonLock and breaks
+    the next launch.
+
+    Spawns a REAL process tree: a mocked subprocess cannot demonstrate an
+    orphan, and this bug is entirely about what survives the call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_reaps_the_whole_process_tree(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import os
+        import sys as _sys
+
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        # Parent spawns a grandchild, prints its pid, then hangs -- the shape of
+        # a server that ignores the probe flag. The grandchild outlives the
+        # parent unless the whole process GROUP is signalled.
+        marker = tmp_pid_file = None
+        import tempfile
+
+        fd, tmp_pid_file = tempfile.mkstemp()
+        os.close(fd)
+        script = (
+            "import subprocess,sys,time;"
+            f"p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+            f"open({tmp_pid_file!r},'w').write(str(p.pid));"
+            "time.sleep(30)"
+        )
+
+        real_wait_for = asyncio.wait_for
+
+        async def _fast_timeout(awaitable, timeout=None):
+            # Let the child start and record its grandchild, then time out.
+            return await real_wait_for(awaitable, timeout=1.5)
+
+        monkeypatch.setattr("pmcp.tools.handlers.asyncio.wait_for", _fast_timeout)
+
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await gt._run_update_probe_command([_sys.executable, "-c", script])
+
+        await asyncio.sleep(0.5)
+        grandchild = (open(tmp_pid_file).read() or "").strip()
+        assert grandchild, "test setup failed: grandchild pid never recorded"
+        alive = os.path.exists(f"/proc/{grandchild}")
+        os.unlink(tmp_pid_file)
+        assert not alive, (
+            f"probe orphaned grandchild pid={grandchild}: the process tree "
+            "survived the timeout"
+        )
+
+    @pytest.mark.asyncio
+    async def test_normal_probe_still_returns_output(self) -> None:
+        """The happy path is unchanged by the hardening."""
+        import sys as _sys
+
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        ok, output = await gt._run_update_probe_command(
+            [_sys.executable, "-c", "print('probe-ok')"]
+        )
+        assert ok is True
+        assert "probe-ok" in output
+
+
 class TestUpdateServerVersionRepair:
     """A successful gateway.update_server must clear the stale-notice trail
     -- but only once the update is actually *active*, not merely fetched.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4872,63 +4872,93 @@ class TestUpdateProbeProcessCleanup:
     WITHOUT `start_new_session` and awaited `wait_for(communicate(), 60)`. On
     timeout `wait_for` cancels the await but never signals the child, so a probe
     against a package that ignores its flag and runs as a server left the whole
-    tree alive -- including grandchildren such as the Chrome that
-    @playwright/mcp launches, which holds the profile SingletonLock and breaks
-    the next launch.
+    tree alive -- including grandchildren such as the browser `@playwright/mcp`
+    launches, which holds the profile SingletonLock and breaks the next launch.
 
-    Spawns a REAL process tree: a mocked subprocess cannot demonstrate an
-    orphan, and this bug is entirely about what survives the call.
+    RUN IN A CHILD INTERPRETER. Demonstrating an orphan requires spawning real
+    process trees, and doing that inside the pytest process perturbs state that
+    neighbouring tests measure -- `tests/runtime/test_downstream_remote.py`
+    asserts on THIS process's open socket count and on the process-global
+    `sse_starlette.AppStatus` latch. Running the scenario in a subprocess keeps
+    the real-process proof (a mock cannot show an orphan) without touching the
+    suite's shared state. Stdlib only; no test-runner plugin needed.
     """
 
-    @pytest.mark.asyncio
-    async def test_timeout_reaps_the_whole_process_tree(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        import os
+    _SCENARIO = """
+import asyncio, os, sys, tempfile
+
+sys.path.insert(0, {src!r})
+from pmcp.tools.handlers import GatewayTools
+from pmcp.policy.policy import PolicyManager
+
+
+class _CM:
+    def is_server_online(self, name): return False
+    def get_all_tools(self): return []
+
+
+async def main():
+    gt = GatewayTools(client_manager=_CM(), policy_manager=PolicyManager())
+    fd, pidfile = tempfile.mkstemp()
+    os.close(fd)
+    # Parent spawns a grandchild, records its pid, then hangs -- the shape of a
+    # server that ignores the probe flag. The grandchild outlives the parent
+    # unless the whole process GROUP is signalled.
+    script = (
+        "import subprocess,sys,time;"
+        "p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
+        "open(%r,'w').write(str(p.pid));"
+        "time.sleep(30)" % pidfile
+    )
+    real_wait_for = asyncio.wait_for
+
+    async def fast(aw, timeout=None):
+        return await real_wait_for(aw, timeout=1.5)
+
+    import pmcp.tools.handlers as H
+    H.asyncio.wait_for = fast
+    try:
+        await gt._run_update_probe_command([sys.executable, "-c", script])
+    except BaseException:
+        pass
+    await asyncio.sleep(0.5)
+    pid = (open(pidfile).read() or "").strip()
+    os.unlink(pidfile)
+    if not pid:
+        print("SETUP-FAILED"); return
+    print("ORPHANED" if os.path.exists("/proc/" + pid) else "REAPED")
+
+asyncio.run(main())
+"""
+
+    def _run_scenario(self) -> str:
+        import subprocess
         import sys as _sys
+        from pathlib import Path as _Path
 
-        gt = GatewayTools(
-            client_manager=MockClientManager(),  # type: ignore
-            policy_manager=PolicyManager(),
+        src = str(_Path(__file__).resolve().parents[1] / "src")
+        out = subprocess.run(
+            [_sys.executable, "-c", self._SCENARIO.format(src=src)],
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-        # Parent spawns a grandchild, prints its pid, then hangs -- the shape of
-        # a server that ignores the probe flag. The grandchild outlives the
-        # parent unless the whole process GROUP is signalled.
-        import tempfile
-
-        fd, tmp_pid_file = tempfile.mkstemp()
-        os.close(fd)
-        script = (
-            "import subprocess,sys,time;"
-            f"p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);"
-            f"open({tmp_pid_file!r},'w').write(str(p.pid));"
-            "time.sleep(30)"
+        return (
+            (out.stdout or "").strip().splitlines()[-1]
+            if out.stdout.strip()
+            else out.stderr[-400:]
         )
 
-        real_wait_for = asyncio.wait_for
-
-        async def _fast_timeout(awaitable, timeout=None):
-            # Let the child start and record its grandchild, then time out.
-            return await real_wait_for(awaitable, timeout=1.5)
-
-        monkeypatch.setattr("pmcp.tools.handlers.asyncio.wait_for", _fast_timeout)
-
-        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
-            await gt._run_update_probe_command([_sys.executable, "-c", script])
-
-        await asyncio.sleep(0.5)
-        grandchild = (open(tmp_pid_file).read() or "").strip()
-        assert grandchild, "test setup failed: grandchild pid never recorded"
-        alive = os.path.exists(f"/proc/{grandchild}")
-        os.unlink(tmp_pid_file)
-        assert not alive, (
-            f"probe orphaned grandchild pid={grandchild}: the process tree "
-            "survived the timeout"
+    def test_timeout_reaps_the_whole_process_tree(self) -> None:
+        result = self._run_scenario()
+        assert result == "REAPED", (
+            f"probe did not reap its process tree (got {result!r}): a hung probe "
+            "leaves grandchildren alive"
         )
 
     @pytest.mark.asyncio
     async def test_normal_probe_still_returns_output(self) -> None:
-        """The happy path is unchanged by the hardening."""
+        """The happy path is unchanged by the hardening (safe in-process)."""
         import sys as _sys
 
         gt = GatewayTools(


### PR DESCRIPTION
Found by the advisor board while reviewing an unrelated plan for #150, then verified independently. This is a **live bug in shipped code**, not a hypothetical.

## The bug

`_run_update_probe_command` runs the downstream package's own code — `npx <pkg> --help`, `uvx --refresh <pkg> --help` — on behalf of `gateway.update_server`. It spawned like this:

```python
process = await asyncio.create_subprocess_exec(
    *command, stdout=PIPE, stderr=PIPE, env=env,
)
stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60.0)
```

Two problems compounding:

1. **No `start_new_session`**, so the child is not a process-group leader and cannot be reaped as a tree.
2. **`wait_for` cancels the await, not the process.** On timeout it raises and the child is simply abandoned — never signalled, never waited on.

So a package that ignores the probe flag and runs as a server leaves its **entire process tree alive**. That is not a rare shape: measured against this repo's own manifest, `@circleci/mcp-server-circleci` ignores the flag and was still running at 90 seconds with 7 processes and 5 open sockets.

The worst case is one this codebase already documents elsewhere: `_terminate_process_tree`'s own docstring notes that an orphaned `@playwright/mcp` grandchild keeps the browser profile's `SingletonLock` and **breaks the next launch**.

## The fix

Spawn with `start_new_session=True` and reap the group via the existing `_terminate_process_tree` helper on timeout *or* cancellation. No new cleanup logic — this reuses the pattern `ClientManager` already uses for exactly this reason.

## Verification

- **RED proof**: reverting only the src change makes the new test fail with a real orphan, not an assertion about intent:

  ```
  AssertionError: probe orphaned grandchild pid=1502977: the process tree survived the timeout
  ```

  The test spawns a **real** process tree — a parent that starts a grandchild, records its pid and hangs, which is the shape of a server ignoring the probe flag. A mocked subprocess cannot demonstrate an orphan, and this bug is entirely about what survives the call.

- `pytest -q` → **2555 passed, 3 skipped, 0 failed** (2553 baseline + 2)
- `ruff check .`, `ruff format --check src/ tests/`, `mypy src` — clean

## Scope

Deliberately narrow: the probe's process handling only. It does not touch what the probe is *for*, which is the open question in #150.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789585879&installation_model_id=427051&pr_number=157&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F157&signature=f3aa17825a8ea3199917397fed7f987a019636599f3228db4a740336f4bfd316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->