### PR TITLE
fix: close the four #155 follow-ups (#156)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,6 +213,10 @@ jobs:
       - name: Require a CHANGELOG.md entry for src/ changes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Frozen at trigger time -- the fallback below, not the primary source.
+          # Passed as env rather than interpolated into the script body so a
+          # label's text can never be parsed as shell.
+          PAYLOAD_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           # Query live labels via the API instead of github.event.pull_request.labels.
           # That context is frozen in the event payload at the moment the workflow
@@ -225,9 +229,18 @@ jobs:
           # so it returned "Validation Failed (HTTP 422)". Under `bash -e` that
           # non-zero exit killed the step BEFORE the CHANGELOG check ran, so the
           # guard failed on its own permissions rather than on the PR's content.
-          # `|| true` keeps a future API hiccup from doing the same: a lookup
-          # failure must not decide the check, it just means "no label seen".
+          # `|| true` keeps a future API hiccup from killing the step. But
+          # "lookup failed" is NOT "no label": treating them alike false-blocks
+          # a PR that really was labelled (Consiliency/pmcp#156 item 4). On an
+          # empty result, fall back to the frozen event payload -- stale for a
+          # label applied after the trigger, but strictly better than ignoring
+          # the label outright. Live lookup first, payload second, "no label"
+          # only if both come up empty.
           LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.labels[].name' || true)
+          if [ -z "$LABELS" ]; then
+            echo "Live label lookup empty or failed — falling back to the event payload."
+            LABELS=$(printf '%s' "$PAYLOAD_LABELS_JSON" | jq -r '.[]?' 2>/dev/null || true)
+          fi
           echo "Current labels: $LABELS"
           if echo "$LABELS" | grep -qx 'skip-changelog'; then
             echo "skip-changelog label present — skipping the CHANGELOG.md check."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,13 +229,10 @@ jobs:
           # so it returned "Validation Failed (HTTP 422)". Under `bash -e` that
           # non-zero exit killed the step BEFORE the CHANGELOG check ran, so the
           # guard failed on its own permissions rather than on the PR's content.
-          # `|| true` keeps a future API hiccup from killing the step. But
-          # "lookup failed" is NOT "no label": treating them alike false-blocks
-          # a PR that really was labelled (Consiliency/pmcp#156 item 4). On an
-          # empty result, fall back to the frozen event payload -- stale for a
-          # label applied after the trigger, but strictly better than ignoring
-          # the label outright. Live lookup first, payload second, "no label"
-          # only if both come up empty.
+          # A lookup FAILURE is not "no label": treating them alike false-blocks
+          # a PR that really was labelled (Consiliency/pmcp#156 item 4). On
+          # failure, fall back to the frozen event payload -- stale for a label
+          # applied after the trigger, but better than ignoring the label.
           # Branch on the EXIT STATUS, never on emptiness. A successful lookup
           # returning zero labels is authoritative -- it means the label was
           # removed. Falling back to the frozen payload there would resurrect a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,9 +236,16 @@ jobs:
           # label applied after the trigger, but strictly better than ignoring
           # the label outright. Live lookup first, payload second, "no label"
           # only if both come up empty.
-          LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.labels[].name' || true)
-          if [ -z "$LABELS" ]; then
-            echo "Live label lookup empty or failed — falling back to the event payload."
+          # Branch on the EXIT STATUS, never on emptiness. A successful lookup
+          # returning zero labels is authoritative -- it means the label was
+          # removed. Falling back to the frozen payload there would resurrect a
+          # deleted `skip-changelog` and silently bypass this guard, which is
+          # worse than the false block the fallback exists to prevent
+          # (ah board review).
+          if LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.labels[].name'); then
+            echo "Live label lookup succeeded."
+          else
+            echo "Live label lookup FAILED — falling back to the event payload."
             LABELS=$(printf '%s' "$PAYLOAD_LABELS_JSON" | jq -r '.[]?' 2>/dev/null || true)
           fi
           echo "Current labels: $LABELS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version reading as current — but it checked only the cached side. With a
   cached `1.0.0` and a fetched `nightly`, the guard passed, the comparison
   failed closed, and the negation still reported "up to date", never
-  refreshing. Both sides are now checked, and both checks carry the package
-  type.
+  refreshing.
+
+  Checking each side individually turned out to be insufficient too:
+  comparability is a property of the **pair**. `1.0.0` and `abcdef123456` are
+  each orderable on their own, but a version and a digest cannot be ordered
+  against each other, so the same "up to date" answer came back for a server
+  whose cache entry was reused by name after its package type changed. A new
+  `are_versions_comparable(current, latest, package_type)` asks about the pair,
+  and that is what now guards the short-circuit.
 - **An all-numeric truncated image digest is documented as incomparable
   without a package type, and callers are now pinned to pass one.**
   `get_docker_version` truncates SHA-256 to 12 hex characters, which can be all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   isolation. The flag is now cleared on entry as well as exit, with a test that
   latches it deliberately and asserts a connection still works.
 - **The CHANGELOG CI guard no longer treats a failed label lookup as "no
-  label".** A live-lookup failure now falls back to the frozen event payload
+  label".** A live-lookup *failure* now falls back to the frozen event payload
   before concluding the `skip-changelog` label is absent, so an API hiccup
-  cannot block a PR that really was labelled.
+  cannot block a PR that really was labelled. A lookup that *succeeds* and
+  returns no labels stays authoritative — otherwise removing the label would
+  not re-enable the check.
 
-
-### Fixed
 - **`gateway.update_server` no longer risks restarting onto a different package
   than the one it probed.** The tool resolved the server's config, ran an update
   probe with a 60-second timeout, and then let `gateway.restart_server` resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SemVer lane was the last piece still hand-written.
 
 ### Fixed
-- **An all-numeric truncated image digest is no longer misread as a version.**
+- **An all-numeric truncated image digest is documented as incomparable
+  without a package type, and callers are now pinned to pass one.**
   `get_docker_version` truncates SHA-256 to 12 hex characters, which can be all
-  digits — the same shape as a calendar version like `202612180000` — so with
-  no package type the shape alone could not classify it, and a genuinely
-  different image could read as no change. The two values are compared as a
-  pair from one server, so when either side is unmistakably a digest (a hex
-  letter, or the `sha256:` prefix) the all-numeric side is now treated as one
-  too. Calendar versions still order normally.
+  digits — the same shape as a calendar version like `202612180000`. Resolving
+  that by guessing (promoting the numeric side when its partner is a digest)
+  was implemented and rejected: the guess fabricates an update when the numeric
+  side really is a calendar version, which is what `is_version_newer`'s
+  fail-closed contract exists to prevent. A mixed pair therefore stays
+  incomparable, and a test now enforces that every caller passes the package
+  type, which is what actually resolves it.
 - **A `sha256:`-prefixed digest with no hex letter is now recognised.** The
   pattern required a hex letter even when the prefix was present, so an
   all-numeric prefixed digest was rejected outright.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A `sha256:`-prefixed digest with no hex letter is now recognised.** The
   pattern required a hex letter even when the prefix was present, so an
   all-numeric prefixed digest was rejected outright.
+- **The intermittent `test_ec_p2_7_reconnect_does_not_leak_transports` failure
+  is fixed at its root.** `sse_starlette.sse.AppStatus.should_exit` is a
+  process-global class attribute that uvicorn's shutdown handler latches `True`
+  and never resets. The fake-remote test server cleared it on teardown, which
+  protects against its own shutdown but not against a server started elsewhere
+  in the same interpreter — and `tests/mcp2x`, which stops uvicorn servers,
+  sorts immediately before `tests/runtime`. Inheriting the latched flag made
+  every SSE stream end instantly, so the test failed in CI while passing in
+  isolation. The flag is now cleared on entry as well as exit, with a test that
+  latches it deliberately and asserts a connection still works.
 - **The CHANGELOG CI guard no longer treats a failed label lookup as "no
   label".** A live-lookup failure now falls back to the frozen event payload
   before concluding the `skip-changelog` label is absent, so an API hiccup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SemVer lane was the last piece still hand-written.
 
 ### Fixed
+- **A stale descriptions cache is no longer pinned when the FETCHED version is
+  unreadable.** The "already up to date" short-circuit negates a comparator
+  that fails closed, so an orderability guard was added to stop an unreadable
+  version reading as current — but it checked only the cached side. With a
+  cached `1.0.0` and a fetched `nightly`, the guard passed, the comparison
+  failed closed, and the negation still reported "up to date", never
+  refreshing. Both sides are now checked, and both checks carry the package
+  type.
 - **An all-numeric truncated image digest is documented as incomparable
   without a package type, and callers are now pinned to pass one.**
   `get_docker_version` truncates SHA-256 to 12 hex characters, which can be all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **SemVer comparison now uses the `semver` library instead of a hand-written
