### PR TITLE
fix: update_server verifies config after the probe (#151)

### DIFF
--- a/.consiliency/plans/detailed-update-server-toctou-20260820-1300.md
+++ b/.consiliency/plans/detailed-update-server-toctou-20260820-1300.md
@@ -41,10 +41,23 @@ It is explicitly **not** "the config on disk at the instant the restart complete
 
 - `_restart_resolved_server` — **add** — private helper holding the post-resolve body of `restart_server`: active-task accounting, the `_client_manager.restart_server(config, force=...)` call, and `_lifecycle_output` shaping. Signature `(self, server_name: str, config: ResolvedServerConfig, *, force: bool, prior_status: str) -> LifecycleServerOutput`.
 - `restart_server` — **modify** — becomes resolve + delegate to the helper. **Behaviour must be byte-identical**; this is a pure extraction and any observable change is a bug in the refactor.
+**Board correction — the check must precede `refresh()`, not merely precede the restart.** My first implementation placed the guard immediately before the restart, which two reviewers independently blocked. Between the probe and the restart, `update_server` calls `await self.refresh(...)` — and `refresh()` is itself a **diff-based config reconcile**: it re-reads the config and disconnects/reconnects any server whose definition changed. So a mid-probe edit could cause `refresh()` to **activate the freshly-fetched package on its own**, after which the guard would report "fetched but NOT activated" — a false statement.
+
+Worse, it defeats the test I had planned. `refresh()` activates through `disconnect_server` + `connect_all`, **not** `restart_server`, so the planned assertion "`_client_manager.restart_server` was never called" would have passed while the bug survived. That is the exact failure mode this plan's test section warns about, and I walked into it.
+
+The guard therefore sits immediately after the probe's success check and **before** `refresh()`. The tests must assert the target's actual connect/disconnect state, not just that `restart_server` was skipped.
+
 - `update_server` — **modify** — after the probe returns:
   1. **Recompute `prior_status`.** The pre-probe value is up to 60 seconds stale. Use the fresh value for resolve#2 and the helper.
   2. Resolve #2 via `_resolve_lifecycle_config`. On failure, return `UpdateServerOutput(ok=False, ...)` exactly as the pre-probe failure path does. This also covers *server deleted from config mid-probe* for free.
-  3. Compare resolve#2's `ResolvedServerConfig` against resolve#1's with a **strict full-model `==`, including `source`**. A benign `source` flip (e.g. the same config moving project→user) will refuse; that is rare and fails closed, which is the correct bias here.
+  3. Compare resolve#2 against resolve#1 using the **existing `_refresh_config_unchanged(old, new)`** (`handlers.py:177`).
+
+     **Correction to this plan, found while implementing — the original said "strict full-model `==`, including `source`", and that was wrong.** `handlers.py` already carries a battle-tested predicate for exactly this question ("do these two describe the same downstream process?"), and it deliberately does *not* use full-model equality. Its docstring records why, and both reasons apply here:
+
+     * **`env` is compared by *effective* override only** — entries that genuinely differ from `os.environ`. Naive full-`env` comparison "would spuriously tear down running provisioned servers on every refresh (issue #79)". A full-model `==` in `update_server` would reintroduce that class as **spurious refusals of legitimate updates**.
+     * **`source` is excluded deliberately** — the same effective server can present as `manifest` or as a configured source. My original plan called over-refusal on a source flip "rare and fails closed". That was a judgement made without reading this function; the codebase had already decided the question, with a linked issue.
+
+     Reusing it also keeps **one** definition of "same server" instead of a second, subtly different one. `update_server` only reaches the comparison for local servers (remote returns early — no local package to update), so only the `LocalMcpServerConfig` branch is exercised; the header-rotation logic is inert here and needs no arguments.
   4. On mismatch — refuse. Return `ok=False` with a message saying the configuration changed during the update and the package was **fetched but not activated**, and do **not** restart, do **not** persist any version bookkeeping.
   5. On match — call `_restart_resolved_server` with **resolve#2's config object**. Since it is equal to #1 the choice is immaterial by construction; using the compared object is what makes the window exactly zero rather than one event-loop tick.
 - The comment block at `4924-4936` — **rewrite**. It currently asserts *"Resolving once through restart_server's own resolver makes that divergence impossible: both calls are the same lookup against the same inputs, so they can't disagree."* The premise "same inputs" is exactly what a mid-probe edit breaks. The issue names this comment specifically.

--- a/.consiliency/plans/detailed-update-server-toctou-20260820-1300.md
+++ b/.consiliency/plans/detailed-update-server-toctou-20260820-1300.md
@@ -1,0 +1,124 @@
+# Detailed plan: close the update_server TOCTOU window
+
+## Task
+
+Fix Consiliency/pmcp#151. `gateway.update_server` resolves the target server's config, runs an update probe with a **60-second** timeout, and then calls `self.restart_server(...)`, which resolves the config **again**. A config edit landing inside that window means pmcp can probe and install package A, restart onto package B, and persist A's version bookkeeping for B.
+
+Severity rose with 2.2.0. #159 removed the automatic update notices, so `gateway.update_server` is now the **sole** update path — there is no second mechanism around a config-resolution race here.
+
+## Research summary
+
+Verified against source at `c326a4c` (post-2.2.0). Line numbers below were read in this session; #159 shifted everything in `handlers.py` by ~193 lines, so the numbers in the issue text are stale.
+
+**The two reads.**
+
+| # | Site | What it feeds |
+|---|---|---|
+| 1 | `update_server` → `_resolve_lifecycle_config` (`handlers.py:4938`) | the probe command/args/env, and the version bookkeeping persisted afterwards |
+| 2 | `restart_server` → `_resolve_lifecycle_config` (`handlers.py:2827`), reached from `update_server` at `5058` | what actually gets restarted |
+
+Between them: `await self._run_update_probe_command(...)` (`5018`), bounded at 60s.
+
+**Correction to the issue's own fix sketch — verified, not assumed.** The issue says threading the resolved config through to the restart "would mean either duplicating [policy checks, credential-gap detection, and remote-header validation] or accepting their loss." That is **wrong**. All three checks live inside `_resolve_lifecycle_config` itself (`handlers.py:3237-3295`): policy at `3238`, remote-header env vars at `3253`, configured-duplicate credential gap at `3268`. Read #1 already performs every one of them.
+
+What `restart_server` adds *beyond* the resolver is only: input parsing (`force`), `prior_status`, active-task accounting before/after, the `_client_manager.restart_server` call, and `_lifecycle_output` shaping. That is why the helper extraction below is cheap and loses nothing.
+
+**The compare is not vacuous — checked because it would have invalidated the design.** Neither `load_configs` (`config/loader.py:754`) nor `load_manifest` (`manifest/loader.py:754`) is `lru_cache`/`@cache`-decorated, and neither module holds a `_cache`/`_memo` at module level. Both re-read from disk on every call. Consequence: resolve#2 genuinely observes a mid-probe edit, and **the race is reachable through both the `.mcp.json` branch and the manifest branch** — not just the former.
+
+**Blast radius of the extraction.** `restart_server` has exactly two callers: the tool dispatch at `server.py:350` and `update_server` at `handlers.py:5058`. Nothing in the CLI calls it. Carving out a private helper cannot affect anything else.
+
+**`ResolvedServerConfig`** (`types.py:319`) is a plain pydantic `BaseModel` with `name`, `source`, `config` — so `==` is structural equality, no custom comparator needed.
+
+## The contract this fix establishes
+
+> The config restarted onto is the config that was probed.
+
+It is explicitly **not** "the config on disk at the instant the restart completes." An edit landing after the comparison applies on the *next* update — that is correct behaviour, not a residual race. State this in the PR so a reviewer does not read the remaining (unavoidable) gap as an incomplete fix.
+
+## Changes
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_restart_resolved_server` — **add** — private helper holding the post-resolve body of `restart_server`: active-task accounting, the `_client_manager.restart_server(config, force=...)` call, and `_lifecycle_output` shaping. Signature `(self, server_name: str, config: ResolvedServerConfig, *, force: bool, prior_status: str) -> LifecycleServerOutput`.
+- `restart_server` — **modify** — becomes resolve + delegate to the helper. **Behaviour must be byte-identical**; this is a pure extraction and any observable change is a bug in the refactor.
+- `update_server` — **modify** — after the probe returns:
+  1. **Recompute `prior_status`.** The pre-probe value is up to 60 seconds stale. Use the fresh value for resolve#2 and the helper.
+  2. Resolve #2 via `_resolve_lifecycle_config`. On failure, return `UpdateServerOutput(ok=False, ...)` exactly as the pre-probe failure path does. This also covers *server deleted from config mid-probe* for free.
+  3. Compare resolve#2's `ResolvedServerConfig` against resolve#1's with a **strict full-model `==`, including `source`**. A benign `source` flip (e.g. the same config moving project→user) will refuse; that is rare and fails closed, which is the correct bias here.
+  4. On mismatch — refuse. Return `ok=False` with a message saying the configuration changed during the update and the package was **fetched but not activated**, and do **not** restart, do **not** persist any version bookkeeping.
+  5. On match — call `_restart_resolved_server` with **resolve#2's config object**. Since it is equal to #1 the choice is immaterial by construction; using the compared object is what makes the window exactly zero rather than one event-loop tick.
+- The comment block at `4924-4936` — **rewrite**. It currently asserts *"Resolving once through restart_server's own resolver makes that divergence impossible: both calls are the same lookup against the same inputs, so they can't disagree."* The premise "same inputs" is exactly what a mid-probe edit breaks. The issue names this comment specifically.
+- The comment at `5055` referencing "the same resolve+disconnect+connect machinery gateway.restart_server" — **review and correct** if it still implies a single resolve.
+
+**Sweep for the same claim elsewhere.** Grep comments, docstrings **and exported tool descriptions** for any surviving "resolved once" / "cannot disagree" wording. This is the exact gap class codex caught on #159: a symbol grep does not see prose, and `get_gateway_tool_definitions()` output ships to every client.
+
+### `tests/test_tools.py` (modify)
+
+- **add** — `test_update_server_refuses_when_config_changes_during_probe`. Monkeypatch `_run_update_probe_command` to **edit the config on disk** and then return success, exercising the real loader path (which also smokes out any caching that would make the compare vacuous). Assert **observables**, not internals:
+  - `_client_manager.restart_server` was **never called**
+  - `ok is False` and the message names the configuration change
+  - **the descriptions-cache version was not persisted** — this is the assertion that matters, because the bug class is "persist A's bookkeeping for B". A test that only checks `ok is False` would pass against a fix that still writes the wrong version.
+- **add** — `test_update_server_restarts_when_config_is_unchanged`. The happy path is byte-identical to today: restart happens, version persists, output fields unchanged.
+- **add** — `test_update_server_refuses_when_server_removed_during_probe`. Resolve#2 fails outright rather than differing.
+- Existing `update_server` and `restart_server` tests — **keep unchanged and passing.** The extraction is behaviour-preserving; if any existing test needs editing, that is evidence the refactor changed behaviour and must be re-examined rather than accommodated.
+
+**Prove the mismatch test RED against `c326a4c` before the fix lands.** Several tests in this series have passed while their bug survived, by asserting a mutated argument rather than an observable outcome. A test that cannot fail is worse than no test.
+
+### `CHANGELOG.md` (modify)
+
+`### Fixed` under `## [Unreleased]`. **Mandatory** — `main` is protected and the `changelog` check fails any PR touching `src/`. Note the raised severity: `update_server` is the only update path as of 2.2.0.
+
+## Documentation impact
+
+`README.md` — none expected; it documents `gateway.update_server`'s behaviour, which is unchanged on the happy path. Verify with a grep for update/restart wording rather than asserting it; a new refusal mode is user-visible if the README enumerates failure cases.
+
+## Frozen vocabulary / protocol check
+
+**No protocol change.** No new field on any output model — the refusal uses the existing `ok` and `message`. `RestartServerInput` is untouched; the new parameter is on a *private* method, not the tool schema. This matters: 2.2.0 just removed four public fields, and this fix must not add any back.
+
+## Dependencies & order
+
+1. Extract `_restart_resolved_server` and re-point `restart_server`. Full suite must pass **before** any behaviour change — that proves the extraction is inert.
+2. Add resolve#2 + compare + refusal in `update_server`.
+3. Rewrite the false comments; sweep for the same claim in prose and tool descriptions.
+4. Tests, then CHANGELOG.
+
+No new dependency. No migration.
+
+## Verification
+
+```bash
+cd /mnt/workspace/worktrees/pmcp-151-toctou
+uv run pytest tests/test_tools.py -q -k 'update_server or restart_server'
+uv run pytest -q          # 2548 baseline + 3 new; 0 failed
+uv run ruff check . && uv run ruff format --check src/ tests/ && uv run mypy src
+
+# The comment/prose sweep the identifier grep cannot do:
+grep -rn 'resolved once\|resolve once\|cannot disagree\|can.t disagree\|same inputs' src/
+```
+
+Edge cases: server removed from config mid-probe (covered); a remote server (no local package — `update_server` returns early, so resolve#2 is never reached); `force=True` interaction with the fresh `prior_status`; a probe that times out (returns before resolve#2, so no comparison happens — confirm that path is unchanged).
+
+## Acceptance criteria
+
+- [ ] A config edit during the probe window causes a refusal, proven by `test_update_server_refuses_when_config_changes_during_probe` asserting the restart never happened **and** no version was persisted — and proven RED against `c326a4c`.
+- [ ] The unchanged-config path is behaviour-identical, proven by the existing `update_server`/`restart_server` tests passing **without modification**.
+- [ ] No comment, docstring, or exported tool description still claims the config is resolved once or cannot disagree — proven by the prose sweep returning nothing.
+- [ ] Full suite passes, 0 failures; ruff, format, mypy clean; `### Fixed` CHANGELOG entry present.
+
+## Non-goals
+
+- **Locking the config file.** Out of scope and wrong shape: pmcp does not own `.mcp.json`, and the operator's editor is not going to honour an advisory lock.
+- **Making the restart atomic with respect to disk.** Impossible without owning the file. The contract stated above is the achievable guarantee.
+- **Changing `restart_server`'s public behaviour.** The extraction is inert by construction.
+
+## Execution Policy
+
+- execute: effort=medium, reason=small diff, but it refactors a lifecycle path with two callers and adds a refusal branch to the only remaining update path; a behaviour change smuggled in by the extraction would be invisible to the new tests.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checking afterwards would have allowed the fetched package to be activated
   before the refusal was reported.
 
-  The verification covers the spawned process environment as well as the
-  command: dropping an explicit `env` entry whose value happens to match the
-  ambient one would otherwise compare as unchanged while silently removing a
-  PMCP-managed credential from the restarted server (or, reversed, newly
-  exposing one to it).
+  The verification covers configuration-driven changes to the spawned process
+  environment as well as to the command: dropping an explicit `env` entry whose
+  value happens to match the ambient one would otherwise compare as unchanged
+  while silently removing a PMCP-managed credential from the restarted server
+  (or, reversed, newly exposing one to it). It deliberately does not freeze the
+  *ambient* environment across the update — a shell or secret-store change
+  during the probe affects the probe and the restart alike.
 
   This matters more since 2.2.0: with the automatic update notices removed,
   `gateway.update_server` is the only update path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checking afterwards would have allowed the fetched package to be activated
   before the refusal was reported.
 
+  The verification covers the spawned process environment as well as the
+  command: dropping an explicit `env` entry whose value happens to match the
+  ambient one would otherwise compare as unchanged while silently removing a
+  PMCP-managed credential from the restarted server (or, reversed, newly
+  exposing one to it).
+
   This matters more since 2.2.0: with the automatic update notices removed,
   `gateway.update_server` is the only update path.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`gateway.update_server` no longer risks restarting onto a different package
+  than the one it probed.** The tool resolved the server's config, ran an update
+  probe with a 60-second timeout, and then let `gateway.restart_server` resolve
+  the config a second, independent time. The config loaders re-read from disk on
+  every call, so a `.mcp.json` or manifest edit landing inside that window could
+  make pmcp probe and install package A, restart onto package B, and then record
+  A's version as B's — the silent-misreport class, reached through a race rather
+  than through resolver divergence.
+
+  `update_server` now re-resolves after the probe, verifies the result still
+  describes the same downstream process, and restarts onto that exact verified
+  config. If the configuration changed, or the server is gone from the config
+  entirely, the update is refused: the package was fetched but is **not**
+  activated and **no** version is recorded, with a message saying so.
+
+  The check runs *before* `gateway.refresh()`, which is itself a diff-based
+  reconcile that can disconnect and reconnect a changed server on its own —
+  checking afterwards would have allowed the fetched package to be activated
+  before the refusal was reported.
+
+  This matters more since 2.2.0: with the automatic update notices removed,
+  `gateway.update_server` is the only update path.
+
+
 ## [2.2.0] - 2026-08-20
 
 ### Removed

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -5126,21 +5126,32 @@ class GatewayTools:
         # differ here, where we are deciding whether the thing we probed is the
         # thing we are about to launch.
         #
-        # Both sides are sanitized NOW, in one synchronous block, so ambient
-        # os.environ and env-store state are identical for the two calls and
-        # cancel out -- only the config-driven difference remains.
-        probe_child_env = sanitized_subprocess_env(
-            resolved_config.config.env
-            if isinstance(resolved_config.config, LocalMcpServerConfig)
-            else None,
-            self._project_root,
-        )
-        restart_child_env = sanitized_subprocess_env(
-            recheck_config.config.env
-            if isinstance(recheck_config.config, LocalMcpServerConfig)
-            else None,
-            self._project_root,
-        )
+        # Scope, stated precisely: this detects a CONFIG-driven change to the
+        # child environment. It does not freeze the ambient environment across
+        # the update -- an os.environ or secret-store change during the probe
+        # affects both sides equally and cancels out by construction. Holding
+        # the probe's exact environment all the way to the spawn would mean
+        # threading a frozen env through ClientManager, which is a separate
+        # concern from this TOCTOU (tracked separately).
+        #
+        # Derive BOTH sides from ONE stripped base. Calling
+        # sanitized_subprocess_env twice would re-read the credential files
+        # twice (managed_secret_keys hits disk per call), so a write landing
+        # between the two reads could make identical configs compare unequal --
+        # a spurious refusal on the only update path pmcp has (ah board
+        # review, second pass). One read, one base, no window.
+        stripped_base = sanitized_subprocess_env(None, self._project_root)
+
+        def _child_env(candidate: ResolvedServerConfig) -> dict[str, str]:
+            own = (
+                candidate.config.env
+                if isinstance(candidate.config, LocalMcpServerConfig)
+                else None
+            )
+            return {**stripped_base, **(own or {})}
+
+        probe_child_env = _child_env(resolved_config)
+        restart_child_env = _child_env(recheck_config)
         if (
             not _refresh_config_unchanged(resolved_config, recheck_config)
             or probe_child_env != restart_child_env

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -2839,9 +2839,33 @@ class GatewayTools:
                 errors=[f"Unable to resolve server: {server_name}"],
             )
 
+        return await self._restart_resolved_server(
+            server_name, config, force=parsed.force, prior_status=prior_status
+        )
+
+    async def _restart_resolved_server(
+        self,
+        server_name: str,
+        config: ResolvedServerConfig,
+        *,
+        force: bool,
+        prior_status: str,
+    ) -> LifecycleServerOutput:
+        """Restart a server whose config the caller has ALREADY resolved.
+
+        Split out of ``restart_server`` so ``update_server`` can restart onto
+        the exact config object it probed and verified, instead of triggering a
+        second independent resolve across the probe's 60-second await
+        (Consiliency/pmcp#151).
+
+        Every safety check -- policy, remote-header env vars, credential gaps --
+        lives in ``_resolve_lifecycle_config``, which the caller runs to obtain
+        ``config``. This helper deliberately holds none of them, so calling it
+        with an unresolved or unverified config would bypass all three.
+        """
         active_tasks_before = len(self._client_manager.get_active_tasks(server_name))
         ok, cancelled, errors = await self._client_manager.restart_server(
-            config, force=parsed.force
+            config, force=force
         )
         active_tasks_after = len(self._client_manager.get_active_tasks(server_name))
         return self._lifecycle_output(
@@ -4931,9 +4955,12 @@ class GatewayTools:
         # meant probing one command while restarting a different one --
         # structurally capable of probing/installing upstream @latest while
         # restarting onto a completely different, e.g. pinned, config.
-        # Resolving once through restart_server's own resolver makes that
-        # divergence impossible: both calls are the same lookup against the
-        # same inputs, so they can't disagree.
+        # Resolving through restart_server's own resolver makes that
+        # divergence impossible for a STABLE configuration: both reads are the
+        # same lookup, so identical inputs cannot produce different answers.
+        # They are still two separate reads of a file that can change between
+        # them, which is why the restart below re-resolves and verifies rather
+        # than assuming this one still holds (Consiliency/pmcp#151).
         prior_status = self._status_value(server_name)
         resolved_config, resolve_failure = self._resolve_lifecycle_config(
             server_name, action="restart", prior_status=prior_status
@@ -5043,6 +5070,61 @@ class GatewayTools:
                 message=f"Update command failed: {short_output}",
             )
 
+        # Consiliency/pmcp#151: the probe above is a 60-second await, and the
+        # config loaders re-read from disk on every call, so the configuration
+        # backing this update may have changed since it was resolved. Verify
+        # BEFORE going any further.
+        #
+        # This check must precede refresh(). refresh() is itself a diff-based
+        # config reconcile: it re-reads the config and disconnects/reconnects
+        # servers whose definition changed, which means it can ACTIVATE the
+        # freshly-fetched package on its own, via disconnect_server +
+        # connect_all rather than restart_server. Checking after it would let
+        # this tool report "fetched but not activated" after activation had
+        # already happened -- a false statement, and one that a test asserting
+        # "restart_server was never called" would not catch (ah board review).
+        #
+        # The guarantee is "the config restarted onto is the config that was
+        # probed" -- NOT "the config on disk when the restart completes". An
+        # edit landing after this check applies on the next update.
+        recheck_config, recheck_failure = self._resolve_lifecycle_config(
+            server_name,
+            action="restart",
+            prior_status=self._status_value(server_name),
+        )
+        if recheck_failure is not None or recheck_config is None:
+            return UpdateServerOutput(
+                ok=False,
+                server=server_name,
+                package_type=package_type,
+                package_name=package_name,
+                message=(
+                    f"'{server_name}' could no longer be resolved after the update "
+                    f"was fetched, so it was not activated: "
+                    f"{recheck_failure.message if recheck_failure else 'server not found'}"
+                ),
+            )
+        # Reuse refresh()'s own predicate rather than full-model equality: it
+        # compares the fields that determine the spawned process, ignores
+        # `source` (the same effective server can arrive as manifest or as a
+        # configured entry), and compares `env` by effective override only --
+        # naive full-env comparison caused spurious teardowns in #79, and here
+        # it would cause spurious refusals of legitimate updates.
+        if not _refresh_config_unchanged(resolved_config, recheck_config):
+            return UpdateServerOutput(
+                ok=False,
+                server=server_name,
+                package_type=package_type,
+                package_name=package_name,
+                message=(
+                    f"Configuration for '{server_name}' changed while the update "
+                    f"was being fetched. The package was fetched but NOT activated, "
+                    f"and no version was recorded. Re-run "
+                    f"gateway.update_server(server_name='{server_name}') to update "
+                    f"against the current configuration."
+                ),
+            )
+
         refresh_result = await self.refresh({"reason": f"update_server:{server_name}"})
         latest_version, _ = await get_package_version(command, args, timeout=5.0)
 
@@ -5055,8 +5137,11 @@ class GatewayTools:
         # the same resolve+disconnect+connect machinery gateway.restart_server
         # already exercises, so the freshly-fetched package is what's actually
         # running.
-        restart_result = await self.restart_server(
-            {"server_name": server_name, "force": parsed.force}
+        restart_result = await self._restart_resolved_server(
+            server_name,
+            recheck_config,
+            force=parsed.force,
+            prior_status=self._status_value(server_name),
         )
 
         # `desc.version` is an upstream snapshot from the last `pmcp

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -5104,13 +5104,47 @@ class GatewayTools:
                     f"{recheck_failure.message if recheck_failure else 'server not found'}"
                 ),
             )
-        # Reuse refresh()'s own predicate rather than full-model equality: it
-        # compares the fields that determine the spawned process, ignores
-        # `source` (the same effective server can arrive as manifest or as a
-        # configured entry), and compares `env` by effective override only --
-        # naive full-env comparison caused spurious teardowns in #79, and here
-        # it would cause spurious refusals of legitimate updates.
-        if not _refresh_config_unchanged(resolved_config, recheck_config):
+        # Two-part check. _refresh_config_unchanged covers command/args/cwd and
+        # is the right predicate for process identity -- it ignores `source`
+        # (the same effective server can arrive as manifest or as a configured
+        # entry) and compares `env` by effective override only, because naive
+        # full-env comparison caused spurious teardowns in #79 and here would
+        # cause spurious refusals of legitimate updates.
+        #
+        # But it is NOT sufficient on its own for this decision (ah board
+        # review). It discards an explicit env entry whose value equals the
+        # ambient value, while sanitized_subprocess_env strips every
+        # PMCP-managed key and restores only explicit entries. So dropping
+        # `env={"KEY": <same value as os.environ>}` compares "unchanged" yet
+        # silently removes KEY from the spawned process -- and the reverse edit
+        # newly exposes a managed credential. That is a material change to what
+        # gets launched, which is exactly what this guard exists to catch.
+        # Verified empirically, not inferred.
+        #
+        # This is not a defect in _refresh_config_unchanged for refresh()'s own
+        # purpose (deciding whether to tear down a running server); the stakes
+        # differ here, where we are deciding whether the thing we probed is the
+        # thing we are about to launch.
+        #
+        # Both sides are sanitized NOW, in one synchronous block, so ambient
+        # os.environ and env-store state are identical for the two calls and
+        # cancel out -- only the config-driven difference remains.
+        probe_child_env = sanitized_subprocess_env(
+            resolved_config.config.env
+            if isinstance(resolved_config.config, LocalMcpServerConfig)
+            else None,
+            self._project_root,
+        )
+        restart_child_env = sanitized_subprocess_env(
+            recheck_config.config.env
+            if isinstance(recheck_config.config, LocalMcpServerConfig)
+            else None,
+            self._project_root,
+        )
+        if (
+            not _refresh_config_unchanged(resolved_config, recheck_config)
+            or probe_child_env != restart_child_env
+        ):
             return UpdateServerOutput(
                 ok=False,
                 server=server_name,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5040,6 +5040,102 @@ class TestUpdateServerVersionRepair:
         assert cache.servers["playwright"].version == "0.1.0"
 
     @pytest.mark.asyncio
+    async def test_update_server_refuses_when_managed_credential_is_dropped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Dropping an explicit env entry that matches ambient must still refuse.
+
+        Board review of this PR found the guard's first comparator insufficient.
+        `_refresh_config_unchanged` discards an explicit env entry whose value
+        equals `os.environ`, but `sanitized_subprocess_env` strips every
+        PMCP-managed key and restores only explicit entries. So removing
+        `env={"KEY": <same value as ambient>}` mid-probe compares "unchanged"
+        while the restarted process silently loses KEY -- and the reverse edit
+        newly exposes a managed credential to it.
+
+        The other TOCTOU test only changes argv and cannot catch this: it is a
+        different axis of the same "restart onto something other than what was
+        probed" defect.
+        """
+        self._make_manifest_with_playwright(monkeypatch)
+        monkeypatch.setattr(
+            "pmcp.env_store.managed_secret_keys", lambda project=None: {"SECRET_TOKEN"}
+        )
+        monkeypatch.setenv("SECRET_TOKEN", "value")
+
+        with_credential = [
+            ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(
+                    command="npx",
+                    args=["-y", "@playwright/mcp"],
+                    env={"SECRET_TOKEN": "value"},
+                ),
+            )
+        ]
+        # Identical command/args; the ONLY change is the explicit env entry,
+        # whose value matches ambient -- invisible to the effective-override
+        # comparison, but decisive for the spawned process.
+        without_credential = [
+            ResolvedServerConfig(
+                name="playwright",
+                source="project",
+                config=LocalMcpServerConfig(
+                    command="npx", args=["-y", "@playwright/mcp"], env=None
+                ),
+            )
+        ]
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.load_configs", lambda **_: with_credential
+        )
+
+        cache = self._make_cache(version="0.1.0")
+        client_manager = MockClientManager()
+        gt = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+            descriptions_cache=cache,
+        )
+
+        refresh_called = False
+
+        async def _tracking_refresh(input_data):
+            nonlocal refresh_called
+            refresh_called = True
+            return types.SimpleNamespace(ok=True)
+
+        monkeypatch.setattr(gt, "refresh", _tracking_refresh)
+
+        async def fake_get_package_version(command, args, timeout=5.0):
+            return ("0.2.0", "npm")
+
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.get_package_version", fake_get_package_version
+        )
+
+        async def _probe_that_drops_the_credential(command, env=None):
+            assert env is not None and env.get("SECRET_TOKEN") == "value", (
+                "probe should have received the credential"
+            )
+            monkeypatch.setattr(
+                "pmcp.tools.handlers.load_configs", lambda **_: without_credential
+            )
+            return (True, "ok")
+
+        monkeypatch.setattr(
+            gt, "_run_update_probe_command", _probe_that_drops_the_credential
+        )
+
+        result = await gt.update_server({"server_name": "playwright"})
+
+        assert result.ok is False
+        assert "changed while the update was being fetched" in result.message
+        assert refresh_called is False
+        assert not any("connect_server" in e for e in client_manager.events)
+        assert cache.servers["playwright"].version == "0.1.0"
+
+    @pytest.mark.asyncio
     async def test_update_server_refuses_when_server_removed_during_probe(
         self, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4957,6 +4957,130 @@ class TestUpdateServerVersionRepair:
         assert client_manager.is_server_online("playwright") is True
 
     @pytest.mark.asyncio
+    async def test_update_server_refuses_when_config_changes_during_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A config edit landing inside the probe window must refuse, not activate.
+
+        Consiliency/pmcp#151. The probe is a 60-second await and the config
+        loaders re-read on every call, so `.mcp.json` can change underneath a
+        running update. Before the fix, update_server probed package A and then
+        let a second, independent resolve restart onto package B -- persisting
+        A's version as B's.
+
+        The `refresh_called` assertion is the load-bearing one. Two reviewers
+        blocked the first implementation for putting this guard AFTER
+        `refresh()`, which is itself a diff-based reconcile that
+        disconnects/reconnects changed servers -- so it could have activated the
+        fetched package before the guard ever ran, making "fetched but not
+        activated" a lie. Because refresh() activates via disconnect + connect
+        rather than restart_server, asserting only "restart_server was not
+        called" would have passed while the bug survived.
+        """
+        self._make_manifest_with_playwright(monkeypatch)
+        cache = self._make_cache(version="0.1.0")
+        client_manager = MockClientManager()
+        gt = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+            descriptions_cache=cache,
+        )
+
+        refresh_called = False
+
+        async def _tracking_refresh(input_data):
+            nonlocal refresh_called
+            refresh_called = True
+            return types.SimpleNamespace(ok=True)
+
+        monkeypatch.setattr(gt, "refresh", _tracking_refresh)
+
+        async def fake_get_package_version(command, args, timeout=5.0):
+            return ("0.2.0", "npm")
+
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.get_package_version", fake_get_package_version
+        )
+
+        async def _probe_that_edits_the_config(command, env=None):
+            # Stand-in for an operator (or an automated rollout) editing
+            # .mcp.json while the probe runs. Routed through the real
+            # _resolve_lifecycle_config -> load_configs path, so a cached
+            # resolve would make this test fail -- it doubles as the
+            # no-caching check.
+            monkeypatch.setattr(
+                "pmcp.tools.handlers.load_configs",
+                lambda **_: [
+                    ResolvedServerConfig(
+                        name="playwright",
+                        source="project",
+                        config=LocalMcpServerConfig(
+                            command="npx",
+                            args=["-y", "@playwright/mcp@1.0.0-pinned"],
+                        ),
+                    )
+                ],
+            )
+            return (True, "ok")
+
+        monkeypatch.setattr(
+            gt, "_run_update_probe_command", _probe_that_edits_the_config
+        )
+
+        result = await gt.update_server({"server_name": "playwright"})
+
+        assert result.ok is False
+        assert "changed while the update was being fetched" in result.message
+        # Nothing was activated -- not by the restart, and not by refresh().
+        assert refresh_called is False
+        assert not any("disconnect_server" in e for e in client_manager.events)
+        assert not any("connect_server" in e for e in client_manager.events)
+        # The bug class is "persist A's bookkeeping for B". This is the
+        # assertion that actually pins it.
+        assert cache.servers["playwright"].version == "0.1.0"
+
+    @pytest.mark.asyncio
+    async def test_update_server_refuses_when_server_removed_during_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A server deleted from config mid-probe must refuse, not restart."""
+        self._make_manifest_with_playwright(monkeypatch)
+        cache = self._make_cache(version="0.1.0")
+        client_manager = MockClientManager()
+        gt = GatewayTools(
+            client_manager=client_manager,  # type: ignore
+            policy_manager=PolicyManager(),
+            descriptions_cache=cache,
+        )
+
+        async def fake_get_package_version(command, args, timeout=5.0):
+            return ("0.2.0", "npm")
+
+        monkeypatch.setattr(
+            "pmcp.tools.handlers.get_package_version", fake_get_package_version
+        )
+
+        async def _probe_that_removes_the_server(command, env=None):
+            empty = Manifest(
+                version="1.0",
+                cli_alternatives={},
+                servers={},
+                discovery_queue_path=".mcp-gateway/discovery_queue.json",
+            )
+            monkeypatch.setattr("pmcp.tools.handlers.load_manifest", lambda: empty)
+            return (True, "ok")
+
+        monkeypatch.setattr(
+            gt, "_run_update_probe_command", _probe_that_removes_the_server
+        )
+
+        result = await gt.update_server({"server_name": "playwright"})
+
+        assert result.ok is False
+        assert "could no longer be resolved" in result.message
+        assert cache.servers["playwright"].version == "0.1.0"
+
+    @pytest.mark.asyncio
     async def test_update_server_bumps_descriptions_cache_version(
         self, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5040,8 +5040,9 @@ class TestUpdateServerVersionRepair:
         assert cache.servers["playwright"].version == "0.1.0"
 
     @pytest.mark.asyncio
-    async def test_update_server_refuses_when_managed_credential_is_dropped(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("direction", ["drop", "add"])
+    async def test_update_server_refuses_when_managed_credential_changes(
+        self, monkeypatch: pytest.MonkeyPatch, direction: str
     ):
         """Dropping an explicit env entry that matches ambient must still refuse.
 
@@ -5086,9 +5087,16 @@ class TestUpdateServerVersionRepair:
                 ),
             )
         ]
