### PR TITLE
chore: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-20
+
 ### Removed
 - **Automatic "update available" notices.** `gateway.describe`, `gateway.invoke`
   and `gateway.provision` no longer return `update_warning`,
@@ -40,8 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   breaks the next launch. The probe now spawns as a process-group leader and
   reaps the group on timeout or cancellation.
 
-
-### Fixed
 - **Update notices are no longer fabricated for servers whose version is not a
   release number.** The version comparison extracted digits from whatever it was
   given and had no way to say "I cannot read this", so a server reporting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.1.1"
+version = "2.2.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.1.1"
+__version__ = "2.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **2.2.0** from the three merged fixes: #155, #157, #159.

## Why minor, not patch

#159 removes four fields from public tool output — `update_warning` from `describe`/`invoke`/`provision`, and `stale_updates` from `catalog_search`. Those were emitted on the wire as explicit nulls (`model_dump()` runs without `exclude_none`), so a client doing a key-presence check sees a real change. That is a breaking change to the tool surface, so patch would be wrong.

## What's in it

All three commits are one coherent theme — **version handling that told the truth or said nothing**:

- **#155** — version comparison fails closed. A server reporting `nightly`, `build-1` or an empty string previously compared as *older* than any real release and produced an update notice that was never true. An empty version is the current MCP SDK default, so this was reachable in ordinary use. Now uses `packaging.version`.
- **#157** — the update probe no longer orphans its process tree on timeout. It spawns as a process-group leader and reaps the group, so a package that ignores the probe flag no longer leaves a browser holding the Playwright profile lock.
- **#159** — the automatic update notices are removed outright, after eight attempts to make them correct. The gateway cannot observe which artifact a running server executes, so the notice could be wrong in both directions.

I verified #155 and #157 are **not** made dead by #159: `is_version_newer`/`is_version_orderable` still back `refresher.py` (the `pmcp refresh --check-versions` path), and the probe fix still backs `update_server`. Nothing shipped here is unreachable.

## What users get

`gateway.update_server` and `pmcp refresh --check-versions` still report versions **on request**. What's gone is the gateway volunteering a claim it could not substantiate.

## Housekeeping folded in

- Merged the **two duplicate `### Fixed` headings** that accumulated under `[Unreleased]` from three separate PRs.
- Synced `src/pmcp/__init__.py:__version__`, which was still `2.1.1` — bumping `pyproject.toml` alone would have shipped a runtime version that disagreed with the package metadata.

## Verification

- `pytest -q` → **2548 passed, 3 skipped, 0 failed**
- `ruff check .`, `mypy src` — clean
- Version agreement asserted at runtime: `pmcp.__version__ == pyproject version == 2.2.0`

## Known, deliberately not blocking

#156 (semver follow-ups) and #151 (update_server TOCTOU) are pre-existing and present in 2.1.1 — not regressions from these commits — so holding the release would delay the fabricated-notice fix without protecting anyone.

Worth flagging: **#151 is more severe as of #159.** With the notices gone, `update_server` is the sole update path, so a config-resolution race there no longer has a second mechanism around it. Recommend it as the next piece of work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789822090&installation_model_id=427051&pr_number=160&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F160&signature=404b394dbf062e7c01af5802353fdb4a265091ae78b5e24ce6e2ac4d478d28b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->