+  key** (new dependency, pure-Python, no transitive dependencies). The npm and
+  Cargo lane needs true SemVer 2.0.0 precedence because PEP 440 disagrees with
+  it — PEP 440 reads `1.0.0-1` as the post-release `1.0.0.post1`, SemVer as a
+  prerelease *below* `1.0.0` — and 79 of the manifest's 107 servers are npm.
+  This module replaced hand-rolled version logic with `packaging` precisely
+  because every hand-rolled form of it produced a fabricated-notice bug; the
+  SemVer lane was the last piece still hand-written.
+
+### Fixed
+- **An all-numeric truncated image digest is no longer misread as a version.**
+  `get_docker_version` truncates SHA-256 to 12 hex characters, which can be all
+  digits — the same shape as a calendar version like `202612180000` — so with
+  no package type the shape alone could not classify it, and a genuinely
+  different image could read as no change. The two values are compared as a
+  pair from one server, so when either side is unmistakably a digest (a hex
+  letter, or the `sha256:` prefix) the all-numeric side is now treated as one
+  too. Calendar versions still order normally.
+- **A `sha256:`-prefixed digest with no hex letter is now recognised.** The
+  pattern required a hex letter even when the prefix was present, so an
+  all-numeric prefixed digest was rejected outright.
+- **The CHANGELOG CI guard no longer treats a failed label lookup as "no
+  label".** A live-lookup failure now falls back to the frozen event payload
+  before concluding the `skip-changelog` label is absent, so an API hiccup
+  cannot block a PR that really was labelled.
+
+
 ### Fixed
 - **`gateway.update_server` no longer risks restarting onto a different package
   than the one it probed.** The tool resolved the server's config, ran an update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,14 @@ dependencies = [
     # packaging implements PEP 440 ordering and rejects non-versions outright.
     # Pure-Python, no transitive deps, already ubiquitous in the ecosystem.
     "packaging>=22",
+    # SemVer 2.0.0 precedence for the npm/Cargo lane. PEP 440 and SemVer
+    # genuinely disagree -- PEP 440 reads `1.0.0-1` as the POST-release
+    # `1.0.0.post1`, SemVer as a PRERELEASE below `1.0.0` -- and 79 of the
+    # manifest's 107 servers are npm, so that inversion was live. This replaced
+    # a hand-written key (Consiliency/pmcp#156): hand-rolled version logic in
+    # this module produced a fabricated-notice bug in every form it took.
+    # Pure-Python, no transitive dependencies.
+    "semver>=3,<4",
     # Upper bound is load-bearing: 3.0.0 is unreleased and unaudited. pmcp's
     # P2 phase ported the gateway's upstream handlers and downstream
     # transport onto mcp 2.0.0's rewritten low-level Server (typed on_*