-        monkeypatch.setattr(
-            "pmcp.tools.handlers.load_configs", lambda **_: with_credential
+        # Both directions matter and the defect is symmetric: dropping the
+        # entry silently REMOVES a managed credential from the restarted
+        # server, adding one newly EXPOSES it. Board review asked whether the
+        # test covered the reverse; it did not.
+        before, after = (
+            (with_credential, without_credential)
+            if direction == "drop"
+            else (without_credential, with_credential)
         )
+        monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: before)
 
         cache = self._make_cache(version="0.1.0")
         client_manager = MockClientManager()
@@ -5114,17 +5122,18 @@ class TestUpdateServerVersionRepair:
             "pmcp.tools.handlers.get_package_version", fake_get_package_version
         )
 
-        async def _probe_that_drops_the_credential(command, env=None):
-            assert env is not None and env.get("SECRET_TOKEN") == "value", (
-                "probe should have received the credential"
+        async def _probe_that_changes_the_credential(command, env=None):
+            assert env is not None
+            expected = "value" if direction == "drop" else None
+            assert env.get("SECRET_TOKEN") == expected, (
+                f"probe env should start {direction!r}-side: "
+                f"expected {expected!r}, got {env.get('SECRET_TOKEN')!r}"
             )
-            monkeypatch.setattr(
-                "pmcp.tools.handlers.load_configs", lambda **_: without_credential
-            )
+            monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: after)
             return (True, "ok")
 
         monkeypatch.setattr(
-            gt, "_run_update_probe_command", _probe_that_drops_the_credential
+            gt, "_run_update_probe_command", _probe_that_changes_the_credential
         )
 
         result = await gt.update_server({"server_name": "playwright"})


