### PR TITLE
chore: v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-08-23
+
 ### Changed
 - **SemVer comparison now uses the `semver` library instead of a hand-written
   key** (new dependency, pure-Python, no transitive dependencies). The npm and
@@ -93,7 +95,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This matters more since 2.2.0: with the automatic update notices removed,
   `gateway.update_server` is the only update path.
-
 
 ## [2.2.0] - 2026-08-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.2.0"
+version = "2.2.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **2.2.1** from #161 (#151) and #163 (#156, #158).

## Why patch, not minor

pmcp's public surface is its **MCP tool schemas**, and none changed. The new `semver` runtime dependency and the new internal `are_versions_comparable` helper in `pmcp.manifest.version_checker` don't alter what a client sees. (Contrast 2.2.0, which removed four fields from tool output and was correctly a minor.)

## What's in it

**`gateway.update_server` no longer risks restarting onto a different package than it probed** (#151). It resolved the config, ran a 60-second probe, then let `restart_server` resolve independently — so a `.mcp.json` edit inside that window could probe package A, restart onto B, and record A's version as B's. It now re-verifies before `refresh()` and restarts onto the exact verified config, refusing with "fetched but not activated" if anything changed.

**Version comparison hardened** (#156):
- SemVer ordering moved from a hand-written key to the `semver` library — the last hand-rolled comparison in a module where every hand-rolled form produced a fabricated-notice bug.
- A stale descriptions cache is no longer pinned when the *fetched* version is unreadable, or when the pair is incomparable at all (an npm version against a docker digest). Comparability is now asked about the **pair**, not each value.
- An all-numeric truncated digest is documented as incomparable without a package type, and callers are pinned to pass one.
- A `sha256:`-prefixed digest with no hex letter is now recognised.
- The CHANGELOG CI guard no longer treats a failed label lookup as "no label".

**The intermittent transport-leak test failure is fixed at its root** (#158). `sse_starlette`'s `AppStatus.should_exit` is process-global and was cleared only on teardown, so a server started by an earlier test file poisoned every SSE stream that followed.

## Verification

- `pytest -q` → **2568 passed, 3 skipped, 0 failed**
- `ruff check .`, `mypy src` — clean
- Version agreement asserted at runtime: `pmcp.__version__ == pyproject version == 2.2.1`

## Known and deliberately deferred

**#164** — replace the fail-closed boolean with a tri-state; makes the whole negation-hazard class unrepresentable.
**#165** — the refresh short-circuit ignores package identity, so a server repointed at a different package of the same version keeps serving the old descriptions.

Both surfaced during review of the work in this release and are recorded rather than rushed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790043993&installation_model_id=427051&pr_number=166&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F166&signature=5ab7d39c580aa9d4577d33ddf2ca79f5cb9243b6e366b165d1c0dca44e3bb608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->