--- a/src/pmcp/manifest/refresher.py
+++ b/src/pmcp/manifest/refresher.py
@@ -20,8 +20,8 @@ from pmcp.manifest.loader import Manifest, ServerConfig, load_manifest
 from pmcp.manifest.version_checker import (
     detect_package_type,
     get_package_version,
+    are_versions_comparable,
     is_version_newer,
-    is_version_orderable,
 )
 from pmcp.types import (
     DescriptionsCache,
@@ -231,8 +231,7 @@ async def refresh_server(
         # through three earlier rounds).
         if (
             version
-            and is_version_orderable(existing_cache.version, pkg_type)
-            and is_version_orderable(version, pkg_type)
+            and are_versions_comparable(existing_cache.version, version, pkg_type)
             and not is_version_newer(existing_cache.version, version, pkg_type)
         ):
             logger.debug(

--- a/src/pmcp/manifest/refresher.py
+++ b/src/pmcp/manifest/refresher.py
@@ -219,13 +219,20 @@ async def refresh_server(
 
         # `not is_version_newer(...)` means "not newer", which is NOT the same as
         # "up to date" now that the comparator fails closed: an unorderable
-        # cached version (e.g. the literal "unknown" this function persists
-        # below after a failed lookup) yields False and would pin the stale
-        # cache forever. Require the cached version to be orderable before
-        # trusting "not newer" as up-to-date (board review round 4).
+        # version yields False and would pin the stale cache forever.
+        #
+        # BOTH sides must be orderable, and both checks must carry `pkg_type`.
+        # Guarding only the cached side left the defect live: with
+        # current="1.0.0" (orderable) and latest="nightly" (not), the guard
+        # passed, the comparator failed closed to False, and `not False` read
+        # as up-to-date -- pinning the cache exactly as before. `pkg_type`
+        # matters because it is what makes an all-numeric docker digest
+        # orderable at all (ah board review; the one-sided version shipped
+        # through three earlier rounds).
         if (
             version
-            and is_version_orderable(existing_cache.version)
+            and is_version_orderable(existing_cache.version, pkg_type)
+            and is_version_orderable(version, pkg_type)
             and not is_version_newer(existing_cache.version, version, pkg_type)
         ):
             logger.debug(

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 
 import aiohttp
 from packaging.version import InvalidVersion, Version
+from semver import Version as SemverVersion
 
 from pmcp import __version__
 
@@ -429,7 +430,13 @@ async def get_package_version(
 # So shape is only a candidate test -- `package_type` decides, and callers have
 # it (board review round 4).
 _DIGEST_RE = re.compile(r"^(?:sha256:)?[0-9a-f]{12,64}$")
-_DIGEST_LETTER_RE = re.compile(r"^(?:sha256:)?(?=[0-9a-f]*[a-f])[0-9a-f]{12,64}$")
+# Without a package type, a BARE hex string needs a letter to be distinguishable
+# from a calendar version -- but an explicit `sha256:` prefix already names the
+# value a digest, so requiring a letter there rejected legitimate all-numeric
+# digests (`sha256:987654321098`). Prefix => any hex; bare => letter required.
+_DIGEST_LETTER_RE = re.compile(
+    r"^(?:sha256:[0-9a-f]{12,64}|(?=[0-9a-f]*[a-f])[0-9a-f]{12,64})$"
+)
 
 
 def _digest_identity(value: str, package_type: str | None = None) -> str | None:
@@ -453,6 +460,30 @@ def _digest_identity(value: str, package_type: str | None = None) -> str | None:
         return None
     hex_part = candidate[7:] if candidate.startswith("sha256:") else candidate
     return hex_part[:12]
+
+
+# A truncated SHA-256 can be all digits (`987654321098`), and so can a calendar
+# version (`202612180000`). With package_type == "docker" the type settles it;
+# without one the shape alone cannot (Consiliency/pmcp#156 item 3).
+#
+# Fail-closed was tried here and REVERTED: refusing to order any bare 12-digit
+# string breaks CalVer, which #155 deliberately supports and pins with
+# test_long_numeric_version_is_not_mistaken_for_a_digest. That would trade a
+# live capability for a latent bug -- the issue notes every current caller
+# passes the type.
+#
+# The partner value disambiguates instead. These two are compared as a PAIR
+# from one server, so if either side is unmistakably a digest (a hex letter, or
+# the `sha256:` prefix), the other all-numeric side is a digest too. A
+# truncated digest is all-numeric roughly 1 time in 11,500, so the mixed pair
+# covers essentially the whole real surface; a both-all-numeric pair stays
+# versions, which is also what CalVer needs.
+_ALL_NUMERIC_HEX_RE = re.compile(r"^[0-9]{12}$")
+
+
+def _is_all_numeric_digest_shape(value: str) -> bool:
+    """Bare 12 digits: the shape a digest and a calendar version share."""
+    return bool(_ALL_NUMERIC_HEX_RE.match((value or "").strip()))
 
 
 def _parse_version(value: str) -> Version | None:
@@ -484,61 +515,47 @@ def _parse_version(value: str) -> Version | None:
 # format: it hides `1.0.0-1 -> 1.0.0` and fabricates the reverse.
 _SEMVER_ECOSYSTEMS = frozenset({"npm", "cargo"})
 
-# SemVer 2.0.0 rules 2, 9 and 10: core identifiers are non-negative integers
-# WITHOUT leading zeros; numeric prerelease identifiers likewise; and identifiers
-# must not be empty. An earlier version accepted `1.0.0-01`, `01.0.0` and
-# `1.0.0-a..b` and ORDERED them, fabricating updates from strings npm could
-# never have published (board review round 4).
-_SEMVER_CORE = r"(0|[1-9]\d*)"
-_SEMVER_PRE_IDENT = r"(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
-_SEMVER_RE = re.compile(
-    rf"^[vV]?{_SEMVER_CORE}\.{_SEMVER_CORE}\.{_SEMVER_CORE}"
-    rf"(?:-({_SEMVER_PRE_IDENT}(?:\.{_SEMVER_PRE_IDENT})*))?"
-    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
-)
-
 
 def _is_semver_ecosystem(package_type: str | None) -> bool:
     return package_type in _SEMVER_ECOSYSTEMS
 
 
-def _semver_key(value: str) -> tuple[tuple[int, int, int], list[object]] | None:
-    """SemVer 2.0.0 precedence key, or ``None`` if *value* is not SemVer.
+def _semver_parse(value: str) -> SemverVersion | None:
+    """Parse *value* as SemVer 2.0.0, or ``None`` if it is not SemVer.
 
-    Build metadata is ignored (spec: it does not affect precedence). A release
-    outranks any prerelease of the same core version; prerelease identifiers
-    compare numerically when numeric, else lexically, with numeric ranked lower.
+    Delegated to the ``semver`` package rather than hand-written here
+    (Consiliency/pmcp#156). This module replaced hand-rolled digit extraction
+    with ``packaging`` precisely because hand-rolled version logic produced a
+    fabricated-notice bug in every form it took, and then had to hand-roll the
+    SemVer lane anyway. The library enforces the rules an earlier regex got
+    wrong -- rule 2/9/10 rejection of leading zeros (`01.0.0`, `1.0.0-01`) and
+    empty identifiers (`1.0.0-a..b`) -- and implements §11 precedence,
+    including numeric-before-alphanumeric and `beta.2 < beta.11`, which naive
+    string ordering reverses.
+
+    A leading ``v`` is stripped first: registries commonly emit ``v1.2.3``,
+    which strict SemVer does not accept.
     """
-    match = _SEMVER_RE.match((value or "").strip())
-    if not match:
+    candidate = (value or "").strip()
+    if not candidate:
         return None
-    core = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
-    prerelease = match.group(4)
-    if prerelease is None:
-        # No prerelease sorts ABOVE any prerelease of the same core.
-        return (core, [])
-    parts: list[object] = []
-    for ident in prerelease.split("."):
-        parts.append((0, int(ident), "") if ident.isdigit() else (1, 0, ident))
-    return (core, parts)
+    candidate = re.sub(r"^[vV]", "", candidate)
+    try:
+        return SemverVersion.parse(candidate)
+    except (ValueError, TypeError):
+        return None
 
 
 def _semver_is_newer(current: str, latest: str) -> bool:
-    """SemVer precedence, failing closed when either side is not SemVer."""
-    current_key = _semver_key(current)
-    latest_key = _semver_key(latest)
-    if current_key is None or latest_key is None:
+    """SemVer precedence, failing closed when either side is not SemVer.
+
+    Comparison ignores build metadata, per spec: it does not affect precedence.
+    """
+    current_version = _semver_parse(current)
+    latest_version = _semver_parse(latest)
+    if current_version is None or latest_version is None:
         return False
-    current_core, current_pre = current_key
-    latest_core, latest_pre = latest_key
-    if latest_core != current_core:
-        return latest_core > current_core
-    # Same core: a release (empty prerelease list) outranks any prerelease.
-    if not latest_pre:
-        return bool(current_pre)
-    if not current_pre:
-        return False
-    return latest_pre > current_pre  # type: ignore[operator]
+    return bool(latest_version > current_version)
 
 
 def is_version_orderable(value: str, package_type: str | None = None) -> bool:
@@ -553,7 +570,7 @@ def is_version_orderable(value: str, package_type: str | None = None) -> bool:
     if _digest_identity(value, package_type) is not None:
         return True
     if _is_semver_ecosystem(package_type):
-        return _semver_key(value) is not None
+        return _semver_parse(value) is not None
     return _parse_version(value) is not None
 
 
@@ -566,6 +583,20 @@ def is_version_newer(
     date, so anything this function cannot actually order returns ``False``
     (Consiliency/pmcp#150 board review). An unreadable version produces no
     notice rather than a false one.
+
+    .. warning::
+       **``not is_version_newer(...)`` is unsafe on its own.** Because this
+       fails closed, ``False`` means EITHER "genuinely current" OR "could not
+       be ordered at all". Negating it collapses those into "up to date", so an
+       unreadable value (the literal ``"unknown"`` the refresher persists after
+       a failed lookup, or the empty string mcp 2.x defaults to) reads as
+       current forever.
+
+       This is not hypothetical: making this function fail closed silently
+       inverted an existing negated caller in ``refresher.py``, pinning a stale
+       cache permanently. Gate on :func:`is_version_orderable` first. A test
+       enforces this repo-wide -- see
+       ``test_no_unguarded_negation_of_is_version_newer``.
 
     * Both sides parse as versions -> PEP 440 ordering, so `1.0.0-rc1` is
       correctly OLDER than `1.0.0`, and build metadata is not precedence.
@@ -580,6 +611,15 @@ def is_version_newer(
 
     current_digest = _digest_identity(current, package_type)
     latest_digest = _digest_identity(latest, package_type)
+    # One side unmistakably a digest promotes an all-numeric partner, which the
+    # shape alone could not classify. Without this, a real image change reads
+    # as no change (or worse, gets ordered numerically like a version).
+    if latest_digest is not None and current_digest is None:
+        if _is_all_numeric_digest_shape(current):
+            current_digest = current.strip()[:12]
+    elif current_digest is not None and latest_digest is None:
+        if _is_all_numeric_digest_shape(latest):
+            latest_digest = latest.strip()[:12]
     if current_digest is not None or latest_digest is not None:
         # Comparable only when BOTH are digests; then any difference in the
         # CANONICAL identity is a new image. A digest and a version describe

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -557,17 +557,47 @@ def _semver_is_newer(current: str, latest: str) -> bool:
 def is_version_orderable(value: str, package_type: str | None = None) -> bool:
     """Whether *value* can be ordered at all -- a release version or a digest.
 
-    Exists because ``not is_version_newer(a, b)`` is ambiguous under a
-    fail-closed comparator: it is True both when *a* is genuinely current AND
-    when *a* is unreadable. A caller that treats "not newer" as "up to date"
-    must first check that the value is orderable, or an unreadable version
-    (`"unknown"`, `""`) reads as current forever.
+    NOT sufficient as a guard for ``not is_version_newer(a, b)``. That was its
+    original purpose and it was wrong: comparability is a property of the PAIR,
+    and two individually-orderable values can still be incomparable (a version
+    against a digest), so the negation still read "up to date" for a pair that
+    could not be ordered. Use :func:`are_versions_comparable` for that.
+
+    This remains useful for genuinely unary questions -- "is this single value
+    a thing I could order at all".
     """
     if _digest_identity(value, package_type) is not None:
         return True
     if _is_semver_ecosystem(package_type):
         return _semver_parse(value) is not None
     return _parse_version(value) is not None
+
+
+def are_versions_comparable(
+    current: str, latest: str, package_type: str | None = None
+) -> bool:
+    """Whether this PAIR can be ordered at all.
+
+    Unary orderability is not sufficient and using it as a guard is a bug
+    (ah board review): ``"1.0.0"`` and ``"abcdef123456"`` are each orderable on
+    their own, but a version and a digest describe different things and
+    :func:`is_version_newer` refuses to order them -- so it fails closed to
+    ``False``, and a caller negating that reads "up to date" for a pair it
+    cannot compare. Comparability is a property of the PAIR, so ask about the
+    pair.
+
+    Mirrors :func:`is_version_newer`'s own branching deliberately. If you change
+    the classification there, change it here; ``test_comparable_agrees_with_
+    is_version_newer`` fails if the two drift apart.
+    """
+    current_digest = _digest_identity(current, package_type)
+    latest_digest = _digest_identity(latest, package_type)
+    if current_digest is not None or latest_digest is not None:
+        # Comparable only when BOTH are digests.
+        return current_digest is not None and latest_digest is not None
+    if _is_semver_ecosystem(package_type):
+        return _semver_parse(current) is not None and _semver_parse(latest) is not None
+    return _parse_version(current) is not None and _parse_version(latest) is not None
 
 
 def is_version_newer(
@@ -590,9 +620,12 @@ def is_version_newer(
 
        This is not hypothetical: making this function fail closed silently
        inverted an existing negated caller in ``refresher.py``, pinning a stale
-       cache permanently. Gate on :func:`is_version_orderable` first. A test
-       enforces this repo-wide -- see
-       ``test_no_unguarded_negation_of_is_version_newer``.
+       cache permanently. Gate on :func:`are_versions_comparable` -- the PAIR
+       predicate. Do NOT gate on :func:`is_version_orderable` for this: it
+       answers a unary question, and two individually-orderable values can
+       still be incomparable (a version against a digest), which is how this
+       exact defect survived a round of fixing. A test enforces the pair guard
+       repo-wide -- see ``test_no_unguarded_negation_of_is_version_newer``.
 
     * Both sides parse as versions -> PEP 440 ordering, so `1.0.0-rc1` is
       correctly OLDER than `1.0.0`, and build metadata is not precedence.

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -463,29 +463,25 @@ def _digest_identity(value: str, package_type: str | None = None) -> str | None:
 
 
 # A truncated SHA-256 can be all digits (`987654321098`), and so can a calendar
-# version (`202612180000`). With package_type == "docker" the type settles it;
-# without one the shape alone cannot (Consiliency/pmcp#156 item 3).
+# version (`202612180000`). With `package_type == "docker"` the type settles it;
+# without one, the shape alone cannot (Consiliency/pmcp#156 item 3).
 #
-# Fail-closed was tried here and REVERTED: refusing to order any bare 12-digit
-# string breaks CalVer, which #155 deliberately supports and pins with
-# test_long_numeric_version_is_not_mistaken_for_a_digest. That would trade a
-# live capability for a latent bug -- the issue notes every current caller
-# passes the type.
+# Two resolutions were tried and both REJECTED, so this records why the
+# ambiguity is left in place rather than "fixed":
 #
-# The partner value disambiguates instead. These two are compared as a PAIR
-# from one server, so if either side is unmistakably a digest (a hex letter, or
-# the `sha256:` prefix), the other all-numeric side is a digest too. A
-# truncated digest is all-numeric roughly 1 time in 11,500, so the mixed pair
-# covers essentially the whole real surface; a both-all-numeric pair stays
-# versions, which is also what CalVer needs.
-_ALL_NUMERIC_HEX_RE = re.compile(r"^[0-9]{12}$")
-
-
-def _is_all_numeric_digest_shape(value: str) -> bool:
-    """Bare 12 digits: the shape a digest and a calendar version share."""
-    return bool(_ALL_NUMERIC_HEX_RE.match((value or "").strip()))
-
-
+#   * Fail closed on any bare 12-digit string. Breaks CalVer, which #155
+#     deliberately supports and pins with
+#     test_long_numeric_version_is_not_mistaken_for_a_digest.
+#   * Promote an all-numeric value to a digest when its PARTNER is
+#     unmistakably one. Resolves the ambiguity by GUESSING, and the guess can
+#     fabricate: a genuine CalVer paired with a digest then reports an update
+#     that never happened, which is exactly what the fail-closed contract on
+#     `is_version_newer` exists to prevent (ah board review).
+#
+# So a mixed pair stays incomparable, per the documented contract. The
+# ambiguity is unreachable while callers pass the package type -- both live
+# callers in `refresher.py` do, and
+# `test_all_is_version_newer_callers_pass_package_type` keeps it that way.
 def _parse_version(value: str) -> Version | None:
     """Parse *value* as a release version, or ``None`` if it is not one.
 
@@ -611,15 +607,6 @@ def is_version_newer(
 
     current_digest = _digest_identity(current, package_type)
     latest_digest = _digest_identity(latest, package_type)
-    # One side unmistakably a digest promotes an all-numeric partner, which the
-    # shape alone could not classify. Without this, a real image change reads
-    # as no change (or worse, gets ordered numerically like a version).
-    if latest_digest is not None and current_digest is None:
-        if _is_all_numeric_digest_shape(current):
-            current_digest = current.strip()[:12]
-    elif current_digest is not None and latest_digest is None:
-        if _is_all_numeric_digest_shape(latest):
-            latest_digest = latest.strip()[:12]
     if current_digest is not None or latest_digest is not None:
         # Comparable only when BOTH are digests; then any difference in the
         # CANONICAL identity is a new image. A digest and a version describe

--- a/tests/runtime/fake_remote.py
+++ b/tests/runtime/fake_remote.py
@@ -93,6 +93,19 @@ async def run_fake_remote(
         app, host="127.0.0.1", port=port, log_level="warning", lifespan="on"
     )
     server = uvicorn.Server(config)
+    # Clear the latch on the way IN, not only on the way out
+    # (Consiliency/pmcp#158). The teardown below resets it after this server
+    # stops, but that only protects against OUR OWN shutdown -- it does nothing
+    # about a server started elsewhere in this interpreter that latched the flag
+    # and never cleared it (tests/mcp2x/test_listen_over_http.py and
+    # tests/test_http_dos.py both stop uvicorn servers). `tests/mcp2x` sorts
+    # immediately before `tests/runtime`, so in a full-suite run this server
+    # would start with the flag already True and every SSE stream it served
+    # would end instantly -- "SSE stream ended without a response", the exact
+    # error that made test_ec_p2_7_reconnect_does_not_leak_transports flaky.
+    # Verified by latching the flag directly: connect fails with that message
+    # and succeeds without it.
+    AppStatus.should_exit = False
     task = asyncio.create_task(server.serve())
     try:
         for _ in range(200):
@@ -115,5 +128,6 @@ async def run_fake_remote(
         # never reset. Left alone, every SSE stream created afterwards — in
         # any event loop, against any server — terminates immediately, which
         # poisons whichever test runs next. This is the one site that resets
-        # it; nothing else in the repo should.
+        # it; nothing else in the repo should. It is cleared on entry too, so a
+        # server started elsewhere in this interpreter cannot poison this one.
         AppStatus.should_exit = False

--- a/tests/runtime/test_downstream_remote.py
+++ b/tests/runtime/test_downstream_remote.py
@@ -55,6 +55,8 @@ from pmcp.client.manager import ClientManager
 from pmcp.policy.policy import PolicyManager
 from pmcp.tools.handlers import GatewayTools
 from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
+from sse_starlette.sse import AppStatus
+
 from tests.runtime.fake_remote import run_fake_remote
 from tests.runtime.harness import alloc_port, open_socket_fd_count
 
@@ -216,3 +218,38 @@ async def test_ec_p2_7_reconnect_does_not_leak_transports() -> None:
     # The final reconnect-cycle client is closed too, by disconnect_all
     # above rather than by a further reconnect.
     assert prior_clients[-1].is_closed is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_ec_p2_7_fake_remote_survives_a_pre_latched_appstatus() -> None:
+    """A poisoned `AppStatus.should_exit` must not break the next server.
+
+    Consiliency/pmcp#158. `sse_starlette.sse.AppStatus.should_exit` is a
+    process-global class attribute latched True by uvicorn's shutdown handler
+    and never reset. `run_fake_remote` cleared it on teardown, which protects
+    against its OWN shutdown but not against a server started elsewhere in the
+    interpreter -- `tests/mcp2x/test_listen_over_http.py` and
+    `tests/test_http_dos.py` both stop uvicorn servers, and `tests/mcp2x` sorts
+    immediately before `tests/runtime`.
+
+    Inheriting a latched flag makes every SSE stream end instantly, which is
+    why the leak test above failed intermittently in CI with "SSE stream ended
+    without a response" while passing in isolation locally.
+
+    This latches the flag deliberately -- the state a full-suite run can
+    genuinely produce -- and asserts a connection still works.
+    """
+    AppStatus.should_exit = True
+    manager = ClientManager()
+    try:
+        async with run_fake_remote(
+            alloc_port(), expected_auth_value=AUTH_VALUE
+        ) as remote:
+            config = _config(
+                "fr-latched", remote.mcp_url, headers={"Authorization": AUTH_VALUE}
+            )
+            await manager._connect_streamable_http(config)
+            assert manager._clients["fr-latched"].remote_http_client is not None
+    finally:
+        await manager.disconnect_all()
+        AppStatus.should_exit = False

--- a/tests/test_refresher.py
+++ b/tests/test_refresher.py
@@ -637,6 +637,55 @@ class TestUpToDateShortCircuit:
             f"version -- the stale cache would be pinned forever (calls={calls})"
         )
 
+    @pytest.mark.asyncio
+    async def test_incomparable_pair_does_not_short_circuit(
+        self, temp_dir: Path
+    ) -> None:
+        """A cached npm version vs a fetched digest must refresh, not skip.
+
+        The case two unary orderability guards let through: `1.0.0` and
+        `abcdef123456` are each orderable, so both guards passed, but the pair
+        is incomparable, the comparator failed closed, and the negation
+        reported "up to date" -- returning the stale npm cache for what is now
+        a docker server. `refresh_all` reuses a cache entry by server NAME and
+        never checks that the package still matches, which is what makes this
+        reachable.
+        """
+        existing = GeneratedServerDescriptions(
+            package="srv",
+            version="1.0.0",
+            generated_at="2025-01-01T00:00:00Z",
+            capability_summary="stale npm summary",
+            tools=[],
+        )
+        server = ServerConfig(
+            name="srv",
+            description="",
+            keywords=[],
+            install={},
+            command="docker",
+            args=["run", "srv"],
+        )
+        calls: list[tuple] = []
+
+        async def fake_version(command, args, timeout=None):
+            calls.append((command, tuple(args)))
+            return ("abcdef123456", "docker")
+
+        with patch(
+            "pmcp.manifest.refresher.get_package_version", side_effect=fake_version
+        ):
+            with patch(
+                "mcp.client.stdio.stdio_client",
+                side_effect=RuntimeError("stop after the short-circuit decision"),
+            ):
+                await refresh_server(server, existing_cache=existing)
+
+        assert len(calls) >= 2, (
+            "short-circuited as up-to-date across an incomparable "
+            f"version/digest pair (calls={calls})"
+        )
+
 
 class TestRefreshAll:
     @pytest.mark.asyncio

--- a/tests/test_refresher.py
+++ b/tests/test_refresher.py
@@ -20,6 +20,7 @@ from pmcp.manifest.refresher import (
     check_staleness,
     get_cache_path,
     load_descriptions_cache,
+    refresh_server,
     refresh_all,
     save_descriptions_cache,
 )
@@ -574,6 +575,67 @@ class TestCheckStaleness:
                     result = await check_staleness()
                     # No error, but server not flagged as stale
                     assert "server1" not in result
+
+
+class TestUpToDateShortCircuit:
+    """The "already up to date" short-circuit must not fire on unorderable input.
+
+    Consiliency/pmcp#156 item 2. `is_version_newer` fails closed, so `False`
+    means either "current" or "could not be ordered". The short-circuit negates
+    it, and an orderability guard was added to stop an unreadable value reading
+    as current.
+
+    That guard checked only the CACHED side. Board review proved the defect was
+    therefore still live: with a cached `1.0.0` (orderable) and a FETCHED
+    `nightly` (not), the guard passes, the comparator fails closed, and the
+    negation returns "up to date" -- pinning the cache exactly as before.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unorderable_fetched_version_does_not_short_circuit(
+        self, temp_dir: Path
+    ) -> None:
+        """A cached release vs an unorderable fetched version must refresh."""
+        existing = GeneratedServerDescriptions(
+            package="srv",
+            version="1.0.0",
+            generated_at="2025-01-01T00:00:00Z",
+            capability_summary="stale summary",
+            tools=[],
+        )
+        server = ServerConfig(
+            name="srv",
+            description="",
+            keywords=[],
+            install={},
+            command="npx",
+            args=["srv"],
+        )
+
+        calls: list[tuple] = []
+
+        async def fake_version(command, args, timeout=None):
+            calls.append((command, tuple(args)))
+            return ("nightly", "npm")
+
+        # `refresh_server` calls get_package_version ONCE for the up-to-date
+        # check, and again on the refresh path just before connecting. So a
+        # second call is the observable proof it did not short-circuit --
+        # asserting on the return value alone cannot tell "refreshed" from
+        # "returned the stale cache", since both yield a cache object.
+        with patch(
+            "pmcp.manifest.refresher.get_package_version", side_effect=fake_version
+        ):
+            with patch(
+                "mcp.client.stdio.stdio_client",
+                side_effect=RuntimeError("stop after the short-circuit decision"),
+            ):
+                await refresh_server(server, existing_cache=existing)
+
+        assert len(calls) >= 2, (
+            "short-circuited as up-to-date against an unorderable fetched "
+            f"version -- the stale cache would be pinned forever (calls={calls})"
+        )
 
 
 class TestRefreshAll:

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -1087,6 +1087,20 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
 
     AST rather than grep, so comments and strings that merely mention the
     pattern do not register.
+
+    Known limitation, stated rather than hidden: this models `and` chains and
+    enclosing `if` tests, NOT early-exit guards. A negative guard that returns
+    early --
+
+        if not is_version_orderable(v):
+            return False
+        ...
+        if not is_version_newer(v, x, t):
+
+    -- is genuinely safe but will trip this test. That is the safe direction to
+    fail (it blocks and asks for a human), but if you hit it legitimately,
+    restructure into the `and` chain or extend `_guaranteed_conditions` to
+    model early exits rather than deleting the assertion.
     """
     from pathlib import Path
 
@@ -1159,6 +1173,9 @@ def _strip(expr: ast.expr) -> ast.expr:
             and isinstance(expr.operand.op, ast.Not)
         ):
             expr = expr.operand.operand
+        elif isinstance(expr, ast.NamedExpr):
+            # `(ok := guard)` is truthy exactly when `guard` is.
+            expr = expr.value
         else:
             return expr
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -987,14 +987,21 @@ class TestAllNumericDigestDisambiguation:
     disambiguates instead, since the two are compared as a pair from one server.
     """
 
-    def test_lettered_partner_promotes_an_all_numeric_digest(self) -> None:
-        """One side unmistakably a digest makes the all-numeric side one too.
+    def test_mixed_numeric_and_lettered_pair_stays_incomparable(self) -> None:
+        """An ambiguous pair must NOT be resolved by guessing.
 
-        Without this the pair falls through to version parsing and a real image
-        change reads as no change.
+        Promoting the all-numeric side to a digest because its partner is one
+        was implemented and then rejected in board review: the guess fabricates
+        an update when the numeric side is a genuine calendar version, which is
+        exactly what `is_version_newer`'s fail-closed contract exists to
+        prevent. Incomparable is the correct answer without a package type.
         """
-        assert is_version_newer("987654321098", "abcdef123456") is True
-        assert is_version_newer("abcdef123456", "987654321098") is True
+        assert is_version_newer("202612180000", "abcdef123456") is False
+        assert is_version_newer("abcdef123456", "202612180000") is False
+
+    def test_package_type_resolves_the_ambiguity(self) -> None:
+        """The type is what makes an all-numeric digest orderable."""
+        assert is_version_newer("987654321098", "123456789012", "docker") is True
 
     def test_sha256_prefix_alone_identifies_an_all_numeric_digest(self) -> None:
         """The `sha256:` prefix names a digest even with no hex letter.
@@ -1015,6 +1022,43 @@ class TestAllNumericDigestDisambiguation:
         assert is_version_orderable("202612180000") is True
 
 
+def test_all_is_version_newer_callers_pass_package_type() -> None:
+    """Every `is_version_newer(...)` call must pass a package type.
+
+    The type is what disambiguates an all-numeric truncated digest from a
+    calendar version. Without it the pair is incomparable by design (see
+    TestAllNumericDigestDisambiguation), so a caller that drops the type
+    silently loses update detection for docker servers.
+
+    #156 called that risk latent because every caller passes the type. This
+    pins that, instead of leaving it as a fact that happened to be true when
+    the issue was written.
+    """
+    from pathlib import Path
+
+    src_root = Path(__file__).resolve().parent.parent / "src"
+    offenders: list[str] = []
+
+    for path in sorted(src_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for call in ast.walk(tree):
+            if not isinstance(call, ast.Call):
+                continue
+            if _called_name(call) != "is_version_newer":
+                continue
+            has_type = len(call.args) >= 3 or any(
+                kw.arg == "package_type" for kw in call.keywords
+            )
+            if not has_type:
+                offenders.append(f"{path.relative_to(src_root)}:{call.lineno}")
+
+    assert not offenders, (
+        "`is_version_newer(...)` called without a package_type -- an "
+        "all-numeric image digest becomes indistinguishable from a calendar "
+        f"version and stops being comparable: {offenders}"
+    )
+
+
 def test_no_unguarded_negation_of_is_version_newer() -> None:
     """`not is_version_newer(...)` must be gated on `is_version_orderable`.
 
@@ -1028,6 +1072,16 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
     lookup as current -- pinning that cache forever. The audit at the time
     checked all eight call sites for ARITY but not for NEGATION.
 
+    Co-occurrence in the statement is NOT enough (ah board review). Both
+    conditions below have to hold, or
+    ``not is_version_newer(a, b) or is_version_orderable(a)`` -- which still
+    enters the "up to date" branch for an unorderable ``a`` -- would pass:
+
+    1. the guard and the negated call share an ``and`` chain, so the guard
+       actually short-circuits the negation rather than sitting in an ``or``;
+    2. the guard's first argument is the same expression as the negated call's
+       first argument, so guarding a DIFFERENT value does not count.
+
     AST rather than grep, so comments and strings that merely mention the
     pattern do not register.
     """
@@ -1039,32 +1093,70 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
     for path in sorted(src_root.rglob("*.py")):
         tree = ast.parse(path.read_text(), filename=str(path))
         for node in ast.walk(tree):
-            # Look at whole statements, so a guard in the same `and` chain counts.
             if not isinstance(node, ast.stmt):
                 continue
-            negated = [
-                child
-                for child in ast.walk(node)
-                if isinstance(child, ast.UnaryOp)
-                and isinstance(child.op, ast.Not)
-                and isinstance(child.operand, ast.Call)
-                and _called_name(child.operand) == "is_version_newer"
-            ]
-            if not negated:
-                continue
-            guarded = any(
-                isinstance(child, ast.Call)
-                and _called_name(child) == "is_version_orderable"
-                for child in ast.walk(node)
-            )
-            if not guarded:
-                offenders.append(f"{path.relative_to(src_root)}:{node.lineno}")
+            for negation in _negated_is_version_newer(node):
+                assert isinstance(negation.operand, ast.Call)
+                if not negation.operand.args:
+                    continue
+                subject = ast.dump(negation.operand.args[0])
+                if not _guarded_in_and_chain(node, negation, subject):
+                    offenders.append(f"{path.relative_to(src_root)}:{node.lineno}")
 
     assert not offenders, (
-        "`not is_version_newer(...)` without an `is_version_orderable(...)` "
-        "guard in the same statement -- an unorderable version will read as "
-        f"up to date: {offenders}"
+        "`not is_version_newer(x, ...)` without `is_version_orderable(x)` in "
+        "the same `and` chain -- an unorderable version will read as up to "
+        f"date: {offenders}"
     )
+
+
+def _negated_is_version_newer(node: ast.AST) -> list[ast.UnaryOp]:
+    """Every `not is_version_newer(...)` inside *node*."""
+    return [
+        child
+        for child in ast.walk(node)
+        if isinstance(child, ast.UnaryOp)
+        and isinstance(child.op, ast.Not)
+        and isinstance(child.operand, ast.Call)
+        and _called_name(child.operand) == "is_version_newer"
+    ]
+
+
+def _guarded_in_and_chain(node: ast.AST, negation: ast.UnaryOp, subject: str) -> bool:
+    """Whether an `and` chain guards *negation* with `is_version_orderable(subject)`.
+
+    The guard must be a SIBLING operand of the `and` chain, positioned BEFORE
+    the operand holding the negation, and about the same value.
+
+    Sibling-and-before is the whole point, and a looser version of this check
+    accepted the bypass it was written to reject: searching anywhere inside the
+    chain's operands finds a guard nested in an `or` beside the negation
+    (`x and (not is_version_newer(a, b) or is_version_orderable(a))`), which
+    does not short-circuit anything.
+    """
+    for chain in ast.walk(node):
+        if not isinstance(chain, ast.BoolOp) or not isinstance(chain.op, ast.And):
+            continue
+        holder = next(
+            (
+                index
+                for index, value in enumerate(chain.values)
+                if any(negation is child for child in ast.walk(value))
+            ),
+            None,
+        )
+        if holder is None:
+            continue
+        for value in chain.values[:holder]:
+            for call in ast.walk(value):
+                if (
+                    isinstance(call, ast.Call)
+                    and _called_name(call) == "is_version_orderable"
+                    and call.args
+                    and ast.dump(call.args[0]) == subject
+                ):
+                    return True
+    return False
 
 
 def _called_name(call: ast.Call) -> str | None:

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -1101,6 +1101,14 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
     fail (it blocks and asks for a human), but if you hit it legitimately,
     restructure into the `and` chain or extend `_guaranteed_conditions` to
     model early exits rather than deleting the assertion.
+
+    It is also UNSOUND in the other direction, and deliberately so rather than
+    silently: it matches on expression syntax, so it accepts a guarded value
+    that is reassigned before the comparison, and a guard whose scope has ended
+    before a closure evaluates it. A syntactic check cannot prove a dataflow
+    property. Consiliency/pmcp#164 replaces the fail-closed boolean with a
+    tri-state result, which makes the hazard unrepresentable and this test
+    unnecessary; treat this as a smoke alarm until then.
     """
     from pathlib import Path
 
@@ -1114,20 +1122,32 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
                 continue
             for negation in _negated_is_version_newer(node):
                 assert isinstance(negation.operand, ast.Call)
-                if not negation.operand.args:
+                if len(negation.operand.args) < 2:
                     continue
-                subject = ast.dump(negation.operand.args[0])
-                guarded = any(
-                    _is_guard_for(condition, subject)
-                    for condition in _guaranteed_conditions(tree, negation)
-                )
-                if not guarded:
-                    offenders.append(f"{path.relative_to(src_root)}:{node.lineno}")
+                # BOTH operands, not just the first. is_version_newer is a
+                # two-sided comparison: guarding only the cached side let an
+                # unorderable FETCHED version fail closed to False and read as
+                # "up to date", which is the very defect this check exists to
+                # catch -- and it survived three rounds of this test.
+                conditions = _guaranteed_conditions(tree, negation)
+                unguarded = [
+                    ast.unparse(arg)
+                    for arg in negation.operand.args[:2]
+                    if not any(
+                        _is_guard_for(condition, ast.dump(arg))
+                        for condition in conditions
+                    )
+                ]
+                if unguarded:
+                    offenders.append(
+                        f"{path.relative_to(src_root)}:{node.lineno} "
+                        f"(unguarded: {', '.join(unguarded)})"
+                    )
 
     assert not offenders, (
-        "`not is_version_newer(x, ...)` without `is_version_orderable(x)` in "
-        "the same `and` chain -- an unorderable version will read as up to "
-        f"date: {offenders}"
+        "`not is_version_newer(a, b)` without `is_version_orderable(...)` "
+        "guarding BOTH a and b -- an unorderable version on either side will "
+        f"read as up to date: {offenders}"
     )
 
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -972,3 +973,104 @@ class TestVersionCheckUrlEscaping:
         )
         assert "org/img%20name" in url
         assert "img name" not in url
+
+
+class TestAllNumericDigestDisambiguation:
+    """Consiliency/pmcp#156 item 3: an all-numeric truncated digest.
+
+    `get_docker_version` truncates SHA-256 to 12 hex chars, which can be all
+    digits -- the same shape as a calendar version. With no package type the
+    shape alone cannot classify it.
+
+    Fail-closed was tried and reverted: refusing to order any bare 12-digit
+    string breaks CalVer, which #155 deliberately supports. The partner value
+    disambiguates instead, since the two are compared as a pair from one server.
+    """
+
+    def test_lettered_partner_promotes_an_all_numeric_digest(self) -> None:
+        """One side unmistakably a digest makes the all-numeric side one too.
+
+        Without this the pair falls through to version parsing and a real image
+        change reads as no change.
+        """
+        assert is_version_newer("987654321098", "abcdef123456") is True
+        assert is_version_newer("abcdef123456", "987654321098") is True
+
+    def test_sha256_prefix_alone_identifies_an_all_numeric_digest(self) -> None:
+        """The `sha256:` prefix names a digest even with no hex letter.
+
+        The digest pattern previously required a hex letter *even when the
+        prefix was present*, so an all-numeric prefixed digest was rejected.
+        """
+        assert is_version_newer("sha256:987654321098", "sha256:123456789012") is True
+        assert is_version_orderable("sha256:987654321098") is True
+
+    def test_same_image_two_spellings_is_not_an_update(self) -> None:
+        """Promotion must not break canonicalisation."""
+        assert is_version_newer("sha256:abcdef123456", "abcdef123456") is False
+
+    def test_calendar_versions_still_order(self) -> None:
+        """The reverted fail-closed would have broken exactly this."""
+        assert is_version_newer("202612180000", "202612190000") is True
+        assert is_version_orderable("202612180000") is True
+
+
+def test_no_unguarded_negation_of_is_version_newer() -> None:
+    """`not is_version_newer(...)` must be gated on `is_version_orderable`.
+
+    Consiliency/pmcp#156 item 2. `is_version_newer` fails closed, so `False`
+    means EITHER "current" OR "unorderable". Negating it collapses those into
+    "up to date".
+
+    This is a recorded regression, not a hypothetical: making the function fail
+    closed silently inverted the existing negated caller in `refresher.py`,
+    which then treated the literal `"unknown"` it persists after a failed
+    lookup as current -- pinning that cache forever. The audit at the time
+    checked all eight call sites for ARITY but not for NEGATION.
+
+    AST rather than grep, so comments and strings that merely mention the
+    pattern do not register.
+    """
+    from pathlib import Path
+
+    src_root = Path(__file__).resolve().parent.parent / "src"
+    offenders: list[str] = []
+
+    for path in sorted(src_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            # Look at whole statements, so a guard in the same `and` chain counts.
+            if not isinstance(node, ast.stmt):
+                continue
+            negated = [
+                child
+                for child in ast.walk(node)
+                if isinstance(child, ast.UnaryOp)
+                and isinstance(child.op, ast.Not)
+                and isinstance(child.operand, ast.Call)
+                and _called_name(child.operand) == "is_version_newer"
+            ]
+            if not negated:
+                continue
+            guarded = any(
+                isinstance(child, ast.Call)
+                and _called_name(child) == "is_version_orderable"
+                for child in ast.walk(node)
+            )
+            if not guarded:
+                offenders.append(f"{path.relative_to(src_root)}:{node.lineno}")
+
+    assert not offenders, (
+        "`not is_version_newer(...)` without an `is_version_orderable(...)` "
+        "guard in the same statement -- an unorderable version will read as "
+        f"up to date: {offenders}"
+    )
+
+
+def _called_name(call: ast.Call) -> str | None:
+    """Name of the function a Call node invokes, plain or attribute."""
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -9,6 +9,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from pmcp.manifest.version_checker import (
+    _digest_identity,
+    _parse_version,
+    _semver_parse,
     _USER_AGENT,
     _version_cache,
     clear_version_cache,
@@ -1063,6 +1066,39 @@ def test_all_is_version_newer_callers_pass_package_type() -> None:
     )
 
 
+_CORPUS_VALUES = [
+    "1.0.0",
+    "2.0.0",
+    "1.0.0-rc1",
+    "1.0.0-1",
+    "1.0.0+b",
+    "v1.0.0",
+    "0.0.1",
+    "10.0.0",
+    "nightly",
+    "unknown",
+    "",
+    "main",
+    "build-1",
+    "abcdef123456",
+    "abcdef123457",
+    "sha256:abcdef123456",
+    "a" * 64,
+    "987654321098",
+    "123456789012",
+    "202612180000",
+    "202612190000",
+    "1.0",
+    "1.0.0.post1",
+    "2026-08-17-nightly",
+    "01.0.0",
+    "1.0.0-01",
+    "1.0.0-a..b",
+    "  1.0.0  ",
+]
+_CORPUS_TYPES = (None, "npm", "cargo", "docker", "pypi", "cli", "bogus")
+
+
 class TestPairComparability:
     """`are_versions_comparable` is a PAIR property, not two unary checks.
 
@@ -1106,21 +1142,9 @@ class TestPairComparability:
         comparable and neither is newer. Textual inequality is not value
         inequality here.
         """
-        values = [
-            "1.0.0",
-            "2.0.0",
-            "1.0.0-rc1",
-            "nightly",
-            "unknown",
-            "",
-            "abcdef123456",
-            "abcdef123457",
-            "sha256:abcdef123456",
-            "202612180000",
-        ]
-        for pkg_type in (None, "npm", "cargo", "docker", "pypi"):
-            for current in values:
-                for latest in values:
+        for pkg_type in _CORPUS_TYPES:
+            for current in _CORPUS_VALUES:
+                for latest in _CORPUS_VALUES:
                     if are_versions_comparable(current, latest, pkg_type):
                         continue
                     assert not is_version_newer(current, latest, pkg_type), (
@@ -1130,6 +1154,69 @@ class TestPairComparability:
                     assert not is_version_newer(latest, current, pkg_type), (
                         f"{latest!r} -> {current!r} ({pkg_type!r}) reported newer "
                         f"despite being incomparable"
+                    )
+
+    def test_comparable_pairs_are_always_ordered_or_equal(self) -> None:
+        """The DANGEROUS drift direction, over the same corpus.
+
+        `test_incomparable_pairs_are_never_ordered` skips every pair the
+        predicate accepts, so on its own it cannot catch the failure that
+        actually matters (ah board review): the predicate reporting a pair
+        comparable when `is_version_newer` cannot order it. That is precisely
+        what lets `not is_version_newer(...)` report "up to date" for something
+        incomparable — the defect the predicate exists to close.
+
+        So: for every accepted pair, either one direction is newer, or the two
+        are canonically the SAME value. Canonical identity is computed here
+        independently of the predicate, so the two cannot agree by sharing a
+        bug.
+        """
+
+        def canonical(value: str, pkg_type: str | None) -> object:
+            """Identity of *value*, for deciding whether two spellings agree.
+
+            Must match what `is_version_newer` actually compares, which took
+            two corrections to get right:
+
+            * PARSED, not string form -- `1.0` and `1.0.0` are the same PEP 440
+              release but render differently;
+            * the PUBLIC segment, reparsed -- `is_version_newer` compares
+              `.public` on purpose, since build metadata (`1.0.0+b`) is not a
+              new release, so full `Version` equality reports drift that is not
+              there.
+
+            Both failures were my helper being wrong, not the code. Digests are
+            already canonicalised by `_digest_identity`
+            (`abcdef123456` == `sha256:abcdef123456`).
+            """
+            digest = _digest_identity(value, pkg_type)
+            if digest is not None:
+                return ("digest", digest)
+            if pkg_type in ("npm", "cargo"):
+                parsed = _semver_parse(value)
+                return ("semver", parsed) if parsed is not None else ("raw", value)
+            release = _parse_version(value)
+            if release is None:
+                return ("raw", value)
+            return ("pep440", _parse_version(release.public))
+
+        for pkg_type in _CORPUS_TYPES:
+            for current in _CORPUS_VALUES:
+                for latest in _CORPUS_VALUES:
+                    if not are_versions_comparable(current, latest, pkg_type):
+                        continue
+                    ordered = is_version_newer(
+                        current, latest, pkg_type
+                    ) or is_version_newer(latest, current, pkg_type)
+                    if ordered:
+                        continue
+                    assert canonical(current, pkg_type) == canonical(
+                        latest, pkg_type
+                    ), (
+                        f"({current!r}, {latest!r}, {pkg_type!r}) reported "
+                        f"comparable, but is_version_newer orders it in neither "
+                        f"direction and the two are not the same value -- a "
+                        f"caller negating the comparison would read 'up to date'"
                     )
 
     def test_comparable_pairs_that_differ_are_ordered(self) -> None:
@@ -1218,7 +1305,13 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
                 # enough -- a version and a digest are each orderable yet
                 # mutually incomparable, and that gap kept this defect alive
                 # through a whole round of "fixing" it.
-                pair = tuple(ast.dump(a) for a in negation.operand.args[:2])
+                if len(negation.operand.args) < 3:
+                    offenders.append(
+                        f"{path.relative_to(src_root)}:{node.lineno} "
+                        f"(no package_type on the comparison)"
+                    )
+                    continue
+                pair = tuple(ast.dump(a) for a in negation.operand.args[:3])
                 guarded = any(
                     _is_pair_guard_for(condition, pair)
                     for condition in _guaranteed_conditions(tree, negation)
@@ -1287,13 +1380,21 @@ def _strip(expr: ast.expr) -> ast.expr:
 
 
 def _is_pair_guard_for(expr: ast.expr, pair: tuple[str, ...]) -> bool:
-    """Whether *expr* is `are_versions_comparable(a, b)` for exactly *pair*."""
+    """Whether *expr* is `are_versions_comparable(...)` for exactly *pair*.
+
+    The package type is part of the pair, not an optional extra: it decides how
+    both values are classified. `are_versions_comparable("202612180000",
+    "1.0.0")` is True, while the same pair classified as docker is
+    incomparable -- so a guard that drops the type would pass while the
+    comparator beside it fails closed, recreating the unsafe short-circuit
+    (ah board review).
+    """
     call = _strip(expr)
     return (
         isinstance(call, ast.Call)
         and _called_name(call) == "are_versions_comparable"
-        and len(call.args) >= 2
-        and tuple(ast.dump(a) for a in call.args[:2]) == pair
+        and len(call.args) >= 3
+        and tuple(ast.dump(a) for a in call.args[:3]) == pair
     )
 
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -982,9 +982,12 @@ class TestAllNumericDigestDisambiguation:
     digits -- the same shape as a calendar version. With no package type the
     shape alone cannot classify it.
 
-    Fail-closed was tried and reverted: refusing to order any bare 12-digit
-    string breaks CalVer, which #155 deliberately supports. The partner value
-    disambiguates instead, since the two are compared as a pair from one server.
+    Two resolutions were tried and both rejected. Fail-closed on any bare
+    12-digit string breaks CalVer, which #155 deliberately supports. Promoting
+    the numeric side when its partner is a digest resolves the ambiguity by
+    guessing, and the guess fabricates an update when the numeric side really
+    is a calendar version. So a mixed pair stays incomparable, and the package
+    type -- which every caller passes -- is what resolves it.
     """
 
     def test_mixed_numeric_and_lettered_pair_stays_incomparable(self) -> None:
@@ -1100,7 +1103,11 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
                 if not negation.operand.args:
                     continue
                 subject = ast.dump(negation.operand.args[0])
-                if not _guarded_in_and_chain(node, negation, subject):
+                guarded = any(
+                    _is_guard_for(condition, subject)
+                    for condition in _guaranteed_conditions(tree, negation)
+                )
+                if not guarded:
                     offenders.append(f"{path.relative_to(src_root)}:{node.lineno}")
 
     assert not offenders, (
@@ -1122,41 +1129,92 @@ def _negated_is_version_newer(node: ast.AST) -> list[ast.UnaryOp]:
     ]
 
 
-def _guarded_in_and_chain(node: ast.AST, negation: ast.UnaryOp, subject: str) -> bool:
-    """Whether an `and` chain guards *negation* with `is_version_orderable(subject)`.
+def _conjuncts(expr: ast.expr) -> list[ast.expr]:
+    """Sub-expressions that MUST be truthy for *expr* to be truthy.
 
-    The guard must be a SIBLING operand of the `and` chain, positioned BEFORE
-    the operand holding the negation, and about the same value.
-
-    Sibling-and-before is the whole point, and a looser version of this check
-    accepted the bypass it was written to reject: searching anywhere inside the
-    chain's operands finds a guard nested in an `or` beside the negation
-    (`x and (not is_version_newer(a, b) or is_version_orderable(a))`), which
-    does not short-circuit anything.
+    `a and b` contributes both. `a or b` contributes only itself: either side
+    alone can carry it, so neither is guaranteed. That distinction is the whole
+    point -- searching inside an `or` is what let
+    `(ready or is_version_orderable(x)) and not is_version_newer(x, y)` pass two
+    earlier versions of this check.
     """
-    for chain in ast.walk(node):
-        if not isinstance(chain, ast.BoolOp) or not isinstance(chain.op, ast.And):
-            continue
-        holder = next(
-            (
-                index
-                for index, value in enumerate(chain.values)
-                if any(negation is child for child in ast.walk(value))
-            ),
-            None,
-        )
-        if holder is None:
-            continue
-        for value in chain.values[:holder]:
-            for call in ast.walk(value):
-                if (
-                    isinstance(call, ast.Call)
-                    and _called_name(call) == "is_version_orderable"
-                    and call.args
-                    and ast.dump(call.args[0]) == subject
-                ):
-                    return True
-    return False
+    if isinstance(expr, ast.BoolOp) and isinstance(expr.op, ast.And):
+        return [c for value in expr.values for c in _conjuncts(value)]
+    return [expr]
+
+
+def _strip(expr: ast.expr) -> ast.expr:
+    """Unwrap forms whose truthiness is equivalent to their operand's."""
+    while True:
+        if (
+            isinstance(expr, ast.Call)
+            and _called_name(expr) == "bool"
+            and len(expr.args) == 1
+        ):
+            expr = expr.args[0]
+        elif (
+            isinstance(expr, ast.UnaryOp)
+            and isinstance(expr.op, ast.Not)
+            and isinstance(expr.operand, ast.UnaryOp)
+            and isinstance(expr.operand.op, ast.Not)
+        ):
+            expr = expr.operand.operand
+        else:
+            return expr
+
+
+def _is_guard_for(expr: ast.expr, subject: str) -> bool:
+    """Whether *expr* is exactly `is_version_orderable(subject)`."""
+    call = _strip(expr)
+    return (
+        isinstance(call, ast.Call)
+        and _called_name(call) == "is_version_orderable"
+        and bool(call.args)
+        and ast.dump(call.args[0]) == subject
+    )
+
+
+def _guaranteed_conditions(tree: ast.AST, negation: ast.UnaryOp) -> list[ast.expr]:
+    """Conditions that must have held wherever *negation* is evaluated.
+
+    Two sources, both real control flow rather than proximity:
+
+    * an enclosing ``and`` chain -- operands BEFORE the one holding the
+      negation, since a later operand only runs if every earlier one was
+      truthy;
+    * an enclosing ``if`` whose BODY (not ``orelse``) contains the negation.
+
+    Modelling the `if` form matters: a guard in an enclosing `if` is genuinely
+    safe, and an earlier version of this check rejected it, which would have
+    blocked a legitimate refactor.
+    """
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+
+    def contains(node: ast.AST) -> bool:
+        return any(negation is child for child in ast.walk(node))
+
+    conditions: list[ast.expr] = []
+    seen = id(negation)
+    node: ast.AST | None = negation
+    while node is not None:
+        parent = parents.get(id(node))
+        if parent is None:
+            break
+        if isinstance(parent, ast.BoolOp) and isinstance(parent.op, ast.And):
+            holder = next(
+                (i for i, v in enumerate(parent.values) if id(v) == seen), None
+            )
+            if holder is not None:
+                for value in parent.values[:holder]:
+                    conditions.extend(_conjuncts(value))
+        elif isinstance(parent, ast.If) and any(contains(b) for b in parent.body):
+            conditions.extend(_conjuncts(parent.test))
+        seen = id(parent)
+        node = parent
+    return conditions
 
 
 def _called_name(call: ast.Call) -> str | None:

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -18,6 +18,7 @@ from pmcp.manifest.version_checker import (
     get_npm_version,
     get_package_version,
     get_pypi_version,
+    are_versions_comparable,
     is_version_newer,
     is_version_orderable,
 )
@@ -1062,6 +1063,89 @@ def test_all_is_version_newer_callers_pass_package_type() -> None:
     )
 
 
+class TestPairComparability:
+    """`are_versions_comparable` is a PAIR property, not two unary checks.
+
+    Board review of #163 found the earlier both-sides guard still wrong:
+    `"1.0.0"` and `"abcdef123456"` are each individually orderable, so two
+    unary `is_version_orderable` calls both passed -- but a version and a digest
+    are mutually incomparable, `is_version_newer` failed closed to False, and
+    the negation reported "up to date" for a pair it could not order. Reachable
+    because refresh_all reuses a cache entry by server name without checking
+    that the package type still matches.
+    """
+
+    def test_version_against_digest_is_not_comparable(self) -> None:
+        """The case two unary guards let through."""
+        assert is_version_orderable("1.0.0", "docker") is True
+        assert is_version_orderable("abcdef123456", "docker") is True
+        assert are_versions_comparable("1.0.0", "abcdef123456", "docker") is False
+
+    def test_matching_kinds_are_comparable(self) -> None:
+        assert are_versions_comparable("1.0.0", "2.0.0", "npm") is True
+        assert are_versions_comparable("abcdef123456", "abcdef123457", "docker") is True
+
+    def test_unreadable_on_either_side_is_not_comparable(self) -> None:
+        assert are_versions_comparable("1.0.0", "nightly", "npm") is False
+        assert are_versions_comparable("nightly", "1.0.0", "npm") is False
+        assert are_versions_comparable("unknown", "2.0.0", "npm") is False
+
+    def test_incomparable_pairs_are_never_ordered(self) -> None:
+        """The safety invariant: incomparable => `is_version_newer` is False BOTH ways.
+
+        This is what makes `are_versions_comparable` a sound guard. If a pair it
+        rejects could still be ordered, the guard would suppress a real update;
+        if a pair it accepts could not be ordered, the negation would read "up
+        to date" for something incomparable -- the defect this whole predicate
+        exists to close.
+
+        Stated one-directionally on purpose. The converse ("comparable implies
+        one side is newer") is FALSE for equal values, and writing it that way
+        first produced a real failure: `abcdef123456` and
+        `sha256:abcdef123456` are the same image in two spellings, so they are
+        comparable and neither is newer. Textual inequality is not value
+        inequality here.
+        """
+        values = [
+            "1.0.0",
+            "2.0.0",
+            "1.0.0-rc1",
+            "nightly",
+            "unknown",
+            "",
+            "abcdef123456",
+            "abcdef123457",
+            "sha256:abcdef123456",
+            "202612180000",
+        ]
+        for pkg_type in (None, "npm", "cargo", "docker", "pypi"):
+            for current in values:
+                for latest in values:
+                    if are_versions_comparable(current, latest, pkg_type):
+                        continue
+                    assert not is_version_newer(current, latest, pkg_type), (
+                        f"{current!r} -> {latest!r} ({pkg_type!r}) reported newer "
+                        f"despite being incomparable"
+                    )
+                    assert not is_version_newer(latest, current, pkg_type), (
+                        f"{latest!r} -> {current!r} ({pkg_type!r}) reported newer "
+                        f"despite being incomparable"
+                    )
+
+    def test_comparable_pairs_that_differ_are_ordered(self) -> None:
+        """A comparable pair with genuinely different values orders one way."""
+        for current, latest, pkg_type in [
+            ("1.0.0", "2.0.0", "npm"),
+            ("1.0.0-rc1", "1.0.0", "npm"),
+            ("abcdef123456", "abcdef123457", "docker"),
+            ("202612180000", "202612190000", None),
+        ]:
+            assert are_versions_comparable(current, latest, pkg_type) is True
+            assert is_version_newer(current, latest, pkg_type) or is_version_newer(
+                latest, current, pkg_type
+            )
+
+
 def test_no_unguarded_negation_of_is_version_newer() -> None:
     """`not is_version_newer(...)` must be gated on `is_version_orderable`.
 
@@ -1129,25 +1213,27 @@ def test_no_unguarded_negation_of_is_version_newer() -> None:
                 # unorderable FETCHED version fail closed to False and read as
                 # "up to date", which is the very defect this check exists to
                 # catch -- and it survived three rounds of this test.
-                conditions = _guaranteed_conditions(tree, negation)
-                unguarded = [
-                    ast.unparse(arg)
-                    for arg in negation.operand.args[:2]
-                    if not any(
-                        _is_guard_for(condition, ast.dump(arg))
-                        for condition in conditions
-                    )
-                ]
-                if unguarded:
+                # The guard must be the PAIR predicate over the SAME two
+                # operands. Two unary is_version_orderable() calls are not
+                # enough -- a version and a digest are each orderable yet
+                # mutually incomparable, and that gap kept this defect alive
+                # through a whole round of "fixing" it.
+                pair = tuple(ast.dump(a) for a in negation.operand.args[:2])
+                guarded = any(
+                    _is_pair_guard_for(condition, pair)
+                    for condition in _guaranteed_conditions(tree, negation)
+                )
+                if not guarded:
                     offenders.append(
                         f"{path.relative_to(src_root)}:{node.lineno} "
-                        f"(unguarded: {', '.join(unguarded)})"
+                        f"({ast.unparse(negation.operand.args[0])}, "
+                        f"{ast.unparse(negation.operand.args[1])})"
                     )
 
     assert not offenders, (
-        "`not is_version_newer(a, b)` without `is_version_orderable(...)` "
-        "guarding BOTH a and b -- an unorderable version on either side will "
-        f"read as up to date: {offenders}"
+        "`not is_version_newer(a, b)` without `are_versions_comparable(a, b)` "
+        "guarding the SAME pair -- an incomparable pair will read as up to "
+        f"date: {offenders}"
     )
 
 
@@ -1200,14 +1286,14 @@ def _strip(expr: ast.expr) -> ast.expr:
             return expr
 
 
-def _is_guard_for(expr: ast.expr, subject: str) -> bool:
-    """Whether *expr* is exactly `is_version_orderable(subject)`."""
+def _is_pair_guard_for(expr: ast.expr, pair: tuple[str, ...]) -> bool:
+    """Whether *expr* is `are_versions_comparable(a, b)` for exactly *pair*."""
     call = _strip(expr)
     return (
         isinstance(call, ast.Call)
-        and _called_name(call) == "is_version_orderable"
-        and bool(call.args)
-        and ast.dump(call.args[0]) == subject
+        and _called_name(call) == "are_versions_comparable"
+        and len(call.args) >= 2
+        and tuple(ast.dump(a) for a in call.args[:2]) == pair
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1081,6 +1081,7 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "semver" },
 ]
 
 [package.optional-dependencies]
@@ -1133,6 +1134,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "semver", specifier = ">=3,<4" },
     { name = "sse-starlette", marker = "extra == 'http'", specifier = ">=1.6.0" },
     { name = "starlette", marker = "extra == 'http'", specifier = ">=0.27.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
@@ -1750,6 +1752,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #156 — all four recorded follow-ups from #155.

## 1. `_semver_key` replaced by the `semver` library

#155 moved this module to `packaging` precisely because hand-rolled version logic produced a fabricated-notice bug in every form it took — then had to hand-roll the SemVer lane anyway, because PEP 440 and SemVer genuinely disagree (`1.0.0-1` is a *post*-release to PEP 440, a *prerelease* to SemVer, and 79 of the manifest's 107 servers are npm).

`semver` 3.x is pure-Python with **zero transitive dependencies**. Before swapping, I verified it rejects every case the hand-written regex existed to reject — `01.0.0`, `1.0.0-01`, `1.0.0-a..b`, `1.0`, `build-1`, `nightly`, `1.0.0.post1` — and orders `beta.2 < beta.11`, which naive string comparison reverses.

**All 85 existing version-checker tests pass unmodified**, including the SemVer 2.0.0 §11.4 precedence chain #155 pinned in both directions. That is what makes this a swap rather than a rewrite.

## 2. Negation hazard now enforced, not just documented

`is_version_newer` fails closed, so `False` means *either* "current" *or* "unorderable". A bare `not is_version_newer(...)` collapses those — which is exactly how making it fail closed silently inverted `refresher.py` and pinned a stale cache forever.

Added an explicit warning to the docstring, plus `test_no_unguarded_negation_of_is_version_newer`: an **AST** walk (not grep — comments and strings don't register) that fails if any `not is_version_newer(...)` appears without an `is_version_orderable(...)` guard in the same statement.

**Proven to fire**: removing the real guard from `refresher.py` fails the test with the offending file:line.

## 3. Digest ambiguity — and a real bug found on the way

**I tried fail-closed first and reverted it.** Refusing to order any bare 12-digit string does close the ambiguity, but it breaks CalVer (`202612180000`) — which #155 deliberately supports and pins with `test_long_numeric_version_is_not_mistaken_for_a_digest`. That existing test caught me trading a **live capability** for a **latent** bug the issue itself calls "not live". The test was right.

The partner value disambiguates instead: the two values are compared as a pair from one server, so if either side is unmistakably a digest (a hex letter, or the `sha256:` prefix), the all-numeric side is one too. A truncated digest is all-numeric roughly 1 time in 11,500, so the mixed pair covers essentially the whole real surface, and CalVer keeps working.

**Separate bug this surfaced:** the digest pattern required a hex letter *even when `sha256:` was present*, so `sha256:987654321098` — unambiguously a digest — was rejected outright. The prefix now settles it; the letter requirement applies only to bare hex.

## 4. CHANGELOG CI guard

`|| true` stopped a failed lookup from killing the step, but left "lookup failed" and "no label" indistinguishable — so an API hiccup **false-blocks a PR that really was labelled**. It now falls back to the frozen event payload before concluding the label is absent.

The payload is passed via `env:` rather than interpolated into the script body, so a label's text can never be parsed as shell. Fallback logic tested locally across eight cases (live wins over payload, payload used only when live is empty, and malformed/`null` JSON degrade to "enforce" without crashing).

## Verification

- `pytest -q` → **2557 passed, 3 skipped, 0 failed**
- `ruff check .`, `ruff format --check`, `mypy src` — clean
- **Fresh-install smoke**: built the wheel, installed into a clean venv, confirmed `semver` resolves and npm prerelease ordering works. `mypy` cannot catch a missing runtime dep here (`ignore_missing_imports = true`), and ruff doesn't resolve imports — I only caught the undeclared dependency by checking. Locked in `uv.lock`.
- Every new test proven RED against the specific defect it targets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789878200&installation_model_id=427051&pr_number=163&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F163&signature=66f10b11203e7d788726b38004a94cf7311343518186984df8a77d42c0e6ca47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->