### PR DESCRIPTION
Closes #151.

`gateway.update_server` resolved the target's config, ran a 60-second probe, then called `gateway.restart_server` — which resolved the config a **second, independent time**. The loaders re-read from disk on every call, so an edit landing in that window could make pmcp probe and install package A, restart onto package B, and record A's version as B's.

Now: resolve #1 → probe → resolve #2 → verify it still describes the same downstream process → restart onto **that exact verified object**. On mismatch, or if the server has vanished from config, refuse — fetched but **not** activated, **no** version recorded.

**Contract:** *the config restarted onto is the config that was probed.* Not "the config on disk when the restart completes" — an edit landing after the check applies on the next update. That is correct behaviour, not a residual race.

## The board caught a real defect in my first version

I put the guard immediately before the restart. Two reviewers independently blocked it, and they were right: between the probe and the restart, `update_server` calls `await self.refresh(...)` — and **`refresh()` is itself a diff-based config reconcile** that disconnects and reconnects servers whose definition changed. It could therefore **activate the freshly-fetched package on its own**, after which my guard would report "fetched but NOT activated" — a false statement.

The sharper half: `refresh()` activates via `disconnect_server` + `connect_all`, **not** `restart_server`. So my planned assertion — "`_client_manager.restart_server` was never called" — **would have passed while the bug survived.** That is the exact failure mode this repo has bitten me with repeatedly.

