### PR TITLE
fix: remove the automatic update notices (#150)

### DIFF
--- a/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
+++ b/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
@@ -44,7 +44,7 @@ Total attachment points are therefore **16**, not the six this plan first docume
 - `_get_update_warning` — **delete**.
 - `_run_stale_index`, `_stale_indexer_loop`, `start_stale_indexer`, `stop_stale_indexer` — **delete**.
 - `_stale_check_cache`, `_stale_index_interval_seconds`, `_stale_index_task`, `_stale_check_ttl_seconds` — **delete**.
-- `_effective_notice_target`, `_notice_package_matches_cache` — **delete** (no remaining callers once the above go; verify by grep rather than assumption).
+- `_effective_notice_target`, `_notice_package_matches_cache` — **delete**. Second correction found while boarding: these have **zero references anywhere in `src/` or `tests/`**. The plan said "used only by the above", which was wrong — they were never wired in at all, and are already-dead residue from the abandoned #154 attempts. Deleting them is unrelated to this feature's behaviour.
 - `catalog_search` — **modify** — drop the `stale_updates` construction and stop passing it.
 - `describe` / `invoke` / `provision` — **modify** — drop the `_get_update_warning` calls and every `update_warning=` argument. Counts matter here: `describe` 1, `invoke` 5, `provision` 10 — **16 attachment points**. Missing one leaves a call to a deleted method.
 - `update_server` — **modify** — remove writes to `_stale_check_cache`, keep everything else. Its own probe-and-report behaviour is explicitly retained.
@@ -87,6 +87,8 @@ This **does** change the protocol surface: four fields are removed from three to
 5. README, then CHANGELOG last.
 
 No new dependency. No migration: `_stale_check_cache` is in-memory and rebuilt per process.
+
+**Blast radius confirmed by grep:** every reference to the deleted machinery lives in `src/pmcp/tools/handlers.py` — nothing else in `src/` touches it. But **15 test references** depend on `_stale_check_cache`, so the test deletions are a larger share of this change than the source deletions, and each must be classified as "asserts the removed feature" (delete) or "asserts `update_server`" (keep).
 
 ## Verification
 

--- a/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
+++ b/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
@@ -31,7 +31,9 @@ Machinery:
 - `InvokeOutput.update_warning` (`754`)
 - `ProvisionOutput.update_warning` (`1204`)
 
-Note `ProvisionOutput.update_warning` is set from `provision`, a path not in the three emission sites above — it must be traced during implementation rather than assumed dead.
+**Correction, traced before boarding:** `provision` is a **fourth emission site**, not a stray field. It calls `_get_update_warning` at `handlers.py:4188` and attaches `update_warning` at **ten** further return paths (`4200, 4228, 4250, 4277, 4298, 4326, 4339, 4358, 4387, 4411`).
+
+Total attachment points are therefore **16**, not the six this plan first documented: `describe` 1, `invoke` 5, `provision` 10. A removal that stops at `describe`/`invoke` leaves `provision` calling a deleted method — the exact half-removal failure this plan warns about, which I nearly committed.
 
 **Documentation:** `README.md:480` states these tools "may return `update_warning` when a newer package version is detected."
 
@@ -44,7 +46,7 @@ Note `ProvisionOutput.update_warning` is set from `provision`, a path not in the
 - `_stale_check_cache`, `_stale_index_interval_seconds`, `_stale_index_task`, `_stale_check_ttl_seconds` — **delete**.
 - `_effective_notice_target`, `_notice_package_matches_cache` — **delete** (no remaining callers once the above go; verify by grep rather than assumption).
 - `catalog_search` — **modify** — drop the `stale_updates` construction and stop passing it.
-- `describe` / `invoke` — **modify** — drop the `_get_update_warning` calls and the `update_warning=` arguments at every return path. `invoke` has **six**; missing one leaves a dangling reference.
+- `describe` / `invoke` / `provision` — **modify** — drop the `_get_update_warning` calls and every `update_warning=` argument. Counts matter here: `describe` 1, `invoke` 5, `provision` 10 — **16 attachment points**. Missing one leaves a call to a deleted method.
 - `update_server` — **modify** — remove writes to `_stale_check_cache`, keep everything else. Its own probe-and-report behaviour is explicitly retained.
 
 ### `src/pmcp/server.py` (modify)

--- a/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
+++ b/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
@@ -1,0 +1,136 @@
+# Detailed plan: remove the automatic update notices
+
+## Task
+
+Close Consiliency/pmcp#150 by removing the feature that produces the defect, rather than attempting a ninth fix.
+
+Maintainer decision, taken after the advisor board rejected the eighth attempt 3/3 and explicitly recommended removal. `gateway.update_server` keeps working unchanged — it reports what it finds when the operator asks it to update something. What goes away is the gateway *volunteering* a claim it cannot substantiate.
+
+## Research summary
+
+**Why removal rather than repair.** Eight attempts failed at one joint: pmcp cannot observe which package artifact a running server is executing. Not from `descriptions_cache.version` (an upstream snapshot written at describe time), not from `serverInfo.version` (an *implementation* version — FastMCP 1.x reports the SDK's, mcp 2.x defaults to `""`), not from the npx/uv runner caches (no server→entry binding; one package was observed cached at 1.2.0, 1.2.1 and 1.2.2 concurrently), and not from spawn argv (npm resolves *after* `create_subprocess_exec` returns; a live `npx` tree exposes no `_npx` path in any descendant).
+
+The board's verdict on the only remaining method — running the package's own `--version` — was that it is disqualifying: it is a **full launch** of the server's argv with `sanitized_subprocess_env` injecting **that server's real credentials**, on a schedule. For a manifest entry using `@latest` it could execute newly published code with those credentials before the operator chose to update. Measured: probing one flag-ignoring server spawned 7 processes and opened 5 sockets. codex left exactly one door open — notices would be defensible *"unless a server exposes trustworthy version metadata without"* execution. Nothing in MCP does today.
+
+**The surface to remove, enumerated from source.**
+
+Emission sites (3 tool outputs):
+- `catalog_search` — builds `stale_updates` from `_stale_check_cache` (`handlers.py:1695-1709`), attached at `1718`.
+- `describe` — `update_warning = await self._get_update_warning(...)` (`handlers.py:1750`), attached at `1832`.
+- `invoke` — same call at `1982`, attached at six return paths (`2069, 2104, 2153, 2188, 2238`).
+
+Machinery:
+- `_stale_check_cache` (`1093`), `_stale_index_interval_seconds` (`1097`), `_stale_index_task` (`1098`)
+- `start_stale_indexer` / `stop_stale_indexer` (`1319`, `1325`), called from `server.py:808` and `server.py:967`
+- `_stale_indexer_loop` (`1332`), `_run_stale_index` (`1346`), `_get_update_warning` (`3630`)
+- `_effective_notice_target`, `_notice_package_matches_cache` — added during the #154 attempts, used only by the above
+
+**Public schema fields** — this is a protocol-surface change, not an internal cleanup:
+- `CatalogSearchOutput.stale_updates` (`types.py:639`)
+- `SchemaCard.update_warning` (`691`)
+- `InvokeOutput.update_warning` (`754`)
+- `ProvisionOutput.update_warning` (`1204`)
+
+Note `ProvisionOutput.update_warning` is set from `provision`, a path not in the three emission sites above — it must be traced during implementation rather than assumed dead.
+
+**Documentation:** `README.md:480` states these tools "may return `update_warning` when a newer package version is detected."
+
+## Changes
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_get_update_warning` — **delete**.
+- `_run_stale_index`, `_stale_indexer_loop`, `start_stale_indexer`, `stop_stale_indexer` — **delete**.
+- `_stale_check_cache`, `_stale_index_interval_seconds`, `_stale_index_task`, `_stale_check_ttl_seconds` — **delete**.
+- `_effective_notice_target`, `_notice_package_matches_cache` — **delete** (no remaining callers once the above go; verify by grep rather than assumption).
+- `catalog_search` — **modify** — drop the `stale_updates` construction and stop passing it.
+- `describe` / `invoke` — **modify** — drop the `_get_update_warning` calls and the `update_warning=` arguments at every return path. `invoke` has **six**; missing one leaves a dangling reference.
+- `update_server` — **modify** — remove writes to `_stale_check_cache`, keep everything else. Its own probe-and-report behaviour is explicitly retained.
+
+### `src/pmcp/server.py` (modify)
+
+- `start_stale_indexer()` call (`~808`) and `stop_stale_indexer()` call (`~967`) — **delete**. These are the only external callers; leaving them would break startup.
+
+### `src/pmcp/types.py` (modify)
+
+- `CatalogSearchOutput.stale_updates`, `SchemaCard.update_warning`, `InvokeOutput.update_warning`, `ProvisionOutput.update_warning` — **delete**.
+
+**Removing a field from a public output model is the load-bearing decision in this plan.** A client reading `update_warning` gets `None` today when there is no notice, so absence is already a normal case; but a client doing `"update_warning" in result` would see a behaviour change. See the open question.
+
+### `tests/` (modify)
+
+- `tests/test_tools.py` — **delete** the tests that assert notice emission (the `TestStaleIndexer` class and the notice tests added across the #154 attempts). Keep every `update_server` test: that path is unchanged and must be proven so.
+- **add** — `test_no_update_warning_field_in_outputs`: `describe`, `invoke` and `catalog_search` outputs do not carry the removed fields. Asserts the removal is complete rather than partial — a half-removal that leaves one emission site is the failure mode to guard.
+- **add** — `test_no_background_indexer_task_is_started`: booting the gateway creates no stale-index task. Pins that the loop is gone rather than merely unused.
+- **add** — `test_update_server_still_reports_versions`: the on-demand path still works. This is what the maintainer is keeping and it must not regress silently.
+
+### `CHANGELOG.md` (modify)
+
+Entry under `## [Unreleased]`. **Mandatory** — `main` is protected and the `changelog` check fails any PR touching `src/`. Must be a `### Removed` entry naming the removed fields, since this is a breaking change to tool output, and must say plainly *why*: the gateway could not determine which version a server was actually running, so the notice could be wrong in both directions.
+
+### `README.md` (modify)
+
+Line ~480 — **delete** the sentence promising `update_warning`, and state that update information comes from `gateway.update_server` on request.
+
+## Frozen vocabulary / protocol check
+
+This **does** change the protocol surface: four fields are removed from three tool outputs. They are removals of optional fields that are already `None` in the common case, and no field is renamed or retyped. No new vocabulary is introduced. Flagged explicitly because every prior plan in this series could honestly claim "no protocol change" and this one cannot.
+
+## Dependencies & order
+
+1. Remove the emission sites first (`catalog_search`, `describe`, `invoke`) — the schema fields cannot go while writers remain.
+2. Remove the background machinery and the `server.py` lifecycle calls together — a deleted method with a live caller breaks startup.
+3. Remove the schema fields.
+4. Delete the obsolete tests; add the three new ones.
+5. README, then CHANGELOG last.
+
+No new dependency. No migration: `_stale_check_cache` is in-memory and rebuilt per process.
+
+## Verification
+
+```bash
+cd <worktree>
+uv run pytest tests/test_tools.py -q -k 'update_server or catalog_search or describe or invoke'
+uv run pytest -q            # baseline 2555 minus deleted tests plus 3 new; 0 failed
+uv run ruff check . && uv run ruff format --check src/ tests/ && uv run mypy src
+
+# Completeness greps — a partial removal is the failure mode here:
+grep -rn '_stale_check_cache\|_stale_index\|_get_update_warning\|update_warning\|stale_updates' src/ || echo "clean"
+```
+
+Then boot the gateway and confirm `describe`/`invoke`/`catalog_search` return successfully with no notice fields, and that `gateway.update_server` still reports a version.
+
+Edge cases: `ProvisionOutput.update_warning` may have a writer outside the three known sites; the six `invoke` return paths; any test asserting the *absence* of a warning that would now fail on a missing attribute.
+
+## Acceptance criteria
+
+- [ ] No code path emits an update notice — proven by `test_no_update_warning_field_in_outputs` and by the completeness grep returning nothing.
+- [ ] No background indexer task is created at startup — proven by `test_no_background_indexer_task_is_started`.
+- [ ] `gateway.update_server` still probes and reports versions on request — proven by `test_update_server_still_reports_versions` and by the retained `update_server` tests passing unchanged.
+- [ ] Full suite passes with 0 failures; ruff, format, mypy clean; `### Removed` CHANGELOG entry present; README no longer promises `update_warning`.
+
+## Non-goals
+
+- **Changing `gateway.update_server`.** Its probe, restart-gating and pin refusal all stay. Only its writes to the deleted cache are touched.
+- **Deprecating rather than removing.** Considered and rejected as the default: keeping the fields as permanently-`None` would preserve a schema promise pmcp no longer fulfils. Raised as the open question below.
+
+## Open question for the board
+
+Removing four public output fields is a breaking change for any consumer reading them. Three options, and I want the board's view rather than my own default:
+
+1. **Remove outright** (this plan). Cleanest; breaks a consumer doing `"update_warning" in result`.
+2. **Retain the fields, always `None`.** Non-breaking, but leaves a documented field that can never be populated — arguably worse, since it promises a capability that no longer exists.
+3. **Remove the emission, retain the fields for one release with a deprecation note.** Slower, and only worthwhile if there is evidence of external consumers.
+
+pmcp is at 2.1.1 and these fields are documented in the README, so a consumer plausibly reads them. My inclination is (1) with a clear `### Removed` entry, because a field that is structurally always-`None` is a worse contract than an absent one — but this is a judgement about consumers I cannot see.
+
+## Execution Policy
+
+- execute: effort=medium, reason=mechanical deletion across a known surface, but it spans four models, six `invoke` return paths and two server lifecycle calls, where a partial removal breaks startup or leaves a dangling reference.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```

--- a/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
+++ b/.consiliency/plans/detailed-remove-automatic-update-notices-20260819-0100.md
@@ -31,9 +31,19 @@ Machinery:
 - `InvokeOutput.update_warning` (`754`)
 - `ProvisionOutput.update_warning` (`1204`)
 
-**Correction, traced before boarding:** `provision` is a **fourth emission site**, not a stray field. It calls `_get_update_warning` at `handlers.py:4188` and attaches `update_warning` at **ten** further return paths (`4200, 4228, 4250, 4277, 4298, 4326, 4339, 4358, 4387, 4411`).
+**Corrected inventory — I got this number wrong twice before the board caught it.**
 
-Total attachment points are therefore **16**, not the six this plan first documented: `describe` 1, `invoke` 5, `provision` 10. A removal that stops at `describe`/`invoke` leaves `provision` calling a deleted method — the exact half-removal failure this plan warns about, which I nearly committed.
+Authoritative count from source (`grep -c 'update_warning=' src/pmcp/tools/handlers.py`): **26 attachment sites**, plus **3** calls to `_get_update_warning` (`1750`, `1982`, `4188`).
+
+| caller | call site | `update_warning=` attachments |
+|---|---|---|
+| `describe` | 1750 | 1 (`1832`) |
+| `invoke` | 1982 | 5 (`2069, 2104, 2153, 2188, 2238`) |
+| `provision` | 4188 | **20** (`4200 … 4630`) |
+
+My first draft said six. My own pre-board correction said sixteen, because I stopped reading the grep output at `4411` when it continues to `4630`. The board caught the second undercount.
+
+**That miscount pattern is the finding, not a footnote.** `provision` alone accounts for 20 of 26 sites, so the mechanical edit is concentrated exactly where I kept failing to look. The implementation must therefore be driven by `grep -c`, verified to reach **zero**, rather than by any hand-enumerated list in this document.
 
 **Documentation:** `README.md:480` states these tools "may return `update_warning` when a newer package version is detected."
 
@@ -46,7 +56,7 @@ Total attachment points are therefore **16**, not the six this plan first docume
 - `_stale_check_cache`, `_stale_index_interval_seconds`, `_stale_index_task`, `_stale_check_ttl_seconds` — **delete**.
 - `_effective_notice_target`, `_notice_package_matches_cache` — **delete**. Second correction found while boarding: these have **zero references anywhere in `src/` or `tests/`**. The plan said "used only by the above", which was wrong — they were never wired in at all, and are already-dead residue from the abandoned #154 attempts. Deleting them is unrelated to this feature's behaviour.
 - `catalog_search` — **modify** — drop the `stale_updates` construction and stop passing it.
-- `describe` / `invoke` / `provision` — **modify** — drop the `_get_update_warning` calls and every `update_warning=` argument. Counts matter here: `describe` 1, `invoke` 5, `provision` 10 — **16 attachment points**. Missing one leaves a call to a deleted method.
+- `describe` / `invoke` / `provision` — **modify** — drop all **3** `_get_update_warning` calls and all **26** `update_warning=` arguments (`describe` 1, `invoke` 5, `provision` 20). Do not work from a list: run `grep -c 'update_warning=' src/pmcp/tools/handlers.py` and drive it to `0`. I miscounted this twice by reading a truncated grep.
 - `update_server` — **modify** — remove writes to `_stale_check_cache`, keep everything else. Its own probe-and-report behaviour is explicitly retained.
 
 ### `src/pmcp/server.py` (modify)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Automatic "update available" notices.** `gateway.describe`, `gateway.invoke`
+  and `gateway.provision` no longer return `update_warning`,
+  `gateway.catalog_search` no longer returns `stale_updates`, and the hourly
+  background stale-version indexer is gone. **These fields are removed from the
+  tool output schemas, not merely left empty** — a client reading them will no
+  longer find the keys, which previously appeared as explicit nulls.
+
+  The gateway cannot determine which version of a package a running server is
+  actually executing. The recorded version was an upstream snapshot taken when
+  the server was last described, so a notice could both invent an update that
+  did not exist and hide one that did — particularly for a server configured in
+  both the manifest and `.mcp.json`. Eight separate attempts to source a
+  trustworthy version failed, and the only remaining method — running each
+  server's own `--version` on a schedule — would mean executing third-party
+  package code with that server's credentials to produce an advisory message.
+
+  **`gateway.update_server` is unchanged** and remains the way to check and
+  apply updates: it probes the package, reports what it found, restarts the
+  server, and refuses servers pinned to a specific version.
+
+
 ### Fixed
 - **`gateway.update_server` no longer orphans a process tree when its update
   probe hangs.** The probe runs the downstream package's own code (e.g.

--- a/README.md
+++ b/README.md
@@ -477,8 +477,7 @@ URL-mode gateway calls.
 
 - `gateway.update_server` is the phase-1 update path for subordinate MCPs.
 - `pmcp update <server>` and `pmcp update --all` call the same gateway update workflow.
-- `gateway.describe`, `gateway.invoke`, and `gateway.provision` may return `update_warning` when a newer package version is detected.
-- Background stale-version indexing is active — warnings are zero-latency via hourly pre-population.
+- Update information is reported on request by `gateway.update_server`; the gateway does not volunteer unprompted "update available" notices. It cannot observe which package version a running server is actually executing, so a volunteered notice could be wrong in either direction (Consiliency/pmcp#150).
 
 ### Feedback Telemetry
 

--- a/src/pmcp/server.py
+++ b/src/pmcp/server.py
@@ -804,9 +804,6 @@ class GatewayServer:
 
         logger.debug("Capability summary:\n%s", self._capability_summary)
 
-        # Start background stale-version indexer (precomputes warnings for low latency)
-        self._gateway_tools.start_stale_indexer()
-
         # Create MCP server with capability instructions
         self._create_server(instructions=self._capability_summary)
 
@@ -964,7 +961,6 @@ class GatewayServer:
         # close carries no response); EC-P3B-2's server-close half is proven
         # deterministically in-process instead (test_listen_registration.py).
         self._listen_handler.close()
-        self._gateway_tools.stop_stale_indexer()
         try:
             await asyncio.wait_for(self._client_manager.disconnect_all(), timeout=10.0)
         except asyncio.TimeoutError:

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -693,7 +693,8 @@ def get_gateway_tool_definitions() -> list[Tool]:
             description=(
                 "Update a subordinate MCP server package to latest version and restart it "
                 "so the new version is actually running. "
-                "Use this when invoke/describe/provision warn that a newer version is available. "
+                "Call this to check for and apply an update -- the gateway does not "
+                "volunteer update notices, so nothing will prompt you. "
                 "Refuses to restart by default when the server has pending requests; "
                 "set force=true to cancel them."
             ),

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -81,7 +81,6 @@ from pmcp.manifest.version_checker import (
     _npm_tag,
     detect_package_type,
     get_package_version,
-    is_version_newer,
 )
 from pmcp.policy.policy import PolicyManager
 from pmcp.remote_auth import (
@@ -1888,7 +1887,6 @@ class GatewayTools:
                 errors=[error.model_dump_json()],
                 feedback_hint=self._feedback_hint(),
             )
-
 
         # Call the tool
         _call_start = time.monotonic()
@@ -5068,7 +5066,6 @@ class GatewayTools:
         # update fetched, and only once the server has actually been restarted
         # onto the new package: a failed or refused restart means the gateway
         # is still serving the old version.
-        now = time.time()
         if restart_result.ok:
             if latest_version:
                 if (

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -1085,17 +1085,6 @@ class GatewayTools:
         # so concurrent polls cannot double-adopt or re-refresh a finished job.
         self._provision_finalize_locks: dict[str, asyncio.Lock] = {}
         self._provision_finalized: set[str] = set()
-        # (checked_at, current, latest, package_type). The package type is
-        # carried so the READ sites can order correctly: npm/cargo publish
-        # SemVer, where `-1` is a prerelease, while PEP 440 reads it as a
-        # post-release. Without it, catalog_search inverts npm prereleases --
-        # hiding a real upgrade and fabricating its reverse (ah board review).
-        self._stale_check_cache: dict[
-            str, tuple[float, str | None, str | None, str | None]
-        ] = {}
-        self._stale_check_ttl_seconds = 6 * 60 * 60
-        self._stale_index_interval_seconds = 60 * 60  # Re-index every hour
-        self._stale_index_task: asyncio.Task[None] | None = None
         self._feedback_events: list[dict[str, Any]] = []
         self._audit_events: deque[GatewayAuditEvent] = deque(maxlen=64)
         self._provisioned_registry: dict[str, str | None] = (
@@ -1315,65 +1304,6 @@ class GatewayTools:
         self._save_provisioned_registry()
 
     # === Stale Version Indexer ===
-
-    def start_stale_indexer(self) -> None:
-        """Start the background stale-version indexing task."""
-        if self._stale_index_task is None or self._stale_index_task.done():
-            self._stale_index_task = asyncio.create_task(self._stale_indexer_loop())
-            logger.info("Started stale-version indexer background task")
-
-    def stop_stale_indexer(self) -> None:
-        """Stop the background stale-version indexing task."""
-        if self._stale_index_task and not self._stale_index_task.done():
-            self._stale_index_task.cancel()
-            self._stale_index_task = None
-            logger.debug("Stopped stale-version indexer background task")
-
-    async def _stale_indexer_loop(self) -> None:
-        """Background loop: precompute stale version checks for all known servers."""
-        while True:
-            try:
-                await self._run_stale_index()
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.debug(f"Stale indexer pass failed: {e}")
-            try:
-                await asyncio.sleep(self._stale_index_interval_seconds)
-            except asyncio.CancelledError:
-                break
-
-    async def _run_stale_index(self) -> None:
-        """One pass: fetch latest versions for all servers in the descriptions cache."""
-        if not self._descriptions_cache:
-            return
-        now = time.time()
-        servers = list(self._descriptions_cache.servers.items())
-        for server_name, server_desc in servers:
-            # Skip if cache entry is still fresh
-            cached = self._stale_check_cache.get(server_name)
-            if cached and (now - cached[0]) < self._stale_check_ttl_seconds:
-                continue
-            server_config = self._get_server_config_for_update(server_name)
-            if not server_config or not server_config.command:
-                continue
-            try:
-                latest, pkg_type = await get_package_version(
-                    server_config.command, server_config.args, timeout=5.0
-                )
-                self._stale_check_cache[server_name] = (
-                    now,
-                    server_desc.version,
-                    latest,
-                    pkg_type,
-                )
-                if latest and is_version_newer(server_desc.version, latest, pkg_type):
-                    logger.info(
-                        f"Update available for '{server_name}': "
-                        f"{server_desc.version} -> {latest}"
-                    )
-            except Exception as e:
-                logger.debug(f"Stale check failed for '{server_name}': {e}")
 
     async def _ensure_server_for_tool(self, tool_id: str) -> bool:
         """Ensure server is connected for a tool, triggering lazy-start if needed.
@@ -1691,23 +1621,6 @@ class GatewayTools:
                 )
             )
 
-        # Collect stale-update notices from precomputed cache (no network call)
-        stale_updates: list[str] | None = None
-        if self._stale_check_cache and not scoped_advisor:
-            stale = [
-                f"Update available for '{sn}': {current} -> {latest}. "
-                f"Call gateway.update_server(server_name='{sn}') to update."
-                for sn, (_, current, latest, pkg_type) in (
-                    self._stale_check_cache.items()
-                )
-                if current
-                and latest
-                and is_version_newer(current, latest, pkg_type)
-                and self._policy_manager.is_server_allowed(sn)
-            ]
-            if stale:
-                stale_updates = stale
-
         return CatalogSearchOutput(
             results=results,
             total_available=total_available,
@@ -1715,7 +1628,6 @@ class GatewayTools:
             cli_hints=cli_hints,
             registry_candidates=registry_candidates,
             manifest_candidates=manifest_candidates,
-            stale_updates=stale_updates,
         )
 
     async def describe(self, input_data: dict[str, Any]) -> SchemaCard:
@@ -1747,7 +1659,6 @@ class GatewayTools:
                     details={"tool_id": parsed.tool_id},
                 )
 
-        update_warning = await self._get_update_warning(tool_info.server_name)
         self._record_feedback_event(
             "invoke_attempt",
             {
@@ -1829,7 +1740,6 @@ class GatewayTools:
             safety_notes=safety_notes if safety_notes else None,
             invoke_template=invoke_template,
             code_snippet=code_snippet,
-            update_warning=update_warning,
             # No feedback hint on a SUCCESSFUL describe. `_feedback_hint()`
             # opens with "Technical failure detected", which is false here and
             # was reaching every client on every successful describe. The
@@ -1979,7 +1889,6 @@ class GatewayTools:
                 feedback_hint=self._feedback_hint(),
             )
 
-        update_warning = await self._get_update_warning(tool_info.server_name)
 
         # Call the tool
         _call_start = time.monotonic()
@@ -2066,7 +1975,6 @@ class GatewayTools:
                 truncated=processed["truncated"],
                 summary=processed["summary"],
                 raw_size_estimate=processed["raw_size"],
-                update_warning=update_warning,
                 feedback_hint=None,
             )
 
@@ -2101,7 +2009,6 @@ class GatewayTools:
                 truncated=False,
                 raw_size_estimate=0,
                 errors=[error.model_dump_json()],
-                update_warning=update_warning,
                 feedback_hint=self._feedback_hint(),
             )
 
@@ -2150,7 +2057,6 @@ class GatewayTools:
                 truncated=False,
                 raw_size_estimate=0,
                 errors=[error.model_dump_json()],
-                update_warning=update_warning,
                 auth_state=cast(Any, auth_state),
                 auth_challenge=auth_challenge,
                 next_step="Resolve remote authorization out of band, then retry gateway.invoke."
@@ -2185,7 +2091,6 @@ class GatewayTools:
                     truncated=False,
                     raw_size_estimate=0,
                     errors=["URL-mode elicitation required."],
-                    update_warning=update_warning,
                     auth_state="elicitation_required",
                     url_elicitations=url_elicitations,
                     next_step=url_elicitations[0].next_step,
@@ -2235,7 +2140,6 @@ class GatewayTools:
                 truncated=False,
                 raw_size_estimate=0,
                 errors=[error.model_dump_json()],
-                update_warning=update_warning,
                 auth_state=cast(Any, auth_state),
                 auth_challenge=auth_challenge,
                 next_step="Resolve remote authorization out of band, then retry gateway.invoke."
@@ -3627,48 +3531,6 @@ class GatewayTools:
             return server_config
         return self._discovered_server_configs.get(server_name)
 
-    async def _get_update_warning(self, server_name: str) -> str | None:
-        """Best-effort stale version warning for a server."""
-        server_config = self._get_server_config_for_update(server_name)
-        if not server_config or not server_config.command:
-            return None
-
-        # Require a known local version to compare against.
-        current_version: str | None = None
-        if self._descriptions_cache and server_name in self._descriptions_cache.servers:
-            current_version = self._descriptions_cache.servers[server_name].version
-        if not current_version:
-            return None
-
-        now = time.time()
-        cached = self._stale_check_cache.get(server_name)
-        if cached and (now - cached[0]) < self._stale_check_ttl_seconds:
-            latest_cached = cached[2]
-            cached_pkg_type = cached[3]
-            if latest_cached and is_version_newer(
-                current_version, latest_cached, cached_pkg_type
-            ):
-                return (
-                    f"Update available for '{server_name}': {current_version} -> {latest_cached}. "
-                    f"Call gateway.update_server with server_name='{server_name}'."
-                )
-            return None
-
-        latest, pkg_type = await get_package_version(
-            server_config.command, server_config.args, timeout=3.0
-        )
-        self._stale_check_cache[server_name] = (now, current_version, latest, pkg_type)
-
-        # Pass the ecosystem: npm/cargo publish SemVer, where `-1` is a
-        # PRERELEASE, while PEP 440 reads it as a POST-release. Without this the
-        # ordering inverts for the 79 npm servers in the manifest.
-        if latest and is_version_newer(current_version, latest, pkg_type):
-            return (
-                f"Update available for '{server_name}': {current_version} -> {latest}. "
-                f"Call gateway.update_server with server_name='{server_name}'."
-            )
-        return None
-
     async def _run_update_probe_command(
         self, command: list[str], env: dict[str, str] | None = None
     ) -> tuple[bool, str]:
@@ -4185,7 +4047,6 @@ class GatewayTools:
         """gateway.provision - Start background installation of an MCP server."""
         parsed = ProvisionInput.model_validate(input_data)
         server_name = parsed.server_name
-        update_warning = await self._get_update_warning(server_name)
         self._record_feedback_event("provision_attempt", {"server": server_name})
 
         configured_servers = self._load_configured_servers()
@@ -4197,7 +4058,6 @@ class GatewayTools:
                 status="failed",
                 message=f"Server '{server_name}' is blocked by policy.",
                 auth_state="policy_denied",
-                update_warning=update_warning,
                 feedback_hint=self._feedback_hint(),
             )
 
@@ -4225,7 +4085,6 @@ class GatewayTools:
                     )
                     for t in tools[:10]
                 ],
-                update_warning=update_warning,
                 feedback_hint=None,
             )
 
@@ -4247,7 +4106,6 @@ class GatewayTools:
                     auth_state="missing_auth",
                     auth_methods=self._auth_methods_for_server(server_name),
                     next_step=f"gateway.auth_connect(server_name='{server_name}')",
-                    update_warning=update_warning,
                     feedback_hint=self._feedback_hint(),
                 )
             credential_gap = self._configured_duplicate_missing_credential(
@@ -4274,7 +4132,6 @@ class GatewayTools:
                     auth_state="missing_auth",
                     auth_metadata=self._auth_metadata_for_server(manifest_server),
                     next_step=f"gateway.auth_connect(server_name='{server_name}')",
-                    update_warning=update_warning,
                     feedback_hint=self._feedback_hint(),
                 )
             try:
@@ -4295,7 +4152,6 @@ class GatewayTools:
                         auth_state="elicitation_required",
                         next_step=url_elicitations[0].next_step,
                         url_elicitations=url_elicitations,
-                        update_warning=update_warning,
                         feedback_hint=self._feedback_hint(),
                     )
                 raise
@@ -4323,7 +4179,6 @@ class GatewayTools:
                         )
                         for t in tools[:10]
                     ],
-                    update_warning=update_warning,
                     feedback_hint=None,
                 )
 
@@ -4336,7 +4191,6 @@ class GatewayTools:
                     "Run gateway.refresh and check gateway.health for connection errors."
                 ),
                 auth_state="unknown",
-                update_warning=update_warning,
                 feedback_hint=self._feedback_hint(),
             )
 
@@ -4355,7 +4209,6 @@ class GatewayTools:
                 message=(
                     f"Server '{server_name}' not found in manifest or .mcp.json configuration."
                 ),
-                update_warning=update_warning,
                 feedback_hint=self._feedback_hint(),
             )
 
@@ -4384,7 +4237,6 @@ class GatewayTools:
                     auth_state="missing_auth",
                     auth_metadata=self._auth_metadata_for_server(server_config),
                     next_step=f"gateway.auth_connect(server_name='{server_name}')",
-                    update_warning=update_warning,
                     feedback_hint=self._feedback_hint(),
                 )
 
@@ -4408,7 +4260,6 @@ class GatewayTools:
                         auth_methods=self._auth_methods_for_server(server_name),
                         auth_metadata=self._auth_metadata_for_server(server_config),
                         next_step=f"gateway.auth_connect(server_name='{server_name}')",
-                        update_warning=update_warning,
                         feedback_hint=self._feedback_hint(),
                     )
                 errors = await self._client_manager.connect_all([resolved_config])
@@ -4435,7 +4286,6 @@ class GatewayTools:
                             auth_metadata=self._auth_metadata_for_server(server_config),
                             next_step=url_elicitations[0].next_step,
                             url_elicitations=url_elicitations,
-                            update_warning=update_warning,
                             feedback_hint=self._feedback_hint(),
                         )
                     auth_challenge = self._auth_challenge_from_message(message)
@@ -4459,7 +4309,6 @@ class GatewayTools:
                         auth_challenge=auth_challenge,
                         auth_metadata=self._auth_metadata_for_server(server_config),
                         next_step="Resolve remote authorization out of band, then retry gateway.provision.",
-                        update_warning=update_warning,
                         feedback_hint=self._feedback_hint(),
                     )
 
@@ -4489,7 +4338,6 @@ class GatewayTools:
                         )
                         for t in tools[:10]
                     ],
-                    update_warning=update_warning,
                     feedback_hint=None,
                 )
 
@@ -4507,7 +4355,6 @@ class GatewayTools:
                     auth_state="missing_auth",
                     auth_metadata=self._auth_metadata_for_server(server_config),
                     next_step=f"gateway.auth_connect(server_name='{server_name}')",
-                    update_warning=update_warning,
                     feedback_hint=self._feedback_hint(),
                 )
 
@@ -4526,7 +4373,6 @@ class GatewayTools:
                         auth_metadata=self._auth_metadata_for_server(server_config),
                         next_step=url_elicitations[0].next_step,
                         url_elicitations=url_elicitations,
-                        update_warning=update_warning,
                         feedback_hint=self._feedback_hint(),
                     )
                 logger.error(f"Failed to connect remote server {server_name}: {e}")
@@ -4545,7 +4391,6 @@ class GatewayTools:
                     message=f"Failed to connect remote server '{server_name}': {self._sanitize_error(e)}",
                     auth_state="unknown",
                     auth_metadata=self._auth_metadata_for_server(server_config),
-                    update_warning=update_warning,
                     feedback_hint=self._feedback_hint(),
                 )
 
@@ -4562,7 +4407,6 @@ class GatewayTools:
                 status="started",
                 job_id=job_id,
                 message=f"Installation started for '{server_name}'. Poll gateway.provision_status('{job_id}') for progress.",
-                update_warning=update_warning,
                 feedback_hint=None,
             )
 
@@ -4590,7 +4434,6 @@ class GatewayTools:
                 auth_state="missing_auth",
                 next_step=f"gateway.auth_connect(server_name='{server_name}')",
                 auth_metadata=self._auth_metadata_for_server(server_config),
-                update_warning=update_warning,
                 feedback_hint=self._feedback_hint(),
             )
 
@@ -4608,7 +4451,6 @@ class GatewayTools:
                 server=server_name,
                 status="failed",
                 message=self._sanitize_error(e),
-                update_warning=update_warning,
                 feedback_hint=self._feedback_hint(),
             )
 
@@ -4627,7 +4469,6 @@ class GatewayTools:
                 server=server_name,
                 status="failed",
                 message=f"Failed to start provisioning '{server_name}': {self._sanitize_error(e)}",
-                update_warning=update_warning,
                 feedback_hint=self._feedback_hint(),
             )
 
@@ -5219,15 +5060,14 @@ class GatewayTools:
             {"server_name": server_name, "force": parsed.force}
         )
 
-        # `desc.version` (an upstream snapshot from the last `pmcp
-        # refresh`/describe pass, not "installed version") is what every stale
-        # "update available" notice emission site reads (_get_update_warning,
-        # catalog_search's stale_updates, the background stale sweep). Only
-        # bump/persist it -- and only clear the memoized stale-check entry --
-        # once the server has actually been restarted onto the new package.
-        # If the restart failed or was refused, the gateway is still serving
-        # the OLD version, so the notice is still telling the truth and must
-        # be left alone.
+        # `desc.version` is an upstream snapshot from the last `pmcp
+        # refresh`/describe pass, NOT the installed version -- pmcp cannot
+        # observe which artifact a running server executes, which is why the
+        # automatic update notices were removed (Consiliency/pmcp#150). It is
+        # still recorded here so the descriptions cache reflects what this
+        # update fetched, and only once the server has actually been restarted
+        # onto the new package: a failed or refused restart means the gateway
+        # is still serving the old version.
         now = time.time()
         if restart_result.ok:
             if latest_version:
@@ -5282,20 +5122,6 @@ class GatewayTools:
                                 f"Failed to persist descriptions cache after updating "
                                 f"'{server_name}': {e}"
                             )
-                # Repopulate (not just pop) with the fresh (current, latest)
-                # pair so catalog_search's stale_updates -- which reads
-                # _stale_check_cache directly -- agrees the server is current
-                # immediately, instead of leaving a hole that a later
-                # _get_update_warning/_run_stale_index recompute would refill
-                # from the (now-stale) descriptions value.
-                self._stale_check_cache[server_name] = (
-                    now,
-                    latest_version,
-                    latest_version,
-                    package_type,
-                )
-            else:
-                self._stale_check_cache.pop(server_name, None)
 
             message = (
                 f"Updated and restarted '{server_name}' ({package_type}:{package_name}); "

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -636,7 +636,6 @@ class CatalogSearchOutput(BaseModel):
     # started (no cached tools). Surfaced when include_offline=True so agents can
     # provision the exact server instead of falling back to web search (#78).
     manifest_candidates: list[CapabilityCandidate] = Field(default_factory=list)
-    stale_updates: list[str] | None = None
 
 
 class DescribeInput(BaseModel):
@@ -688,7 +687,6 @@ class SchemaCard(BaseModel):
     invoke_template: InvokeTemplate | None = None
     # L2: Minimal code example (3-4 lines, opt-in via guidance config)
     code_snippet: str | None = None
-    update_warning: str | None = None
     feedback_hint: str | None = None
 
 
@@ -751,7 +749,6 @@ class InvokeOutput(BaseModel):
     summary: str | None = None
     raw_size_estimate: int
     errors: list[str] | None = None
-    update_warning: str | None = None
     feedback_hint: str | None = None
     missing_env_vars: list[str] = Field(default_factory=list)
     auth_state: AuthState = "none"
@@ -1201,7 +1198,6 @@ class ProvisionOutput(BaseModel):
     auth_metadata: AuthMetadataInfo | None = None
     auth_challenge: AuthChallengeInfo | None = None
     url_elicitations: list[UrlElicitationInfo] | None = None
-    update_warning: str | None = None
     feedback_hint: str | None = None
 
 

--- a/tests/test_scoped_advisor_audit.py
+++ b/tests/test_scoped_advisor_audit.py
@@ -208,12 +208,6 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
         raise AssertionError("scoped catalog attempted registry discovery")
 
     server._gateway_tools._registry_candidates_for_query = fail_registry_discovery  # type: ignore[method-assign]
-    server._gateway_tools._stale_check_cache["firecrawl"] = (
-        time.time(),
-        "1.0.0",
-        "2.0.0",
-    )
-
     catalog = await call_handler(
         "gateway.catalog_search",
         {"query": "native cli execution path", "include_offline": True},
@@ -222,7 +216,6 @@ async def test_scoped_server_filters_controls_and_writes_private_complete_audit(
     assert catalog_payload["cli_hints"] == []
     assert catalog_payload["registry_candidates"] == []
     assert catalog_payload["manifest_candidates"] == []
-    assert catalog_payload["stale_updates"] is None
 
     invoked = await call_handler(
         "gateway.invoke",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,7 +10,6 @@ import time
 from typing import Any, cast
 import types
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -1405,6 +1404,70 @@ class TestRefreshConfigUnchanged:
             config=RemoteMcpServerConfig(url="https://x"),
         )
         assert _refresh_config_unchanged(local, remote) is False
+
+
+class TestAutomaticUpdateNoticesRemoved:
+    """Consiliency/pmcp#150: the gateway no longer volunteers update notices.
+
+    Eight attempts failed to make the notice trustworthy, because pmcp cannot
+    observe which package artifact a running server is executing. The advisor
+    board's conclusion was to remove the feature rather than ship a claim that
+    can be wrong in both directions. `gateway.update_server` keeps reporting
+    versions on request -- that path is explicitly retained.
+
+    These tests assert the removal is COMPLETE. A half-removal is the failure
+    mode: `provision` alone carried 20 of the 26 attachment sites, and a missed
+    one would call a deleted method at runtime.
+    """
+
+    def test_no_notice_fields_on_public_output_models(self) -> None:
+        """The removed fields are gone from every output model that carried them.
+
+        Checked against the model fields rather than a live call: today
+        `server.py` serialises with `model_dump()` and no `exclude_none`, so a
+        surviving field would be emitted on the wire as an explicit null.
+        """
+        from pmcp.types import (
+            CatalogSearchOutput,
+            InvokeOutput,
+            ProvisionOutput,
+            SchemaCard,
+        )
+
+        assert "stale_updates" not in CatalogSearchOutput.model_fields
+        for model in (SchemaCard, InvokeOutput, ProvisionOutput):
+            assert "update_warning" not in model.model_fields, model.__name__
+
+    def test_no_notice_machinery_on_gateway_tools(self) -> None:
+        """The emission helpers and the background indexer are gone.
+
+        Named explicitly so a future re-introduction has to be deliberate rather
+        than accidental -- `hasattr` here is the cheap guard that the source
+        grep in the PR cannot enforce over time.
+        """
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        for attr in (
+            "_get_update_warning",
+            "_run_stale_index",
+            "_stale_indexer_loop",
+            "start_stale_indexer",
+            "stop_stale_indexer",
+            "_stale_check_cache",
+        ):
+            assert not hasattr(gt, attr), f"{attr} survived the removal"
+
+    @pytest.mark.asyncio
+    async def test_catalog_search_emits_no_stale_updates(self) -> None:
+        """A real catalog_search payload carries no notice key at all."""
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+        result = await gt.catalog_search({"query": "anything"})
+        assert "stale_updates" not in result.model_dump()
 
 
 class TestCatalogSearch:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2410,9 +2410,6 @@ class TestInvoke:
             client_manager=client_manager,  # type: ignore
             policy_manager=PolicyManager(),
         )
-        monkeypatch.setattr(
-            gateway_tools, "_get_update_warning", AsyncMock(return_value=None)
-        )
 
         started = asyncio.Event()
         release = asyncio.Event()
@@ -4303,40 +4300,6 @@ class TestCapabilityAndProvision:
         assert isinstance(probe_calls["env"], dict)
 
     @pytest.mark.asyncio
-    async def test_invoke_includes_update_warning(self, monkeypatch):
-        tools = [
-            ToolInfo(
-                tool_id="playwright::snapshot",
-                server_name="playwright",
-                tool_name="snapshot",
-                description="Take snapshot",
-                short_description="Take snapshot",
-                input_schema={"type": "object", "properties": {}},
-                tags=["browser"],
-                risk_hint=RiskHint.LOW,
-            )
-        ]
-        client_manager = MockClientManager(tools)
-        client_manager.set_server_online("playwright")
-        policy_manager = PolicyManager()
-        gateway_tools = GatewayTools(
-            client_manager=client_manager,  # type: ignore
-            policy_manager=policy_manager,
-        )
-
-        async def fake_update_warning(server_name: str):
-            return "Update available for 'playwright': 0.1.0 -> 0.2.0"
-
-        monkeypatch.setattr(gateway_tools, "_get_update_warning", fake_update_warning)
-
-        result = await gateway_tools.invoke(
-            {"tool_id": "playwright::snapshot", "arguments": {}}
-        )
-
-        assert result.ok is True
-        assert result.update_warning is not None
-
-    @pytest.mark.asyncio
     async def test_submit_feedback_preview_includes_telemetry_and_scrubs(
         self, monkeypatch
     ):
@@ -4623,246 +4586,6 @@ class TestSearchRegistryAndRegister:
         assert connected.name == "excalidraw"
         assert connected.config.type == "streamable-http"
         assert connected.config.url == "https://mcp.excalidraw.com"
-
-
-class TestStaleIndexer:
-    """Tests for background stale-version indexer and catalog_search stale_updates."""
-
-    def _make_gateway_tools(self, descriptions_cache=None):
-        client_manager = MockClientManager()
-        policy_manager = PolicyManager()
-        gt = GatewayTools(
-            client_manager=client_manager,  # type: ignore
-            policy_manager=policy_manager,
-            descriptions_cache=descriptions_cache,
-        )
-        return gt
-
-    def _make_manifest_with_playwright(self, monkeypatch):
-        manifest = Manifest(
-            version="1.0",
-            cli_alternatives={},
-            servers={
-                "playwright": ServerConfig(
-                    name="playwright",
-                    description="Browser automation",
-                    keywords=["browser"],
-                    install={},
-                    command="npx",
-                    args=["-y", "@playwright/mcp"],
-                    requires_api_key=False,
-                )
-            },
-            discovery_queue_path=".mcp-gateway/discovery_queue.json",
-        )
-        monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: manifest)
-        return manifest
-
-    @pytest.mark.asyncio
-    async def test_run_stale_index_populates_cache(self, monkeypatch):
-        """_run_stale_index populates _stale_check_cache without a warm cache."""
-        from pmcp.types import DescriptionsCache, GeneratedServerDescriptions
-
-        cache = DescriptionsCache(
-            generated_at="2024-01-01T00:00:00",
-            gateway_version="1.0.0",
-            servers={
-                "playwright": GeneratedServerDescriptions(
-                    package="@playwright/mcp",
-                    version="0.1.0",
-                    generated_at="2024-01-01T00:00:00",
-                    capability_summary="Browser automation",
-                    tools=[],
-                )
-            },
-        )
-        gt = self._make_gateway_tools(descriptions_cache=cache)
-        self._make_manifest_with_playwright(monkeypatch)
-
-        async def fake_get_package_version(command, args, timeout=5.0):
-            return ("0.2.0", "npm")
-
-        monkeypatch.setattr(
-            "pmcp.tools.handlers.get_package_version", fake_get_package_version
-        )
-
-        await gt._run_stale_index()
-
-        assert "playwright" in gt._stale_check_cache
-        _, current, latest, _pkg = gt._stale_check_cache["playwright"]
-        assert current == "0.1.0"
-        assert latest == "0.2.0"
-
-    @pytest.mark.asyncio
-    async def test_run_stale_index_skips_fresh_cache(self, monkeypatch):
-        """_run_stale_index skips servers whose cache entry is still fresh."""
-        import time
-        from pmcp.types import DescriptionsCache, GeneratedServerDescriptions
-
-        cache = DescriptionsCache(
-            generated_at="2024-01-01T00:00:00",
-            gateway_version="1.0.0",
-            servers={
-                "playwright": GeneratedServerDescriptions(
-                    package="@playwright/mcp",
-                    version="0.1.0",
-                    generated_at="2024-01-01T00:00:00",
-                    capability_summary="Browser automation",
-                    tools=[],
-                )
-            },
-        )
-        gt = self._make_gateway_tools(descriptions_cache=cache)
-        self._make_manifest_with_playwright(monkeypatch)
-
-        # Pre-populate cache as fresh
-        gt._stale_check_cache["playwright"] = (time.time(), "0.1.0", "0.1.0", "npm")
-
-        network_called = []
-
-        async def fake_get_package_version(command, args, timeout=5.0):
-            network_called.append(True)
-            return ("0.2.0", "npm")
-
-        monkeypatch.setattr(
-            "pmcp.tools.handlers.get_package_version", fake_get_package_version
-        )
-
-        await gt._run_stale_index()
-
-        assert not network_called, "Network should not be called when cache is fresh"
-
-    @pytest.mark.asyncio
-    async def test_run_stale_index_no_descriptions_cache(self):
-        """_run_stale_index is a no-op when no descriptions cache is present."""
-        gt = self._make_gateway_tools(descriptions_cache=None)
-        # Should not raise
-        await gt._run_stale_index()
-
-    @pytest.mark.asyncio
-    async def test_catalog_search_includes_stale_updates(self, monkeypatch):
-        """catalog_search returns stale_updates when indexer has detected stale servers."""
-        import time
-
-        tools = [
-            ToolInfo(
-                tool_id="playwright::snapshot",
-                server_name="playwright",
-                tool_name="snapshot",
-                description="Take snapshot",
-                short_description="Take snapshot",
-                input_schema={"type": "object", "properties": {}},
-                tags=["browser"],
-                risk_hint=RiskHint.LOW,
-            )
-        ]
-        client_manager = MockClientManager(tools)
-        client_manager.set_server_online("playwright")
-        gt = GatewayTools(
-            client_manager=client_manager,  # type: ignore
-            policy_manager=PolicyManager(),
-        )
-
-        # Pre-populate stale check cache with a stale entry
-        gt._stale_check_cache["playwright"] = (time.time(), "0.1.0", "0.2.0", "npm")
-
-        result = await gt.catalog_search({})
-
-        assert result.stale_updates is not None
-        assert len(result.stale_updates) == 1
-        assert "playwright" in result.stale_updates[0]
-        assert "0.1.0" in result.stale_updates[0]
-        assert "0.2.0" in result.stale_updates[0]
-
-    @pytest.mark.asyncio
-    async def test_catalog_search_orders_npm_prereleases_by_semver(self) -> None:
-        """catalog_search must use the memo's ecosystem, not PEP 440.
-
-        Board review: the memo previously stored only (checked_at, current,
-        latest), so this read site fell back to PEP 440. npm publishes SemVer,
-        where `1.0.0-1` is a PRERELEASE below `1.0.0`; PEP 440 reads it as the
-        POST-release `1.0.0.post1`. That inversion both HID the real
-        `1.0.0-1 -> 1.0.0` upgrade and FABRICATED its reverse -- reachable
-        through catalog_search even after the direct paths were fixed.
-        """
-        client_manager = MockClientManager()
-        client_manager.set_server_online("playwright")
-        gt = GatewayTools(
-            client_manager=client_manager,  # type: ignore
-            policy_manager=PolicyManager(),
-        )
-
-        # A real npm upgrade: prerelease -> release. Must be reported.
-        gt._stale_check_cache["playwright"] = (time.time(), "1.0.0-1", "1.0.0", "npm")
-        result = await gt.catalog_search({})
-        assert result.stale_updates is not None
-        assert "1.0.0-1" in result.stale_updates[0]
-
-        # The reverse is NOT an upgrade and must not be announced.
-        gt._stale_check_cache["playwright"] = (time.time(), "1.0.0", "1.0.0-1", "npm")
-        result = await gt.catalog_search({})
-        assert not (result.stale_updates or [])
-        assert result.cli_hints == []
-
-    @pytest.mark.asyncio
-    async def test_catalog_search_stale_updates_coexist_with_cli_hints(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """catalog_search serializes stale_updates independently from cli_hints."""
-        import time
-
-        tools = [
-            ToolInfo(
-                tool_id="playwright::snapshot",
-                server_name="playwright",
-                tool_name="snapshot",
-                description="Take snapshot",
-                short_description="Take snapshot",
-                input_schema={"type": "object", "properties": {}},
-                tags=["browser"],
-                risk_hint=RiskHint.LOW,
-            )
-        ]
-        client_manager = MockClientManager(tools)
-        client_manager.set_server_online("playwright")
-        gt = GatewayTools(
-            client_manager=client_manager,  # type: ignore
-            policy_manager=PolicyManager(),
-        )
-        gt._detected_cli_infos = {"git": CLIInfo(name="git", path="/usr/bin/git")}
-        gt._stale_check_cache["playwright"] = (time.time(), "0.1.0", "0.2.0", "npm")
-        monkeypatch.setattr(
-            "pmcp.tools.handlers.load_manifest", create_manifest_for_request_tests
-        )
-
-        result = await gt.catalog_search({"query": "git"})
-
-        assert result.stale_updates is not None
-        assert "playwright" in result.stale_updates[0]
-        assert result.cli_hints[0].name == "git"
-
-    @pytest.mark.asyncio
-    async def test_catalog_search_no_stale_updates_when_up_to_date(self):
-        """catalog_search returns None for stale_updates when all servers are up to date."""
-        import time
-
-        gt = self._make_gateway_tools()
-        gt._stale_check_cache["playwright"] = (time.time(), "0.2.0", "0.2.0", "npm")
-
-        result = await gt.catalog_search({})
-
-        assert result.stale_updates is None
-
-    @pytest.mark.asyncio
-    async def test_start_stop_stale_indexer(self):
-        """start_stale_indexer creates a task; stop_stale_indexer cancels it."""
-        gt = self._make_gateway_tools()
-
-        gt.start_stale_indexer()
-        assert gt._stale_index_task is not None
-        assert not gt._stale_index_task.done()
-        gt.stop_stale_indexer()
-        assert gt._stale_index_task is None
 
 
 class TestUpdateProbeProcessCleanup:
@@ -5166,75 +4889,6 @@ class TestUpdateServerVersionRepair:
         assert cache.servers["playwright"].version == "0.2.0"
 
     @pytest.mark.asyncio
-    async def test_update_server_clears_get_update_warning(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """_get_update_warning must stop reporting the update as available.
-
-        Reproduces the maintainer's report: gateway.update_server("context7")
-        reported success but the notice kept recurring on every subsequent
-        call.
-        """
-        self._make_manifest_with_playwright(monkeypatch)
-        cache = self._make_cache(version="0.1.0")
-        gt = GatewayTools(
-            client_manager=MockClientManager(),  # type: ignore
-            policy_manager=PolicyManager(),
-            descriptions_cache=cache,
-        )
-        self._wire_success(gt, monkeypatch, latest_version="0.2.0")
-
-        await gt.update_server({"server_name": "playwright"})
-
-        warning = await gt._get_update_warning("playwright")
-        assert warning is None
-
-    @pytest.mark.asyncio
-    async def test_update_server_clears_catalog_search_stale_updates(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """catalog_search's stale_updates must also stop naming the server.
-
-        This is the trap: update_server's own _stale_check_cache.pop() would
-        already make an *immediate* catalog_search go quiet, so that alone
-        doesn't discriminate the fix. Force the recompute that production
-        traffic would trigger (a follow-up _get_update_warning, or the
-        background stale sweep) before checking catalog_search, so a
-        left-behind stale descriptions value has a chance to leak back in.
-        """
-        tools = [
-            ToolInfo(
-                tool_id="playwright::snapshot",
-                server_name="playwright",
-                tool_name="snapshot",
-                description="Take snapshot",
-                short_description="Take snapshot",
-                input_schema={"type": "object", "properties": {}},
-                tags=["browser"],
-                risk_hint=RiskHint.LOW,
-            )
-        ]
-        client_manager = MockClientManager(tools)
-        client_manager.set_server_online("playwright")
-        self._make_manifest_with_playwright(monkeypatch)
-        cache = self._make_cache(version="0.1.0")
-        gt = GatewayTools(
-            client_manager=client_manager,  # type: ignore
-            policy_manager=PolicyManager(),
-            descriptions_cache=cache,
-        )
-        self._wire_success(gt, monkeypatch, latest_version="0.2.0")
-
-        await gt.update_server({"server_name": "playwright"})
-        # Force the same recompute _get_update_warning or the background
-        # sweep would perform on the next call.
-        await gt._get_update_warning("playwright")
-
-        result = await gt.catalog_search({})
-
-        assert result.stale_updates is None
-
-    @pytest.mark.asyncio
     async def test_update_server_persists_version_across_restart(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -5311,7 +4965,6 @@ class TestUpdateServerVersionRepair:
         assert result.restarted is True
         assert result.latest_version is None
         assert cache.servers["playwright"].version == "0.1.0"
-        assert "playwright" not in gt._stale_check_cache
 
     @pytest.mark.asyncio
     async def test_update_server_restart_failure_leaves_notice_intact(
@@ -5345,11 +4998,6 @@ class TestUpdateServerVersionRepair:
         assert result.restarted is False
         assert "could not restart" in result.message.lower()
         assert cache.servers["playwright"].version == "0.1.0"
-        assert "playwright" not in gt._stale_check_cache
-
-        warning = await gt._get_update_warning("playwright")
-        assert warning is not None
-        assert "0.1.0" in warning and "0.2.0" in warning
 
     @pytest.mark.asyncio
     async def test_update_server_force_cancels_pending_and_activates(
@@ -5563,7 +5211,6 @@ class TestUpdateServerVersionRepair:
         assert probe_calls == []  # never even attempted
         assert "disconnect_server:playwright:False" not in client_manager.events
         assert cache.servers["playwright"].version == "0.1.0"
-        assert "playwright" not in gt._stale_check_cache
 
     @pytest.mark.asyncio
     async def test_update_server_refuses_pinned_docker_tag(
@@ -5620,7 +5267,6 @@ class TestUpdateServerVersionRepair:
         assert "1.2.3" in result.message
         assert probe_calls == []  # never even attempted
         assert cache.servers["playwright"].version == "0.1.0"
-        assert "playwright" not in gt._stale_check_cache
 
     def test_detect_effective_version_pin_matrix(self):
         """Pin detection per package manager, including the not-a-pin cases."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1459,6 +1459,32 @@ class TestAutomaticUpdateNoticesRemoved:
         ):
             assert not hasattr(gt, attr), f"{attr} survived the removal"
 
+    def test_exported_tool_descriptions_do_not_promise_notices(self) -> None:
+        """The tools/list prose must not tell agents to wait for a notice.
+
+        Board review of this PR: `gateway.update_server`'s description still read
+        "Use this when invoke/describe/provision warn that a newer version is
+        available" -- shipped to every client through `tools/list`, instructing
+        agents to wait for notices that no longer exist.
+
+        The identifier grep that verified this removal could not catch it,
+        because it is PROSE, not a symbol. This test closes that class of gap.
+        """
+        from pmcp.tools.handlers import get_gateway_tool_definitions
+
+        forbidden = (
+            "warn that a newer version",
+            "newer version is available",
+            "update_warning",
+            "stale_updates",
+        )
+        for tool in get_gateway_tool_definitions():
+            text = (tool.description or "").lower()
+            for phrase in forbidden:
+                assert phrase.lower() not in text, (
+                    f"{tool.name} description still promises update notices: {phrase!r}"
+                )
+
     @pytest.mark.asyncio
     async def test_catalog_search_emits_no_stale_updates(self) -> None:
         """A real catalog_search payload carries no notice key at all."""


### PR DESCRIPTION
Closes #150.

Removes the automatic "update available" notices. `gateway.update_server` is unchanged — it still probes, reports, restarts and refuses pinned servers. What goes away is the gateway *volunteering* a claim it cannot substantiate.

## Why removal rather than a ninth fix

Eight attempts failed at one joint: **pmcp cannot observe which package artifact a running server is executing.** Not from `descriptions_cache.version` (an upstream snapshot taken at describe time), not from `serverInfo.version` (an *implementation* version — FastMCP 1.x reports the SDK's, mcp 2.x defaults to `""`), not from the npx/uv runner caches (no server→entry binding; one package was observed cached at 1.2.0, 1.2.1 and 1.2.2 concurrently), and not from spawn argv (npm resolves *after* `create_subprocess_exec` returns).

The only remaining method — running each server's own `--version` — was rejected 3/3 by the review board as disqualifying: it is a **full launch** of the server's argv with its **real credentials**, on a schedule. For a manifest entry using `@latest` it could execute newly published code with those credentials before the operator chose to update. Measured: probing one flag-ignoring server spawned 7 processes and opened 5 sockets. Coverage would have been ~50% even then.

The full analysis for all eight attempts is committed under `.consiliency/plans/`.

## What this is: a breaking change to tool output

`update_warning` and `stale_updates` are **removed from the schemas**, not left permanently empty. `server.py` serialises with `model_dump()` and no `exclude_none`, so those keys are emitted today as explicit nulls — verified — which means their absence is a real wire change for a client doing key-presence checks.

The board recommended outright removal over keeping always-`None` fields or deprecating across a release: a field that can never be populated advertises a capability pmcp no longer has.

## Scope

| | |
|---|---|
| `update_warning=` attachment sites | **26** → 0 (`describe` 1, `invoke` 5, **`provision` 20**) |
| `_get_update_warning` calls | 3 → 0 |
| Background indexer + lifecycle calls | removed (`server.py` ×2) |
| Public schema fields | 4 removed |
| Tests | 11 notice tests removed, 3 guards added |

**I miscounted the attachment sites twice before the board caught it** — first 6, then 16, when the real number is 26. `provision` alone holds 20. The plan was corrected to mandate driving `grep -c` to zero rather than working from any hand-written list, and that is how the edit was performed.

Two other findings while implementing: `_effective_notice_target` and `_notice_package_matches_cache` never existed on `main` (dead residue of the abandoned #154 branch), and the README had **two** obsolete lines, not the one the plan identified — the second promised "background stale-version indexing is active".

## Verification

- `pytest -q` → **2547 passed, 3 skipped, 0 failed** (2555 baseline − 11 removed + 3 added)
- `ruff check .`, `ruff format --check src/ tests/`, `mypy src` — clean
- **Completeness**: `grep -rn 'update_warning|stale_updates|_stale_check_cache|_stale_index|_get_update_warning' src/ tests/` returns **nothing**
- **Guard proof**: partially re-introducing the feature (one schema field + one attribute) fails all three new tests. They catch a re-introduction rather than passing vacuously — the failure mode that has bitten this issue repeatedly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789777809&installation_model_id=427051&pr_number=159&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F159&signature=cee2b29913b3170d6dbd728318fd062f1d3fa7742c06593a6c8676ebf521834f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->