The guard now sits immediately after the probe and **before** `refresh()`, and the test asserts `refresh` was never called.

## A second correction, found while implementing

My plan specified a strict full-model `==` including `source`. That was wrong, and `handlers.py` already knew it: `_refresh_config_unchanged` is a battle-tested predicate for exactly this question, and it deliberately avoids full-model equality —

- **`env` is compared by *effective* override only.** Naive full-`env` comparison "would spuriously tear down running provisioned servers on every refresh (#79)". In `update_server` that class returns as **spurious refusals of legitimate updates**.
- **`source` is excluded deliberately** — the same effective server can arrive as `manifest` or as a configured entry.

I'd called over-refusal "rare and fails closed". The codebase had already settled the question with a linked issue. Reusing the predicate also keeps one definition of "same server" instead of two subtly different ones.

## Also corrected: the issue's own fix sketch

#151 says threading the config through would lose "policy checks, credential-gap detection, and remote-header validation". Verified against source — **all three live inside `_resolve_lifecycle_config`** (`handlers.py:3237-3295`), which read #1 already runs. `restart_server` adds only task accounting and output shaping. That is why extracting `_restart_resolved_server` is safe and loses nothing.

## Verification

- `pytest -q` → **2550 passed, 3 skipped, 0 failed** (2548 baseline + 2 new)
- `ruff check .`, `ruff format --check`, `mypy src` — clean
- **No existing test modified.** All 13 `update_server`/`restart_server` tests pass unchanged, which is what makes the helper extraction provably inert.
- **Tests proven RED three ways**, not assumed: against unfixed `c326a4c`; against my own board-blocked ordering (fails on `refresh_called`, the assertion that would otherwise have been vacuous); green against the fix.
- Prose swept — no comment, docstring, or exported tool description still claims the config is resolved once. The false comment the issue names is rewritten.

## Not attempted

Locking `.mcp.json` (pmcp does not own the file, and an operator's editor will not honour an advisory lock) or making the restart atomic with respect to disk (impossible without owning it).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789827487&installation_model_id=427051&pr_number=161&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F161&signature=94d3c474fc78dccad06ef0f2006f48094111d06cb9ed14092171d08a73d020c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->